### PR TITLE
fix(agnocastlib): make agnocast::Node work in a component container

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -404,6 +404,18 @@ The following tables compare methods that are **directly defined** in each class
 
 **Note**: While `agnocast::Node` can be loaded into a Component Container, the Component Container itself becomes a DDS participant. Therefore, the performance maximization benefits—which are the primary purpose of using `agnocast::Node`—cannot be fully realized when using a Component Container.
 
+### 5.1 What a Component Container does not provide
+
+A container's `main()` calls `rclcpp::init()` but never `agnocast::init()`, so the Agnocast global context is brought up lazily when the first `agnocast::Node` (or Agnocast-only executor) is created. This has three consequences:
+
+- **Global arguments do not apply.** `agnocast::init()` is what parses the process command line, so a lazily initialized context exposes no global arguments. Only the `NodeOptions::arguments()` that the Component Manager passes in are honored; remaps and parameter overrides given as global `--ros-args` to the container do not reach the node.
+- **Logging stays under rclcpp's control.** The lazy path deliberately skips `rcl_logging_configure_with_output_handler()` so that it does not take over the output handler that `rclcpp::init()` installed for the whole container.
+- **Agnocast installs SIGINT/SIGTERM handlers.** They chain to the handlers `rclcpp::init()` installed rather than replacing them, so the container's own shutdown path still runs. This is what lets the Agnocast-only executors that `agnocast::Node` spawns internally (the `use_sim_time` clock thread, the `tf2` listener thread) stop on Ctrl-C.
+
+Once the context has been shut down, creating further nodes does not revive it; only an explicit `agnocast::init()` does.
+
+Note also that the container drives the node with its own `rclcpp::Executor`-derived executor (`SingleThreadedAgnocastExecutor`, `MultiThreadedAgnocastExecutor`, `CallbackIsolatedAgnocastExecutor`). The `AgnocastOnly*` executors cannot be used by a Component Manager because they do not derive from `rclcpp::Executor`.
+
 ---
 
 ## 6. Dependencies on rcl/rclcpp

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -13,6 +13,7 @@ Since `rclcpp::Node` is composed of ten modular node interfaces, this document o
 
 - `agnocast::Node` is a node implementation that bypasses the RMW layer entirely (e.g., it does not create a DDS participant)
 - When run as a standalone node (i.e., not loaded into a Component Container), nodes inheriting from `agnocast::Node` must be executed with Agnocast-only executors (i.e., `AgnocastOnlySingleThreadedExecutor`, `AgnocastOnlyMultiThreadedExecutor` or `AgnocastOnlyCallbackIsolatedExecutor`). In contrast, when such nodes are loaded into a Component Container, the container’s Agnocast-compatible executors—`SingleThreadedAgnocastExecutor`, `MultiThreadedAgnocastExecutor`, and `CallbackIsolatedAgnocastExecutor`—can also be used.
+- The converse does not hold: the Agnocast-only executors drive `agnocast::Node` only. They dispatch no RMW callbacks, so an `rclcpp::Node` added to one would never have its subscriptions, timers or services executed. Use the Agnocast-compatible executors for `rclcpp::Node`.
 
 ---
 
@@ -395,7 +396,7 @@ The following tables compare methods that are **directly defined** in each class
 
 | Aspect | agnocast | Notes |
 |--------|----------|-------|
-| Global context required | ✗ (Optional) | Works without agnocast::init() |
+| Global context required | ✗ (Optional) | A process calls exactly one of `agnocast::init()` and `rclcpp::init()`, before any node |
 | NodeOptions support | ✓ | Supports parameter_overrides, context, arguments, etc. |
 | Sub-nodes | ✗ | agnocast does not support sub-nodes |
 | Lifecycle nodes | ✗ | Not applicable |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,6 +60,7 @@ Each script is a thin wrapper that runs `source install/setup.bash` followed by 
 | `test/test_and_create_report.bash` | Build with coverage flags, run `colcon test`, and generate the HTML coverage report for `agnocastlib`. Temporarily removes apt-installed `agnocast-heaphook` if present and restores it at the end. |
 | `test/run_kunit.bash` | Build and insert `agnocast_kunit.ko`, parse pass/fail from dmesg, and generate the HTML coverage report for the kernel module. Requires a kernel with `CONFIG_KUNIT=y` and `CONFIG_GCOV_KERNEL=y`. |
 | `test/run_requires_kernel_module_tests.bash` | Build `agnocast_e2e_test` and run `colcon test` filtered to the `requires_kernel_module` label. Kernel module must already be loaded. |
+| `test/run_node_in_component_container_test.bash` | Run `test_agnocast_node_in_component_container_launch.py`: load an `agnocast::Node` component into `agnocast_component_container` and check it is constructed and receives messages. |
 | `test/e2e_test_1to1.bash` | 1-publisher / 1-subscriber end-to-end test sweeping publisher type (agnocast/ros2), QoS depth, transient-local, take-subscription, and launch-order combinations. Options: `-s` single, `-c` continue-on-failure, `-p N` parallel workers. |
 | `test/e2e_test_2to2.bash` | 2-publisher / 2-subscriber end-to-end test sweeping container layouts and `agno↔ros2` bridge modes. Options: `-s`, `-c`. |
 | `test/e2e_test_many_exit.bash` | Spawn many agnocast talker processes and terminate them via `SIGINT` to exercise graceful-exit cleanup. |

--- a/scripts/test/run_node_in_component_container_test.bash
+++ b/scripts/test/run_node_in_component_container_test.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source install/setup.bash
+launch_test src/agnocast_e2e_test/test/functional/test_agnocast_node_in_component_container_launch.py

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -168,6 +168,7 @@ install(DIRECTORY test
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
   add_launch_test(test/functional/test_agnocast_component_container_cie_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_agnocast_node_in_component_container_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_agnocast_callback_isolated_executor_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_multi_domain_cie_talker_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -132,6 +132,7 @@ install(DIRECTORY test
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)
   add_launch_test(test/functional/test_agnocast_component_container_cie_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_agnocast_node_in_component_container_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_agnocast_callback_isolated_executor_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_multi_domain_cie_talker_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)

--- a/src/agnocast_e2e_test/package.xml
+++ b/src/agnocast_e2e_test/package.xml
@@ -30,6 +30,7 @@
   <depend>agnocast_cie_thread_configurator</depend>
 
   <test_depend>agnocast_cie_config_msgs</test_depend>
+  <test_depend>agnocast_sample_application</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/src/agnocast_e2e_test/package.xml
+++ b/src/agnocast_e2e_test/package.xml
@@ -29,6 +29,7 @@
   <depend>agnocast_cie_thread_configurator</depend>
 
   <test_depend>agnocast_cie_config_msgs</test_depend>
+  <test_depend>agnocast_sample_application</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/src/agnocast_e2e_test/test/functional/test_agnocast_node_in_component_container_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_agnocast_node_in_component_container_launch.py
@@ -1,0 +1,96 @@
+"""
+Regression test for loading an ``agnocast::Node`` into a Component Container.
+
+A container's ``main()`` calls ``rclcpp::init()`` but never ``agnocast::init()``. An
+``agnocast::Node`` still creates Agnocast-only executors internally -- with
+``use_sim_time`` it spawns one for the ``/clock`` thread -- and those used to abort the
+whole container with "Failed to register shutdown eventfd with signal handler" because
+no Agnocast signal handler had been installed.
+"""
+
+import os
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def _heaphook_env():
+    return {'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}"}
+
+
+def generate_test_description():
+    component_container = ComposableNodeContainer(
+        name='agnocast_node_container',
+        namespace='',
+        package='agnocast_components',
+        executable='agnocast_component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='agnocast_sample_application',
+                plugin='NoRclcppSubscriber',
+                name='no_rclcpp_listener_node',
+                # use_sim_time makes NodeTimeSource spawn an AgnocastOnlySingleThreadedExecutor
+                # for the clock thread while the node is being constructed.
+                parameters=[{'use_sim_time': True}],
+            )
+        ],
+        output='screen',
+        additional_env=_heaphook_env(),
+    )
+
+    talker = launch_ros.actions.Node(
+        package='agnocast_sample_application',
+        executable='no_rclcpp_talker',
+        name='no_rclcpp_talker_node',
+        output='screen',
+        additional_env=_heaphook_env(),
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '0'),
+            component_container,
+            launch.actions.TimerAction(period=3.0, actions=[talker]),
+            launch.actions.TimerAction(
+                period=5.0,
+                actions=[launch_testing.actions.ReadyToTest()]
+            )
+        ]),
+        {
+            'component_container': component_container,
+            'talker': talker,
+        }
+    )
+
+
+class TestAgnocastNodeInComponentContainer(unittest.TestCase):
+
+    def test_node_is_loaded(self, proc_output, component_container):
+        """The container must survive constructing the agnocast::Node."""
+        proc_output.assertWaitFor(
+            '=== NoRclcppSubscriber Node Info ===',
+            timeout=15.0,
+            process=component_container
+        )
+
+    def test_signal_handler_is_installed(self, proc_output, component_container):
+        """The old failure mode logged this right before exiting."""
+        output = ''.join(
+            output.text.decode('utf-8') for output in proc_output[component_container]
+        )
+        self.assertNotIn('signal handler is not installed', output)
+        self.assertNotIn('Failed to register shutdown eventfd', output)
+
+    def test_composable_node_receives_messages(self, proc_output, component_container):
+        """The loaded node must still be functional, not merely constructed."""
+        proc_output.assertWaitFor(
+            'I heard dynamic size array message',
+            timeout=15.0,
+            process=component_container
+        )

--- a/src/agnocast_e2e_test/test/functional/test_agnocast_node_in_component_container_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_agnocast_node_in_component_container_launch.py
@@ -1,0 +1,89 @@
+"""Regression test for loading an ``agnocast::Node`` into a Component Container."""
+
+import os
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def _heaphook_env():
+    return {'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}"}
+
+
+def generate_test_description():
+    component_container = ComposableNodeContainer(
+        name='agnocast_node_container',
+        namespace='',
+        package='agnocast_components',
+        executable='agnocast_component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='agnocast_sample_application',
+                plugin='NoRclcppSubscriber',
+                name='no_rclcpp_listener_node',
+                # use_sim_time makes NodeTimeSource spawn an AgnocastOnlySingleThreadedExecutor
+                # for the clock thread while the node is being constructed.
+                parameters=[{'use_sim_time': True}],
+            )
+        ],
+        output='screen',
+        additional_env=_heaphook_env(),
+    )
+
+    talker = launch_ros.actions.Node(
+        package='agnocast_sample_application',
+        executable='no_rclcpp_talker',
+        name='no_rclcpp_talker_node',
+        output='screen',
+        additional_env=_heaphook_env(),
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '0'),
+            component_container,
+            launch.actions.TimerAction(period=3.0, actions=[talker]),
+            launch.actions.TimerAction(
+                period=5.0,
+                actions=[launch_testing.actions.ReadyToTest()]
+            )
+        ]),
+        {
+            'component_container': component_container,
+            'talker': talker,
+        }
+    )
+
+
+class TestAgnocastNodeInComponentContainer(unittest.TestCase):
+
+    def test_node_is_loaded(self, proc_output, component_container):
+        """The container must survive constructing the agnocast::Node."""
+        proc_output.assertWaitFor(
+            '=== NoRclcppSubscriber Node Info ===',
+            timeout=15.0,
+            process=component_container
+        )
+
+        # The Agnocast-only executors the node spawns register their shutdown eventfd with the
+        # signal handler while it is being constructed, and log these when that fails. Asserted
+        # here rather than as a case of its own so that the wait above has already happened.
+        output = ''.join(
+            output.text.decode('utf-8') for output in proc_output[component_container]
+        )
+        self.assertNotIn('signal handler is not installed', output)
+        self.assertNotIn('Failed to register shutdown eventfd', output)
+
+    def test_composable_node_receives_messages(self, proc_output, component_container):
+        """The loaded node must still be functional, not merely constructed."""
+        proc_output.assertWaitFor(
+            'I heard dynamic size array message',
+            timeout=15.0,
+            process=component_container
+        )

--- a/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
@@ -20,6 +20,24 @@ public:
   CommandLineParams command_line_params;
 
   void init(int argc, char const * const * argv);
+
+  // Mark the context as initialized without parsing command-line arguments and
+  // without touching the process-global rcl logging configuration.
+  //
+  // Used when an agnocast::Node lives in a process that never calls agnocast::init(),
+  // e.g. a component container whose main() only calls rclcpp::init(). There, rclcpp
+  // owns the logging configuration and the command line, so agnocast must not claim
+  // either; it only needs agnocast::ok() to report the context as alive so that the
+  // Agnocast-only executors it spawns internally (clock thread, tf listener) keep
+  // spinning. get_parsed_arguments() keeps returning nullptr in this mode, which
+  // callers already handle.
+  //
+  // Does nothing once shutdown() has run: a node created during teardown must not
+  // revive the context. Only an explicit init() may do that.
+  //
+  // @return whether the context is initialized after the call.
+  bool init_without_arguments();
+
   void shutdown();
   bool is_initialized() const { return initialized_; }
 
@@ -30,6 +48,9 @@ public:
 
 private:
   bool initialized_ = false;
+  // Set by shutdown(), cleared by init(). Distinguishes "not initialized yet" from
+  // "already torn down", which init_without_arguments() must not undo.
+  bool shutdown_called_ = false;
   ParsedArguments parsed_arguments_;
 };
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
@@ -3,6 +3,8 @@
 #include "agnocast/agnocast_public_api.hpp"
 #include "agnocast/node/agnocast_arguments.hpp"
 
+#include <rclcpp/context.hpp>
+
 #include <mutex>
 #include <string>
 
@@ -19,9 +21,26 @@ class Context
 public:
   CommandLineParams command_line_params;
 
+  // @throws std::runtime_error if the context is already up, whether from a previous init()
+  //         or from a lazy init_without_arguments().
   void init(int argc, char const * const * argv);
+
+  // @return whether the context is initialized after the call.
+  bool init_without_arguments();
+
+  // Adopting a context that was never initialized -- the global default one, which NodeOptions
+  // hands every node -- would make agnocast::ok() permanently false in an AgnocastOnly process.
+  //
+  // @return whether this call is the one that adopted it.
+  bool adopt_rclcpp_context(const rclcpp::Context::SharedPtr & rclcpp_context);
+
   void shutdown();
   bool is_initialized() const { return initialized_; }
+
+  // Hands the caller responsibility for calling rcl_logging_fini().
+  bool take_configured_logging();
+
+  bool is_ok(rclcpp::Context::SharedPtr & governing_context) const;
 
   const rcl_arguments_t * get_parsed_arguments() const
   {
@@ -30,16 +49,28 @@ public:
 
 private:
   bool initialized_ = false;
+  // Distinguishes "not initialized yet" from "already torn down", which
+  // init_without_arguments() must not undo.
+  bool shutdown_called_ = false;
+  rclcpp::Context::WeakPtr rclcpp_context_;
+  bool adopted_ = false;
+  bool configured_logging_ = false;
   ParsedArguments parsed_arguments_;
 };
 
 extern Context g_context;
 extern std::mutex g_context_mtx;
 
-/// @brief Initialize Agnocast. Must be called once before creating any agnocast::Node.
-/// This is the counterpart of rclcpp::init() for agnocast::Node.
+/// @brief Initialize Agnocast. This is the counterpart of rclcpp::init() for agnocast::Node.
+///
+/// A process calls exactly one of this and rclcpp::init(). Call this one when main() is yours
+/// and nothing brings rclcpp up. In a process rclcpp started, such as a component container, an
+/// agnocast::Node brings the Agnocast context up on its own.
+///
+/// Call it before creating any agnocast::Node or Agnocast-only executor.
 /// @param argc Number of command-line arguments.
 /// @param argv Command-line argument array.
+/// @throws std::runtime_error if the context is already up.
 AGNOCAST_PUBLIC
 void init(int argc, char const * const * argv);
 
@@ -48,7 +79,8 @@ void init(int argc, char const * const * argv);
 AGNOCAST_PUBLIC
 void shutdown();
 
-/// @brief Check whether Agnocast context is valid (initialized and not shutdown).
+/// @brief Check whether Agnocast may keep running: the context is up, it has not been shut
+/// down, and -- in a process that rclcpp started -- rclcpp has not been shut down either.
 /// This is the counterpart of rclcpp::ok() for agnocast::Node.
 AGNOCAST_PUBLIC
 bool ok();

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -719,7 +719,11 @@ private:
     return timer;
   }
 
-  // ParsedArguments must be stored to keep rcl_arguments_t alive
+  // Stored to keep rcl_arguments_t alive, and declared first on purpose: its initializer brings
+  // the Agnocast context up, and later members -- NodeTimeSource's clock-thread executor among
+  // them -- assume agnocast::ok() by the time they are constructed.
+  // TODO(Koichi98): once the Agnocast-only executors take their context instead of reading the
+  // global one, this becomes a data dependency and the declaration order stops mattering.
   ParsedArguments local_args_;
 
   node_interfaces::NodeBase::SharedPtr node_base_;

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -25,8 +25,9 @@ struct AgnocastExecutable;
 class Node;
 
 /**
- * @brief Base class for Stage 2 executors that handle only Agnocast callbacks (no RMW). Used with
- * agnocast::Node.
+ * @brief Base class for Stage 2 executors that handle only Agnocast callbacks (no RMW).
+ *
+ * Drives agnocast::Node only. An rclcpp::Node is not supported.
  *
  * One-shot: once cancel() is called, spin() will not run again on the same instance -- create a
  * new executor instead. All current uses (clock executor, CIE child executors) are recreated.
@@ -88,7 +89,7 @@ public:
 
   /// Add a callback group to this executor.
   /// @param group_ptr Callback group to add.
-  /// @param node_ptr Node the group belongs to.
+  /// @param node_ptr Node the group belongs to. Must be an agnocast::Node's base interface.
   /// @param notify If true, wake the executor so it picks up the change immediately.
   AGNOCAST_PUBLIC
   void add_callback_group(
@@ -117,7 +118,7 @@ public:
   std::vector<rclcpp::CallbackGroup::WeakPtr> get_automatically_added_callback_groups_from_nodes();
 
   /// Add a node to this executor.
-  /// @param node_ptr Node to add.
+  /// @param node_ptr Node to add. Must be an agnocast::Node's base interface.
   /// @param notify If true, wake the executor so it picks up the change immediately.
   AGNOCAST_PUBLIC
   void add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 
 #include "agnocast/agnocast_tracepoint_wrapper.h"
+#include "agnocast_context_internal.hpp"
 #include "agnocast_signal_handler.hpp"
 
 #include <rcl/arguments.h>
@@ -17,7 +18,10 @@ std::mutex g_context_mtx;
 
 void Context::init(int argc, char const * const * argv)
 {
-  if (initialized_) {
+  // Only a previous init() makes this a no-op. A lazy init_without_arguments() leaves
+  // parsed_arguments_ empty, so an explicit init() afterwards must still parse the command
+  // line instead of silently dropping the global arguments.
+  if (initialized_ && parsed_arguments_.is_valid()) {
     return;
   }
 
@@ -48,7 +52,21 @@ void Context::init(int argc, char const * const * argv)
   }
 
   initialized_ = true;
+  shutdown_called_ = false;
   TRACEPOINT(agnocast_init, static_cast<const void *>(this));
+}
+
+bool Context::init_without_arguments()
+{
+  if (initialized_ || shutdown_called_) {
+    return initialized_;
+  }
+
+  // Deliberately no parse_arguments() and no rcl_logging_configure_with_output_handler():
+  // see the declaration in agnocast_context.hpp.
+  initialized_ = true;
+  TRACEPOINT(agnocast_init, static_cast<const void *>(this));
+  return true;
 }
 
 void Context::shutdown()
@@ -57,6 +75,7 @@ void Context::shutdown()
     return;
   }
   initialized_ = false;
+  shutdown_called_ = true;
 }
 
 void init(int argc, char const * const * argv)
@@ -66,6 +85,21 @@ void init(int argc, char const * const * argv)
     g_context.init(argc, argv);
   }
   SignalHandler::install();
+}
+
+void ensure_initialized()
+{
+  bool initialized = false;
+  {
+    std::lock_guard<std::mutex> lock(g_context_mtx);
+    initialized = g_context.init_without_arguments();
+  }
+
+  // Skip while the context is shut down, so that objects created during teardown do not
+  // reinstall the handler that agnocast::shutdown() has just removed.
+  if (initialized) {
+    SignalHandler::install();
+  }
 }
 
 void shutdown()

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 
 #include "agnocast/agnocast_tracepoint_wrapper.h"
+#include "agnocast_context_internal.hpp"
 #include "agnocast_signal_handler.hpp"
 
 #include <rcl/arguments.h>
@@ -8,6 +9,8 @@
 #include <rcl/logging.h>
 #include <rcutils/logging.h>
 #include <rcutils/logging_macros.h>
+
+#include <stdexcept>
 
 namespace agnocast
 {
@@ -18,7 +21,14 @@ std::mutex g_context_mtx;
 void Context::init(int argc, char const * const * argv)
 {
   if (initialized_) {
-    return;
+    // rcl allocates the arguments impl even for an empty command line, so this means init() ran.
+    if (parsed_arguments_.is_valid()) {
+      throw std::runtime_error("agnocast::init() called on an already-initialized context");
+    }
+    throw std::runtime_error(
+      "agnocast::init() was called after an agnocast::Node or an Agnocast-only executor had "
+      "already brought the context up. Call it before creating either; in a process rclcpp "
+      "started, do not call it at all.");
   }
 
   // Copy argv into a safe container to avoid pointer arithmetic
@@ -45,18 +55,68 @@ void Context::init(int argc, char const * const * argv)
     RCUTILS_LOG_ERROR_NAMED(
       "agnocast", "Failed to configure logging: %s", rcl_get_error_string().str);
     rcl_reset_error();
+  } else {
+    configured_logging_ = true;
+  }
+
+  initialized_ = true;
+  shutdown_called_ = false;
+  TRACEPOINT(agnocast_init, static_cast<const void *>(this));
+}
+
+bool Context::take_configured_logging()
+{
+  const bool configured = configured_logging_;
+  configured_logging_ = false;
+  return configured;
+}
+
+bool Context::adopt_rclcpp_context(const rclcpp::Context::SharedPtr & rclcpp_context)
+{
+  if (adopted_) {
+    return false;
+  }
+  if (rclcpp_context && rclcpp_context->is_valid()) {
+    rclcpp_context_ = rclcpp_context;
+    adopted_ = true;
+  }
+  return adopted_;
+}
+
+bool Context::is_ok(rclcpp::Context::SharedPtr & governing_context) const
+{
+  if (!initialized_) {
+    return false;
+  }
+  if (!adopted_) {
+    return true;
+  }
+  governing_context = rclcpp_context_.lock();
+  return governing_context && governing_context->is_valid();
+}
+
+bool Context::init_without_arguments()
+{
+  if (initialized_ || shutdown_called_) {
+    return initialized_;
   }
 
   initialized_ = true;
   TRACEPOINT(agnocast_init, static_cast<const void *>(this));
+  return true;
 }
 
 void Context::shutdown()
 {
+  // A later init() starts a fresh cycle and must not inherit a context that is on its way out.
+  rclcpp_context_.reset();
+  adopted_ = false;
+
   if (!initialized_) {
     return;
   }
   initialized_ = false;
+  shutdown_called_ = true;
 }
 
 void init(int argc, char const * const * argv)
@@ -68,28 +128,67 @@ void init(int argc, char const * const * argv)
   SignalHandler::install();
 }
 
+void ensure_initialized(const rclcpp::Context::SharedPtr & rclcpp_context)
+{
+  bool hook_teardown_onto_rclcpp = false;
+
+  {
+    // install() runs under g_context_mtx so a concurrent shutdown() cannot uninstall between the
+    // decision and the call. SignalHandler::mutex_ is never taken before g_context_mtx, so
+    // nesting them this way cannot deadlock.
+    std::lock_guard<std::mutex> lock(g_context_mtx);
+
+    // Skip while the context is shut down.
+    if (g_context.init_without_arguments()) {
+      const bool adopted = g_context.adopt_rclcpp_context(rclcpp_context);
+      SignalHandler::install();
+      // Only hook the teardown on when the context came up lazily. A process that called
+      // agnocast::init() owns the teardown itself, and its handler went in underneath rclcpp's,
+      // where coming off from a shutdown callback would restore a handler rclcpp is still using.
+      hook_teardown_onto_rclcpp = adopted && g_context.get_parsed_arguments() == nullptr;
+    }
+  }
+
+  // Nothing else calls agnocast::shutdown() in a process that never called agnocast::init().
+  // rclcpp runs these callbacks before uninstalling its own signal handlers, so Agnocast's comes
+  // off first -- the reverse of the order they went on in.
+  //
+  // Registered outside g_context_mtx, which the callback takes: rclcpp runs the callbacks under
+  // its own lock, so acquiring that lock while holding g_context_mtx would invert the order.
+  if (hook_teardown_onto_rclcpp) {
+    rclcpp_context->add_on_shutdown_callback([]() { agnocast::shutdown(); });
+  }
+}
+
 void shutdown()
 {
+  bool finalize_logging = false;
   {
     std::lock_guard<std::mutex> lock(g_context_mtx);
+    finalize_logging = g_context.take_configured_logging();
     g_context.shutdown();
   }
 
   SignalHandler::notify_all_executors();
   SignalHandler::uninstall();
 
-  rcl_ret_t ret = rcl_logging_fini();
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "agnocast", "Failed to finalize logging: %s", rcl_get_error_string().str);
-    rcl_reset_error();
+  if (finalize_logging) {
+    rcl_ret_t ret = rcl_logging_fini();
+    if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "agnocast", "Failed to finalize logging: %s", rcl_get_error_string().str);
+      rcl_reset_error();
+    }
   }
 }
 
 bool ok()
 {
+  // Declared before the lock so that it outlives it: dropping the last reference to the governing
+  // context runs its shutdown callbacks, and ours takes g_context_mtx.
+  rclcpp::Context::SharedPtr governing_context;
   std::lock_guard<std::mutex> lock(g_context_mtx);
-  return g_context.is_initialized();
+  return g_context.is_ok(governing_context);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_context_internal.hpp
+++ b/src/agnocastlib/src/node/agnocast_context_internal.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace agnocast
+{
+
+// Lazily bring up the Agnocast global state when agnocast::init() was not called.
+//
+// agnocast::init() is only reachable from main(), so it never runs in a process whose
+// main() belongs to someone else. The motivating case is a component container: its
+// main() calls rclcpp::init() and then dlopens agnocast::Node components. Without this
+// helper such a process has no signal handler installed and reports agnocast::ok() ==
+// false, which makes the Agnocast-only executors that agnocast::Node spawns internally
+// (the use_sim_time clock thread and the tf2 TransformListener thread) unusable.
+//
+// Idempotent, and safe to call after rclcpp::init(): SignalHandler::install() chains to
+// the handler rclcpp already installed instead of replacing it.
+//
+// Unlike agnocast::init(), this does not parse command-line arguments and does not
+// configure rcl logging, so it never takes over global state that rclcpp owns.
+void ensure_initialized();
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_context_internal.hpp
+++ b/src/agnocastlib/src/node/agnocast_context_internal.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <rclcpp/context.hpp>
+
+namespace agnocast
+{
+
+// Bring the Agnocast context up in a process that called rclcpp::init() instead of
+// agnocast::init(), such as a component container. Without it there is no signal handler and
+// agnocast::ok() is false, stranding the Agnocast-only executors an agnocast::Node spawns
+// internally.
+//
+// Unlike agnocast::init(), it parses no command line and configures no rcl logging, so it never
+// takes over global state that rclcpp owns. Pass the rclcpp context the caller belongs to.
+void ensure_initialized(const rclcpp::Context::SharedPtr & rclcpp_context = nullptr);
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -3,11 +3,27 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/node/agnocast_arguments.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast_context_internal.hpp"
 
 #include <rcl/time.h>
 
 namespace agnocast
 {
+
+namespace
+{
+
+// local_args_ is the first member, so this runs before any of the node interfaces are
+// built. That ordering matters: NodeTimeSource can spawn an AgnocastOnlySingleThreadedExecutor
+// for the use_sim_time clock thread, and that executor needs the Agnocast context and
+// signal handler to already be up.
+ParsedArguments init_and_parse_arguments(const std::vector<std::string> & arguments)
+{
+  ensure_initialized();
+  return parse_arguments(arguments);
+}
+
+}  // namespace
 
 Node::Node(const std::string & node_name, const rclcpp::NodeOptions & options)
 : Node(node_name, "", options)
@@ -17,7 +33,7 @@ Node::Node(const std::string & node_name, const rclcpp::NodeOptions & options)
 Node::Node(
   const std::string & node_name, const std::string & namespace_,
   const rclcpp::NodeOptions & options)
-: local_args_(parse_arguments(options.arguments())),
+: local_args_(init_and_parse_arguments(options.arguments())),
   node_base_(std::make_shared<node_interfaces::NodeBase>(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
     options.use_intra_process_comms(), options.enable_topic_statistics())),

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -3,11 +3,26 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/node/agnocast_arguments.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast_context_internal.hpp"
 
 #include <rcl/time.h>
 
 namespace agnocast
 {
+
+namespace
+{
+
+ParsedArguments init_and_parse_arguments(const rclcpp::NodeOptions & options)
+{
+  // Parse before initializing: parse_arguments() throws on a malformed command line, and a node
+  // that never gets constructed must not leave the context up and the signal handler installed.
+  ParsedArguments args = parse_arguments(options.arguments());
+  ensure_initialized(options.context());
+  return args;
+}
+
+}  // namespace
 
 Node::Node(const std::string & node_name, const rclcpp::NodeOptions & options)
 : Node(node_name, "", options)
@@ -17,7 +32,7 @@ Node::Node(const std::string & node_name, const rclcpp::NodeOptions & options)
 Node::Node(
   const std::string & node_name, const std::string & namespace_,
   const rclcpp::NodeOptions & options)
-: local_args_(parse_arguments(options.arguments())),
+: local_args_(init_and_parse_arguments(options)),
   node_base_(std::make_shared<node_interfaces::NodeBase>(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
     options.use_intra_process_comms(), options.enable_topic_statistics())),

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -5,6 +5,7 @@
 #include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "agnocast_context_internal.hpp"
 #include "agnocast_signal_handler.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -46,10 +47,19 @@ AgnocastOnlyExecutor::AgnocastOnlyExecutor()
     exit(EXIT_FAILURE);
   }
 
+  // Bring up the signal handler if agnocast::init() was never called, e.g. when this
+  // executor is created from inside an agnocast::Node that a component container loaded.
+  ensure_initialized();
+
   if (!SignalHandler::register_shutdown_event(shutdown_event_fd_)) {
-    RCLCPP_ERROR(logger, "Failed to register shutdown eventfd with signal handler");
-    close(shutdown_event_fd_);
-    exit(EXIT_FAILURE);
+    // Reachable once the context has been shut down, i.e. during teardown, since
+    // ensure_initialized() deliberately does not reinstall the handler then. Losing shutdown
+    // notifications at that point is harmless because the spin loops also stop on
+    // agnocast::ok(), so keep the process alive rather than aborting it.
+    RCLCPP_WARN(
+      logger,
+      "Failed to register shutdown eventfd with signal handler; this executor will not be "
+      "notified on SIGINT/SIGTERM");
   }
 }
 

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -5,6 +5,7 @@
 #include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "agnocast_context_internal.hpp"
 #include "agnocast_signal_handler.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -46,10 +47,13 @@ AgnocastOnlyExecutor::AgnocastOnlyExecutor()
     exit(EXIT_FAILURE);
   }
 
+  ensure_initialized();
+
   if (!SignalHandler::register_shutdown_event(shutdown_event_fd_)) {
-    RCLCPP_ERROR(logger, "Failed to register shutdown eventfd with signal handler");
-    close(shutdown_event_fd_);
-    exit(EXIT_FAILURE);
+    RCLCPP_WARN(
+      logger,
+      "Failed to register shutdown eventfd with signal handler; this executor will not be "
+      "notified on SIGINT/SIGTERM");
   }
 }
 

--- a/src/agnocastlib/src/node/agnocast_signal_handler.cpp
+++ b/src/agnocastlib/src/node/agnocast_signal_handler.cpp
@@ -50,11 +50,11 @@ struct sigaction SignalHandler::old_sigterm_action_
 {
 };
 
-void SignalHandler::install()
+bool SignalHandler::install()
 {
   std::lock_guard<std::mutex> lock(mutex_);
   if (state_ != State::NotInstalled) {
-    return;
+    return false;
   }
 
   eventfds_.clear();
@@ -89,6 +89,7 @@ void SignalHandler::install()
   }
 
   state_ = State::Installed;
+  return true;
 }
 
 void SignalHandler::uninstall()

--- a/src/agnocastlib/src/node/agnocast_signal_handler.hpp
+++ b/src/agnocastlib/src/node/agnocast_signal_handler.hpp
@@ -19,7 +19,9 @@ public:
   // - Installs handlers for SIGINT and SIGTERM.
   // - Starts a dedicated thread to process signals.
   // - Initializes eventfds_.
-  static void install();
+  //
+  // Returns whether this call is the one that installed them.
+  static bool install();
 
   // Uninstalls signal handlers.
   // Safe to call multiple times. If it is already uninstalled or currently

--- a/src/agnocastlib/src/node/tf2/buffer.cpp
+++ b/src/agnocastlib/src/node/tf2/buffer.cpp
@@ -114,12 +114,9 @@ bool Buffer::canTransform(
     clock_->now() < start_time + rclcpp_timeout &&
     !canTransform(target_frame, source_frame, time, std::chrono::nanoseconds::zero(), errstr) &&
     (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
-    // agnocast::Buffer is primarily for agnocast::Node. But it is a plain tf data store and does
-    // not touch the Agnocast IPC layer, so it works with rclcpp::Node as well.
-    // In practice, Autoware's agnocast_wrapper uses it from both node types. So poll while
-    // whichever runtime the process initialized is still up:
-    //   - agnocast::ok(): AgnocastOnly mode (rclcpp is uninitialized)
-    //   - rclcpp::ok()  : rclcpp mode (agnocast is uninitialized)
+    // agnocast::Buffer never touches the Agnocast IPC layer, so both node types use it, and
+    // Autoware's agnocast_wrapper does. Poll while either runtime still reports itself running;
+    // whichever one governs the process turns false when that process shuts down.
     (agnocast::ok() || rclcpp::ok())) {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/src/agnocastlib/test/integration/test_agnocast_client.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_client.cpp
@@ -150,9 +150,7 @@ protected:
     if (spin_thread_.joinable()) {
       spin_thread_.join();
     }
-    if (agnocast::ok()) {
-      agnocast::shutdown();
-    }
+    agnocast::shutdown();
   }
 
   auto create_client()

--- a/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
@@ -373,3 +373,108 @@ TEST_F(InitOkShutdownTest, InitAndShutdownAreIdempotent)
   agnocast::shutdown();
   EXPECT_FALSE(agnocast::ok()) << "agnocast::ok() should still be false after second shutdown()";
 }
+
+// A component container's main() calls rclcpp::init() but never agnocast::init(). An
+// agnocast::Node loaded there still creates Agnocast-only executors internally (the
+// use_sim_time clock thread, the tf2 listener thread), so they must come up on their own.
+TEST_F(InitOkShutdownTest, AgnocastOnlyExecutorInitializesContextWhenInitWasNotCalled)
+{
+  ASSERT_FALSE(agnocast::ok()) << "precondition: agnocast::init() has not been called";
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  EXPECT_TRUE(agnocast::ok())
+    << "constructing an Agnocast-only executor should bring the context up by itself";
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+
+  std::this_thread::sleep_for(250ms);
+  EXPECT_FALSE(spin_exited.load()) << "spin() should keep running without an explicit init()";
+
+  agnocast::shutdown();
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s,
+    "executor spin() did not return after agnocast::shutdown().");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// The lazy initialization above must not fight the shutdown path: objects built during
+// teardown (AgnocastOnlyCallbackIsolatedExecutor::spin() creates an agnocast::Node for its
+// client publisher, for instance) would otherwise revive the context and hang every spin
+// loop that waits for agnocast::ok() to turn false.
+TEST_F(InitOkShutdownTest, LazyInitializationDoesNotReviveShutdownContext)
+{
+  agnocast::init(0, nullptr);
+  ASSERT_TRUE(agnocast::ok());
+
+  agnocast::shutdown();
+  ASSERT_FALSE(agnocast::ok());
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  EXPECT_FALSE(agnocast::ok())
+    << "creating an executor after shutdown() must not bring the context back up";
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s, "spin() did not return with a shutdown context.");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// A lazy initialization records no command line, so it must not make a later explicit
+// init() a no-op -- that would silently drop the global arguments.
+TEST_F(InitOkShutdownTest, ExplicitInitStillParsesArgumentsAfterLazyInitialization)
+{
+  {
+    auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+    ASSERT_TRUE(agnocast::ok());
+
+    std::lock_guard<std::mutex> lock(agnocast::g_context_mtx);
+    EXPECT_EQ(nullptr, agnocast::g_context.get_parsed_arguments())
+      << "lazy initialization must not fabricate global arguments";
+  }
+
+  agnocast::init(0, nullptr);
+
+  std::lock_guard<std::mutex> lock(agnocast::g_context_mtx);
+  EXPECT_NE(nullptr, agnocast::g_context.get_parsed_arguments())
+    << "init() after a lazy initialization must still parse the command line";
+}
+
+TEST_F(InitOkShutdownTest, SigintStopsAgnocastOnlyExecutorWhenInitWasNotCalled)
+{
+  ASSERT_FALSE(agnocast::ok()) << "precondition: agnocast::init() has not been called";
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+  std::this_thread::sleep_for(250ms);
+
+  ASSERT_EQ(kill(getpid(), SIGINT), 0);
+
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s, "executor spin() did not stop after SIGINT.");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}

--- a/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
@@ -1,7 +1,11 @@
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_node.hpp"
 #include "agnocast/node/agnocast_only_callback_isolated_executor.hpp"
 #include "agnocast/node/agnocast_only_multi_threaded_executor.hpp"
 #include "agnocast/node/agnocast_only_single_threaded_executor.hpp"
+
+#include <rclcpp/context.hpp>
+#include <rclcpp/node_options.hpp>
 
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -9,6 +13,8 @@
 #include <atomic>
 #include <chrono>
 #include <csignal>
+#include <memory>
+#include <stdexcept>
 #include <thread>
 
 namespace
@@ -352,19 +358,15 @@ TEST_F(InitOkShutdownTest, SigintAndSigtermStopAgnocastOnlyCallbackIsolatedExecu
   run_signal_case(SIGTERM);
 }
 
-TEST_F(InitOkShutdownTest, InitAndShutdownAreIdempotent)
+TEST_F(InitOkShutdownTest, ShutdownIsIdempotent)
 {
   // Calling shutdown() before init() should do nothing and not cause any errors.
   agnocast::shutdown();
   EXPECT_FALSE(agnocast::ok())
     << "agnocast::ok() should still be false after shutdown() without init()";
 
-  // Calling init() multiple times should not cause any errors and should keep the context
-  // initialized.
   agnocast::init(0, nullptr);
-  EXPECT_TRUE(agnocast::ok()) << "agnocast::ok() should be true after first init()";
-  agnocast::init(0, nullptr);
-  EXPECT_TRUE(agnocast::ok()) << "agnocast::ok() should still be true after second init()";
+  ASSERT_TRUE(agnocast::ok());
 
   // Calling shutdown() multiple times should not cause any errors and should keep the context
   // shutdown.
@@ -372,4 +374,243 @@ TEST_F(InitOkShutdownTest, InitAndShutdownAreIdempotent)
   EXPECT_FALSE(agnocast::ok()) << "agnocast::ok() should be false after first shutdown()";
   agnocast::shutdown();
   EXPECT_FALSE(agnocast::ok()) << "agnocast::ok() should still be false after second shutdown()";
+}
+
+// init() is not idempotent, unlike shutdown(). rclcpp draws the same line:
+// rclcpp::Context::init() throws ContextAlreadyInitialized while shutdown() returns false.
+TEST_F(InitOkShutdownTest, InitOnAnAlreadyInitializedContextThrows)
+{
+  agnocast::init(0, nullptr);
+  ASSERT_TRUE(agnocast::ok());
+
+  EXPECT_THROW(agnocast::init(0, nullptr), std::runtime_error);
+  EXPECT_TRUE(agnocast::ok()) << "a rejected init() must leave the context as it was";
+}
+
+TEST_F(InitOkShutdownTest, InitAfterAShutdownStartsAFreshCycle)
+{
+  agnocast::init(0, nullptr);
+  agnocast::shutdown();
+  ASSERT_FALSE(agnocast::ok());
+
+  EXPECT_NO_THROW(agnocast::init(0, nullptr));
+  EXPECT_TRUE(agnocast::ok());
+}
+
+// In a container the Agnocast-only executors an agnocast::Node spawns have to come up without
+// agnocast::init().
+TEST_F(InitOkShutdownTest, AgnocastOnlyExecutorInitializesContextWhenInitWasNotCalled)
+{
+  ASSERT_FALSE(agnocast::ok()) << "precondition: agnocast::init() has not been called";
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  EXPECT_TRUE(agnocast::ok())
+    << "constructing an Agnocast-only executor should bring the context up by itself";
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+
+  std::this_thread::sleep_for(250ms);
+  EXPECT_FALSE(spin_exited.load()) << "spin() should keep running without an explicit init()";
+
+  agnocast::shutdown();
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s,
+    "executor spin() did not return after agnocast::shutdown().");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// AgnocastOnlyCallbackIsolatedExecutor::spin() builds an agnocast::Node for its client
+// publisher, so reviving the context from one would hang every spin loop waiting for
+// agnocast::ok() to turn false.
+TEST_F(InitOkShutdownTest, LazyInitializationDoesNotReviveShutdownContext)
+{
+  agnocast::init(0, nullptr);
+  ASSERT_TRUE(agnocast::ok());
+
+  agnocast::shutdown();
+  ASSERT_FALSE(agnocast::ok());
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  EXPECT_FALSE(agnocast::ok())
+    << "creating an executor after shutdown() must not bring the context back up";
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s, "spin() did not return with a shutdown context.");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// Honouring an init() that follows a lazy one would mean reconfiguring the rcl logging rclcpp
+// owns. It goes first or not at all.
+TEST_F(InitOkShutdownTest, InitAfterALazyInitializationThrows)
+{
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+  ASSERT_TRUE(agnocast::ok());
+
+  EXPECT_THROW(agnocast::init(0, nullptr), std::runtime_error);
+
+  std::lock_guard<std::mutex> lock(agnocast::g_context_mtx);
+  EXPECT_EQ(nullptr, agnocast::g_context.get_parsed_arguments())
+    << "lazy initialization must not fabricate global arguments";
+}
+
+// A Node has to bring the context up too, not just an Agnocast-only executor: everything hung
+// off a node reads agnocast::ok(), and most of it never constructs such an executor.
+TEST_F(InitOkShutdownTest, NodeInitializesContextWhenInitWasNotCalled)
+{
+  ASSERT_FALSE(agnocast::ok()) << "precondition: agnocast::init() has not been called";
+
+  const auto node = std::make_shared<agnocast::Node>("lazy_init_node");
+
+  EXPECT_TRUE(agnocast::ok()) << "constructing a Node should bring the context up by itself";
+}
+
+// ok() answers whether Agnocast may keep running, which is not the same as whether the context
+// is up: a process that called agnocast::init() owns its own teardown, so the governing rclcpp
+// context going down takes ok() with it and leaves the Agnocast context standing.
+//
+// This and the cases below use a context of their own so that they leave the global default one
+// -- and the signal handlers rclcpp::shutdown() would uninstall with it -- alone.
+TEST_F(InitOkShutdownTest, OkFollowsTheGoverningContextWhileTheAgnocastContextStaysUp)
+{
+  auto rclcpp_context = std::make_shared<rclcpp::Context>();
+  rclcpp_context->init(0, nullptr);
+  agnocast::init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  options.context(rclcpp_context);
+  const auto node = std::make_shared<agnocast::Node>("hosted_node", options);
+  ASSERT_TRUE(agnocast::ok());
+
+  rclcpp_context->shutdown("test");
+
+  EXPECT_FALSE(agnocast::ok());
+  EXPECT_THROW(agnocast::init(0, nullptr), std::runtime_error)
+    << "the Agnocast context is still up, so init() still rejects";
+}
+
+// A process that never calls agnocast::init() never calls agnocast::shutdown() either, so what
+// it brought up lazily has to come down with the rclcpp context that governs it.
+TEST_F(InitOkShutdownTest, RclcppShutdownTearsDownALazilyInitializedContext)
+{
+  auto rclcpp_context = std::make_shared<rclcpp::Context>();
+  rclcpp_context->init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  options.context(rclcpp_context);
+  const auto node = std::make_shared<agnocast::Node>("hosted_node", options);
+  ASSERT_TRUE(agnocast::ok());
+
+  rclcpp_context->shutdown("test");
+
+  // init() accepting again is what proves the context came down, not just ok() turning false.
+  EXPECT_NO_THROW(agnocast::init(0, nullptr))
+    << "rclcpp::shutdown() must run the Agnocast teardown, not merely make ok() false";
+}
+
+// A container may build an Agnocast-only executor before its first agnocast::Node, and that
+// executor brings the context up. The node still has to hook the teardown on.
+TEST_F(InitOkShutdownTest, AnExecutorBuiltFirstDoesNotStopTheNodeFromHookingTheTeardownOn)
+{
+  auto rclcpp_context = std::make_shared<rclcpp::Context>();
+  rclcpp_context->init(0, nullptr);
+
+  const auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+  ASSERT_TRUE(agnocast::ok()) << "precondition: the executor brought the context up";
+
+  rclcpp::NodeOptions options;
+  options.context(rclcpp_context);
+  const auto node = std::make_shared<agnocast::Node>("hosted_node", options);
+
+  rclcpp_context->shutdown("test");
+
+  EXPECT_NO_THROW(agnocast::init(0, nullptr))
+    << "rclcpp::shutdown() must run the Agnocast teardown here too";
+}
+
+// The governing context is recorded, not owned.
+TEST_F(InitOkShutdownTest, AdoptingAnRclcppContextDoesNotExtendItsLifetime)
+{
+  auto rclcpp_context = std::make_shared<rclcpp::Context>();
+  rclcpp_context->init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  options.context(rclcpp_context);
+  const long baseline = rclcpp_context.use_count();
+
+  {
+    const auto node = std::make_shared<agnocast::Node>("hosted_node", options);
+    ASSERT_TRUE(agnocast::ok()) << "precondition: the node brought the Agnocast context up";
+  }
+
+  EXPECT_EQ(baseline, rclcpp_context.use_count()) << "adoption must not add a strong reference";
+}
+
+// shutdown() drops the recorded authority, and nothing may put it back until an explicit init():
+// the next cycle must not be governed by whatever a node built after it was holding.
+TEST_F(InitOkShutdownTest, ANodeBuiltAfterShutdownDoesNotReadoptTheRclcppContext)
+{
+  auto stale = std::make_shared<rclcpp::Context>();
+  stale->init(0, nullptr);
+  rclcpp::NodeOptions stale_options;
+  stale_options.context(stale);
+
+  agnocast::init(0, nullptr);
+  agnocast::shutdown();
+  {
+    const auto late_node = std::make_shared<agnocast::Node>("late_node", stale_options);
+    ASSERT_FALSE(agnocast::ok());
+  }
+
+  agnocast::init(0, nullptr);
+  auto governing = std::make_shared<rclcpp::Context>();
+  governing->init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.context(governing);
+  const auto node = std::make_shared<agnocast::Node>("hosted_node", options);
+  ASSERT_TRUE(agnocast::ok());
+
+  governing->shutdown("test");
+  EXPECT_FALSE(agnocast::ok())
+    << "the fresh cycle must follow its own node's context, not one picked up after shutdown()";
+}
+
+TEST_F(InitOkShutdownTest, SigintStopsAgnocastOnlyExecutorWhenInitWasNotCalled)
+{
+  ASSERT_FALSE(agnocast::ok()) << "precondition: agnocast::init() has not been called";
+
+  auto executor = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+  std::this_thread::sleep_for(250ms);
+
+  ASSERT_EQ(kill(getpid(), SIGINT), 0);
+
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s, "executor spin() did not stop after SIGINT.");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
 }

--- a/src/agnocastlib/test/integration/test_agnocast_node.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_node.cpp
@@ -44,9 +44,7 @@ protected:
 
   void TearDown() override
   {
-    if (agnocast::ok()) {
-      agnocast::shutdown();
-    }
+    agnocast::shutdown();
     reset_context_for_test();
   }
 };

--- a/src/agnocastlib/test/integration/test_agnocast_parameter_service.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_parameter_service.cpp
@@ -41,9 +41,7 @@ protected:
     if (spin_thread_.joinable()) {
       spin_thread_.join();
     }
-    if (agnocast::ok()) {
-      agnocast::shutdown();
-    }
+    agnocast::shutdown();
   }
 
   std::shared_ptr<agnocast::Node> create_server_node(const rclcpp::NodeOptions & options)

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -29,9 +29,7 @@ protected:
   {
     graph_.reset();
     node_.reset();
-    if (agnocast::ok()) {
-      agnocast::shutdown();
-    }
+    agnocast::shutdown();
   }
 
   std::shared_ptr<agnocast::Node> node_;

--- a/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
@@ -152,6 +152,8 @@ bool sigactions_equal(const struct sigaction & a, const struct sigaction & b)
 class SignalHandlerTest : public ::testing::Test
 {
 protected:
+  void SetUp() override { agnocast::SignalHandler::uninstall(); }
+
   void TearDown() override
   {
     agnocast::SignalHandler::uninstall();

--- a/src/agnocastlib/test/unit/test_node_base.cpp
+++ b/src/agnocastlib/test/unit/test_node_base.cpp
@@ -5,9 +5,28 @@
 
 #include <gtest/gtest.h>
 
+#include <mutex>
+
+namespace
+{
+void reset_context_for_test()
+{
+  std::lock_guard<std::mutex> lock(agnocast::g_context_mtx);
+  agnocast::g_context = agnocast::Context{};
+}
+}  // namespace
+
 class TestNodeBase : public ::testing::Test
 {
 protected:
+  void SetUp() override { reset_context_for_test(); }
+
+  void TearDown() override
+  {
+    agnocast::shutdown();
+    reset_context_for_test();
+  }
+
   agnocast::Node::SharedPtr node_;
 
   rclcpp::NodeOptions node_options_without_parameter_services() const


### PR DESCRIPTION

## Description

Loading an `agnocast::Node` component into a Component Container killed the container. A container's `main()` calls `rclcpp::init()` but never `agnocast::init()`, and `AgnocastOnlyExecutor`'s constructor treated the resulting missing signal handler as fatal — an `agnocast::Node` creates such executors internally, for the `use_sim_time` clock thread and the `tf2` listener thread.

The Agnocast context now comes up lazily when an `agnocast::Node` or an Agnocast-only executor is created in such a process, without parsing the command line or configuring rcl logging, both of which `rclcpp::init()` owns. 

Three things follow from the context being able to come up at all:

- **`agnocast::ok()` follows the rclcpp context that governs the process.** It was permanently false in a container, so nothing depended on it; now that it can be true it has to become false when the process ends, and there that is an ordinary `rclcpp::shutdown()`. The context records the `rclcpp::Context` its first node belongs to — weakly, so it does not leave `~rclcpp::Context()` to static destruction order.
- **That shutdown tears Agnocast down too.** `agnocast::shutdown()` is registered as a shutdown callback on the adopted context; nothing else would call it, and the signal handler and its thread would outlive `main()`. rclcpp runs these callbacks before uninstalling its own handlers, so the two unwind in the order they went on.
- **`agnocast::init()` throws when the context is already up.** Honouring its arguments after a lazy initialization means reconfiguring the rcl logging rclcpp owns; ignoring them misconfigures every node built afterwards. This is the line rclcpp draws as well — `Context::init()` throws `ContextAlreadyInitialized`, `shutdown()` returns `false` — and `agnocast::shutdown()` stays idempotent to match.

### Which configurations this covers

Where the endpoints live and how the process is deployed fix the executor, giving four configurations. `ensure_initialized()` is reachable only from the `agnocast::Node` and `AgnocastOnlyExecutor` constructors, so the two `rclcpp::Node` rows never bring the Agnocast context up at all.

| Endpoint host | Deployment | Spin stops on | Context up / adopted | Torn down by |
|---|---|---|---|---|
| `rclcpp::Node` | standalone | `rclcpp::ok(context_)` | no | — |
| `rclcpp::Node` | container | `rclcpp::ok(context_)` | no | — |
| `agnocast::Node` | standalone | `agnocast::ok()` | up by `agnocast::init()`; the global default context is invalid, so nothing is adopted | `agnocast::shutdown()` in `main()` |
| `agnocast::Node` | container | `rclcpp::ok()` for the container's executor, `agnocast::ok()` for the `AgnocastOnly*` the node spawns | yes, both | `rclcpp::shutdown()`, through the callback |

In-tree instances of all four: `minimal_publisher.cpp`, `minimal_subscriber.cpp`, `no_rclcpp_publisher.cpp`, `no_rclcpp_subscriber.cpp`.

Everything that reads `agnocast::ok()` is `agnocast::Node`-only — the four `AgnocastOnly*` executors, `diagnostic_updater.cpp`, `agnocast_client.hpp` — except `tf2/buffer.cpp`, and there `agnocast::ok()` is false in the two `rclcpp::Node` rows, so its guard collapses to `rclcpp::ok()`.

Each of the four calls exactly one of `rclcpp::init()` and `agnocast::init()`, which this PR makes the rule. The teardown callback below is the `agnocast::shutdown()` that `ensure_initialized()` registers on the adopted rclcpp context. The last two columns are what a probe reported after teardown: the SIGINT disposition and the thread count, together showing that neither the handler nor its thread outlives `main()`.

| Process calls | Teardown callback registered | What triggers teardown | State afterwards | vs. before this PR |
|---|---|---|---|---|
| `rclcpp::init()` only | yes — the context came up lazily, so nothing else would call `agnocast::shutdown()` | `rclcpp::shutdown()` with no signal: the callback is the only path, and it does the whole teardown | SIGINT back to `SIG_DFL`, signal thread joined | fixed here |
| `rclcpp::init()` only | yes, same as above | Ctrl-C first: the signal thread takes the context down but leaves the handler installed, so the callback still has to uninstall it | SIGINT back to `SIG_DFL`, signal thread joined | fixed here |
| `agnocast::init()` only | no — that `init()` owns the teardown, and the global default context it would hook onto is never initialized | `agnocast::shutdown()` in `main()` | SIGINT back to `SIG_DFL`, signal thread joined | unchanged |

| Out of scope | Why |
|---|---|
| both `init()`s | an `agnocast::Node` reads its global arguments from `agnocast::init()` alone, the only reason left to want both; #1615 removes it |
| neither `init()` | no rclcpp context to hook the teardown onto and no `agnocast::shutdown()` to reach. Ctrl-C still works, and there is no in-tree instance |
| `rclcpp::Node` on an `AgnocastOnly*` executor | dispatches no RMW callbacks. Stated in `agnocast_only_executor.hpp` and in the docs by this PR |
| `AgnocastOnly*` under a Component Manager | does not derive from `rclcpp::Executor` |

Nothing enforces the rule; it is stated in `agnocast_context.hpp` and in the docs. Calling both `init()`s or neither was measured too. The teardown callback goes on only when the context came up lazily: a process that called `agnocast::init()` owns the teardown itself, and its handler went in underneath rclcpp's, where coming off early would wipe a handler rclcpp is still using.

## Related links

#1615 sources global arguments from the governing rclcpp context, and is merged after this one. It will want to revisit the `agnocast::init()` doc comment, which says an `agnocast::Node` reads its global arguments from there.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Post-merge checklist

- [x] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
https://github.com/autowarefoundation/agnocast_doc/pull/57






