### PR TITLE
feat(agnocast_cie_thread_configurator): apply kernel thread and IRQ configs with reapply support

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ All scripts are intended to be invoked from the repository root unless noted oth
 | Script | Purpose |
 |---|---|
 | `dds_config.bash` | Apply CycloneDDS runtime settings (`net.core.rmem_max`, loopback multicast) required for Agnocast over CycloneDDS. Guarded by `/tmp/cycloneDDS_configured` so it runs only once per boot. |
-| `setup_thread_configurator.bash` | Grant `CAP_SYS_NICE` to `thread_configurator_node` and register library paths in `/etc/ld.so.conf.d/agnocast-cie.conf`. Required for Callback Isolated Executor. See the [integration guide](https://autowarefoundation.github.io/agnocast_doc/callback-isolated-executor/integration-guide/#step-2-set-up-the-thread-configurator). |
+| `setup_thread_configurator.bash` | Grant `CAP_SYS_NICE` and `CAP_DAC_OVERRIDE` (for writing `/proc/irq/<N>/smp_affinity_list`) to `thread_configurator_node` and register library paths in `/etc/ld.so.conf.d/agnocast-cie.conf`. Required for Callback Isolated Executor. See the [integration guide](https://autowarefoundation.github.io/agnocast_doc/callback-isolated-executor/integration-guide/#step-2-set-up-the-thread-configurator). |
 | `switch_kmod.bash` | Swap the host's `agnocast-kmod-v<ver>` to another version. For container-based setups where only the host-side kmod needs replacing; the kmod and in-container heaphook must share the same ioctl ABI version. |
 
 ### sample_application/

--- a/scripts/setup_thread_configurator.bash
+++ b/scripts/setup_thread_configurator.bash
@@ -9,7 +9,8 @@
 #   ./scripts/setup_thread_configurator.bash
 #
 # This script automates:
-#   1. Granting CAP_SYS_NICE to the thread_configurator_node binary.
+#   1. Granting CAP_SYS_NICE (scheduling syscalls) and CAP_DAC_OVERRIDE (writes
+#      to root-owned /proc/irq/<N>/smp_affinity_list) to thread_configurator_node.
 #   2. Registering required library paths in /etc/ld.so.conf.d/agnocast-cie.conf.
 
 set -euo pipefail
@@ -62,7 +63,7 @@ fi
 
 # --- Step 1: Grant capabilities --------------------------------------------
 
-echo "[1/2] Grant CAP_SYS_NICE to thread_configurator_node"
+echo "[1/2] Grant CAP_SYS_NICE and CAP_DAC_OVERRIDE to thread_configurator_node"
 
 bin_path=$(readlink -f "${thread_configurator_prefix}/lib/agnocast_cie_thread_configurator/thread_configurator_node")
 
@@ -71,12 +72,15 @@ if [ ! -f "$bin_path" ]; then
 	exit 1
 fi
 
+# getcap prints caps in numeric order: "cap_dac_override,cap_sys_nice=eip".
+# An install by an older script version carries only cap_sys_nice and must not
+# match here, or it would never be upgraded to the combined set.
 current_caps=$(getcap "$bin_path" 2>/dev/null || true)
-if echo "$current_caps" | grep -q "cap_sys_nice=eip"; then
+if echo "$current_caps" | grep -q "cap_dac_override,cap_sys_nice=eip"; then
 	echo "  Already set ($current_caps). Skipping."
 else
 	echo "  Target: $bin_path"
-	sudo setcap cap_sys_nice=eip "$bin_path"
+	sudo setcap "cap_sys_nice,cap_dac_override=eip" "$bin_path"
 	echo "  Done: $(getcap "$bin_path")"
 fi
 

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -15,6 +15,18 @@
 # by a wildcard likewise takes over at the next announcement; until then the
 # wildcard keeps applying to that instance, and from then on only the exact
 # entry does.
+#
+# kernel_threads / irqs entries are matched against a fresh /proc scan on
+# every reapply (no carry-over). Entries whose attribute values are all unset
+# (YAML null or UNMANAGEABLE) appear in no array. "applied" means ensured: an
+# entry already in the desired state counts as applied without any syscall
+# (compare-before-set). There is no skipped_irqs: an IRQ has no announce-later
+# state, so a missing IRQ is reported as failed.
+#
+# Exception: kernel_threads entries with policy SCHED_DEADLINE are always
+# re-applied (runtime/period/deadline cannot be read back from /proc, so
+# in-sync cannot be established); with a non-empty affinity each pass re-runs
+# the cgroup-based affinity setup for every matched thread.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"
@@ -23,3 +35,8 @@ string[] failed_callback_groups    # syscall failed (details in configurator log
 string[] failed_non_ros_threads    # syscall failed (details in configurator log)
 string[] skipped_callback_groups   # thread_id not yet announced; will apply on next announcement
 string[] skipped_non_ros_threads
+string[] applied_kernel_threads    # in desired state; format "<comm>:<tid>", one per matched thread
+string[] failed_kernel_threads     # syscall failed, or an affinity differing from a per-CPU kthread's fixed one
+string[] skipped_kernel_threads    # managed comm matched no running kernel thread; format "<comm>"
+string[] applied_irqs              # in desired state; decimal IRQ number
+string[] failed_irqs               # identity mismatch, missing IRQ, irqbalance running, or write error

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -39,4 +39,4 @@ string[] applied_kernel_threads    # in desired state; format "<comm>:<tid>", on
 string[] failed_kernel_threads     # syscall failed, or an affinity differing from a per-CPU kthread's fixed one
 string[] skipped_kernel_threads    # managed comm matched no running kernel thread; format "<comm>"
 string[] applied_irqs              # in desired state; decimal IRQ number
-string[] failed_irqs               # identity mismatch, missing IRQ, irqbalance running, or write error
+string[] failed_irqs               # identity mismatch, missing IRQ, write needed while irqbalance runs, or write error

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -15,6 +15,13 @@
 # by a wildcard likewise takes over at the next announcement; until then the
 # wildcard keeps applying to that instance, and from then on only the exact
 # entry does.
+#
+# kernel_threads / irqs entries are matched against a fresh /proc scan on
+# every reapply (no carry-over). Entries whose attribute values are all unset
+# (YAML null or UNMANAGEABLE) appear in no array. "applied" means ensured: an
+# entry already in the desired state counts as applied without any syscall
+# (compare-before-set). There is no skipped_irqs: an IRQ has no announce-later
+# state, so a missing IRQ is reported as failed.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"
@@ -23,3 +30,8 @@ string[] failed_callback_groups    # syscall failed (details in configurator log
 string[] failed_non_ros_threads    # syscall failed (details in configurator log)
 string[] skipped_callback_groups   # thread_id not yet announced; will apply on next announcement
 string[] skipped_non_ros_threads
+string[] applied_kernel_threads    # in desired state; format "<comm>:<tid>", one per matched thread
+string[] failed_kernel_threads     # syscall failed or affinity requested on a per-CPU kthread
+string[] skipped_kernel_threads    # managed comm matched no running kernel thread; format "<comm>"
+string[] applied_irqs              # in desired state; decimal IRQ number
+string[] failed_irqs               # identity mismatch, missing IRQ, irqbalance running, or write error

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -61,4 +61,13 @@ std::string format_cpu_list(const std::vector<int> & cpus);
 // nullopt on empty or malformed input.
 std::optional<std::vector<int>> parse_cpu_list(const std::string & s);
 
+// parse_cpu_list, additionally dropping CPUs above this machine's manageable
+// bound (min(CPU_SETSIZE, _SC_NPROCESSORS_CONF) - 1): the kernel prints
+// affinity over the possible-CPU mask, which can exceed the present CPUs.
+// Template emission and the apply-side compare-before-set must share this
+// bound with parse_affinity, or an untouched template entry stops comparing
+// equal to the value it was observed from. nullopt when nothing manageable
+// remains.
+std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & s);
+
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -18,6 +18,8 @@
 class ThreadConfiguratorNode : public rclcpp::Node
 {
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
+  using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
+  using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
 
   // Concurrency:
   // - callback_group_configs_ / id_to_callback_group_config_ /
@@ -27,6 +29,8 @@ class ThreadConfiguratorNode : public rclcpp::Node
   // - non_ros_thread_configs_ / id_to_non_ros_thread_config_: written by both
   //   the NonRosThreadInfoListener reader thread and the reapply handler;
   //   all access must hold non_ros_state_mutex_.
+  // - kernel_thread_configs_ / irq_configs_: written only by the constructor
+  //   (pre-spin) and the reapply handler, so no mutex is needed.
   // - print_all_unapplied(): called only after stop() + executor return, so
   //   reads need no lock.
 
@@ -39,12 +43,33 @@ public:
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;
 
 private:
+  // One kernel-thread/IRQ apply pass. Keys: "<comm>:<tid>" (applied/failed)
+  // and "<comm>" (skipped) for kernel threads; the decimal IRQ number for
+  // IRQs. "applied" = ensured: an already-matching entry counts without
+  // syscalls (compare-before-set).
+  struct SectionApplyOutcome
+  {
+    std::vector<std::string> applied;
+    std::vector<std::string> failed;
+    std::vector<std::string> skipped;
+  };
+
   void validate_hardware_info(const YAML::Node & yaml);
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
   // thread_id is passed explicitly because a wildcard entry applies to many
   // threads (one per matched_tids element), not just config.thread_id.
   bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
+  // policy is compared only against "SCHED_DEADLINE" (cgroup-based affinity);
+  // any other value takes the plain sched_setaffinity path.
+  bool issue_affinity_syscalls(
+    const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+    int64_t thread_id);
+  SectionApplyOutcome apply_kernel_thread_configs();
+  SectionApplyOutcome apply_irq_configs() const;
+  // Sole logging point for the write path: emits errno-specific guidance on
+  // any open/write/short-write failure (returning false) and the success line.
+  bool write_irq_affinity_file(const IrqConfig & config) const;
   void callback_group_callback(
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
@@ -69,6 +94,9 @@ private:
   std::vector<ThreadConfig> non_ros_thread_configs_;
   // thread_name -> ThreadConfig*
   std::map<std::string, ThreadConfig *> id_to_non_ros_thread_config_;
+
+  std::vector<KernelThreadConfig> kernel_thread_configs_;
+  std::vector<IrqConfig> irq_configs_;
 
   std::atomic<int> unapplied_num_{0};
   std::atomic<int> cgroup_num_{0};

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -18,6 +18,8 @@
 class ThreadConfiguratorNode : public rclcpp::Node
 {
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
+  using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
+  using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
 
   // Concurrency:
   // - callback_group_configs_ / id_to_callback_group_config_ /
@@ -27,6 +29,8 @@ class ThreadConfiguratorNode : public rclcpp::Node
   // - non_ros_thread_configs_ / id_to_non_ros_thread_config_: written by both
   //   the NonRosThreadInfoListener reader thread and the reapply handler;
   //   all access must hold non_ros_state_mutex_.
+  // - kernel_thread_configs_ / irq_configs_: written only by the constructor
+  //   (pre-spin) and the reapply handler, so no mutex is needed.
   // - print_all_unapplied(): called only after stop() + executor return, so
   //   reads need no lock.
 
@@ -39,12 +43,29 @@ public:
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;
 
 private:
+  // One kernel-thread/IRQ apply pass. Keys: "<comm>:<tid>" (applied/failed)
+  // and "<comm>" (skipped) for kernel threads; the decimal IRQ number for
+  // IRQs. "applied" = ensured: an already-matching entry counts without
+  // syscalls (compare-before-set).
+  struct SectionApplyOutcome
+  {
+    std::vector<std::string> applied;
+    std::vector<std::string> failed;
+    std::vector<std::string> skipped;
+  };
+
   void validate_hardware_info(const YAML::Node & yaml);
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
   // thread_id is passed explicitly because a wildcard entry applies to many
   // threads (one per matched_tids element), not just config.thread_id.
   bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
+  bool issue_affinity_syscalls(
+    const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+    int64_t thread_id);
+  SectionApplyOutcome apply_kernel_thread_configs();
+  SectionApplyOutcome apply_irq_configs();
+  bool write_irq_affinity_file(const IrqConfig & config);
   void callback_group_callback(
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
@@ -69,6 +90,9 @@ private:
   std::vector<ThreadConfig> non_ros_thread_configs_;
   // thread_name -> ThreadConfig*
   std::map<std::string, ThreadConfig *> id_to_non_ros_thread_config_;
+
+  std::vector<KernelThreadConfig> kernel_thread_configs_;
+  std::vector<IrqConfig> irq_configs_;
 
   std::atomic<int> unapplied_num_{0};
   std::atomic<int> cgroup_num_{0};

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -8,9 +8,6 @@
 
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
 
-#include <sched.h>
-#include <unistd.h>
-
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
@@ -36,26 +33,6 @@ std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> dedup_by_comm(
       [](const auto & a, const auto & b) { return a.comm == b.comm; }),
     scanned.end());
   return scanned;
-}
-
-// The kernel prints affinity over the possible-CPU mask, which can include
-// CPUs the apply-side parser rejects (it bounds them by the present CPUs);
-// keep only acceptable CPUs so the untouched template stays loadable.
-std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & raw)
-{
-  auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(raw);
-  if (!cpus) {
-    return std::nullopt;
-  }
-  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
-  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
-  cpus->erase(
-    std::remove_if(cpus->begin(), cpus->end(), [max_cpu](int cpu) { return cpu > max_cpu; }),
-    cpus->end());
-  if (cpus->empty()) {
-    return std::nullopt;
-  }
-  return cpus;
 }
 
 }  // namespace
@@ -261,7 +238,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     const bool policy_representable =
       agnocast_cie_thread_configurator::policy_to_sched_const.count(info.policy) > 0 &&
       info.policy != "SCHED_DEADLINE";
-    const auto cpus = parse_manageable_cpu_list(info.affinity);
+    const auto cpus = agnocast_cie_thread_configurator::parse_manageable_cpu_list(info.affinity);
 
     out << YAML::BeginMap;
     out << YAML::Key << "comm" << YAML::Value << info.comm;
@@ -293,7 +270,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Value << YAML::BeginSeq;
 
   for (const auto & info : irqs) {
-    const auto cpus = parse_manageable_cpu_list(info.affinity);
+    const auto cpus = agnocast_cie_thread_configurator::parse_manageable_cpu_list(info.affinity);
 
     out << YAML::BeginMap;
     out << YAML::Key << "irq" << YAML::Value << info.irq;

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -2,6 +2,9 @@
 
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
+#include <sched.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <cctype>
 #include <charconv>
@@ -351,6 +354,23 @@ std::optional<std::vector<int>> parse_cpu_list(const std::string & s)
   std::sort(result.begin(), result.end());
   result.erase(std::unique(result.begin(), result.end()), result.end());
   return result;
+}
+
+std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & s)
+{
+  auto cpus = parse_cpu_list(s);
+  if (!cpus) {
+    return std::nullopt;
+  }
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
+  cpus->erase(
+    std::remove_if(cpus->begin(), cpus->end(), [max_cpu](int cpu) { return cpu > max_cpu; }),
+    cpus->end());
+  if (cpus->empty()) {
+    return std::nullopt;
+  }
+  return cpus;
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
@@ -10,10 +11,13 @@
 #include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <error.h>
+#include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -22,6 +26,77 @@
 #include <utility>
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
+
+namespace
+{
+
+bool same_cpu_set(const std::vector<int> & desired, const std::optional<std::vector<int>> & current)
+{
+  if (!current) {
+    return false;
+  }
+  // Both sides are canonical: parse_affinity and parse_manageable_cpu_list
+  // each return sorted, deduplicated lists bounded by the same
+  // manageable-CPU limit.
+  return desired == *current;
+}
+
+// Compare-before-set: unedited templates (observed values as the desired
+// ones) stay no-ops, and threads the kernel refuses to modify even with
+// identical values (stop-class migration/N) are left alone. DEADLINE params
+// cannot be read back from stat, so a DEADLINE request always takes the
+// syscall path (never counted in-sync; it can still end up in failed).
+bool kernel_thread_in_sync(
+  const agnocast_cie_thread_configurator::KernelThreadConfig & config,
+  const agnocast_cie_thread_configurator::KernelThreadInfo & info)
+{
+  if (config.policy.has_value()) {
+    if (*config.policy == "SCHED_DEADLINE") {
+      return false;
+    }
+    if (*config.policy != info.policy) {
+      return false;
+    }
+    // The policy classes tune different knobs: nice for CFS, rt_priority for
+    // FIFO/RR (the emitter and parser agree on this split).
+    const bool tunable_in_sync = agnocast_cie_thread_configurator::is_cfs_policy(*config.policy)
+                                   ? config.nice == info.nice
+                                   : config.priority == info.rt_priority;
+    if (!tunable_in_sync) {
+      return false;
+    }
+  }
+  if (!config.affinity.empty()) {
+    if (!same_cpu_set(
+          config.affinity,
+          agnocast_cie_thread_configurator::parse_manageable_cpu_list(info.affinity))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// The multi-sentence guidance is shared by the open- and write-failure
+// EACCES/EPERM branches so the two cannot drift apart.
+constexpr const char * k_cap_guidance =
+  "Writing /proc/irq/<N>/smp_affinity_list requires CAP_DAC_OVERRIDE in addition to "
+  "CAP_SYS_NICE. Re-run scripts/setup_thread_configurator.bash to grant "
+  "'cap_sys_nice,cap_dac_override=eip' to thread_configurator_node.";
+
+// Shared by the pre-write actions check and the ENOENT open failure. name is
+// optional (empty skips the identity check), so an unset one is labeled
+// instead of being printed as ''.
+void log_irq_vanished(
+  const rclcpp::Logger & logger, const agnocast_cie_thread_configurator::IrqConfig & config)
+{
+  RCLCPP_ERROR(
+    logger,
+    "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
+    "change across boots or device changes; re-run prerun_node and update the config.",
+    config.irq, config.name.empty() ? "<not recorded>" : config.name.c_str());
+}
+
+}  // namespace
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options),
@@ -51,6 +126,21 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   agnocast_cie_thread_configurator::parse_yaml(
     yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
+  kernel_thread_configs_ = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+  irq_configs_ = agnocast_cie_thread_configurator::parse_irqs(yaml);
+
+  // Kernel threads and IRQs never announce themselves: configure them here
+  // from a /proc scan, outside the announcement-driven accounting below.
+  {
+    const SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    const SectionApplyOutcome irq_outcome = apply_irq_configs();
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Kernel threads and IRQs configured: applied=%zu, failed=%zu, skipped=%zu",
+      kernel_thread_outcome.applied.size() + irq_outcome.applied.size(),
+      kernel_thread_outcome.failed.size() + irq_outcome.failed.size(),
+      kernel_thread_outcome.skipped.size() + irq_outcome.skipped.size());
+  }
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -379,12 +469,19 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     return false;
   }
 
-  if (config.affinity.size() > 0) {
-    if (config.policy == "SCHED_DEADLINE") {
-      if (!set_affinity_by_cgroup(thread_id, config.affinity)) {
+  return issue_affinity_syscalls(config.thread_str, config.policy, config.affinity, thread_id);
+}
+
+bool ThreadConfiguratorNode::issue_affinity_syscalls(
+  const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+  int64_t thread_id)
+{
+  if (affinity.size() > 0) {
+    if (policy == "SCHED_DEADLINE") {
+      if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id,
+          thread_str.c_str(), thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
         return false;
@@ -392,19 +489,254 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     } else {
       cpu_set_t set;
       CPU_ZERO(&set);
-      for (int cpu : config.affinity) {
+      for (int cpu : affinity) {
         CPU_SET(cpu, &set);
       }
       if (sched_setaffinity(thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
     }
   }
 
   return true;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel_thread_configs()
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    kernel_thread_configs_.begin(), kernel_thread_configs_.end(),
+    [](const KernelThreadConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  const auto scanned = agnocast_cie_thread_configurator::scan_kernel_threads();
+  for (const auto & config : kernel_thread_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    const auto matches =
+      agnocast_cie_thread_configurator::find_kernel_threads_by_comm(scanned, config.comm);
+    if (matches.empty()) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "No running kernel thread matches comm=%s; skipping. It may appear later; call "
+        "~/reapply_config to retry.",
+        config.comm.c_str());
+      outcome.skipped.push_back(config.comm);
+      continue;
+    }
+
+    // Reuse the announcement-path syscall code (and its error wording)
+    // verbatim by shaping the entry as a ThreadConfig: one desired state,
+    // applied to every matched tid.
+    std::optional<ThreadConfig> shaped;
+    if (config.policy.has_value()) {
+      ThreadConfig tmp;
+      tmp.thread_str = config.comm;
+      tmp.policy = *config.policy;
+      tmp.nice = config.nice;
+      tmp.priority = config.priority;
+      tmp.affinity = config.affinity;
+      tmp.runtime = config.runtime;
+      tmp.period = config.period;
+      tmp.deadline = config.deadline;
+      shaped = std::move(tmp);
+    }
+
+    for (const auto * info : matches) {
+      std::string key = config.comm + ":" + std::to_string(info->tid);
+      if (kernel_thread_in_sync(config, *info)) {
+        outcome.applied.push_back(std::move(key));
+        continue;
+      }
+      // A per-CPU kthread's affinity is kernel-fixed, but a request equal to
+      // that fixed value needs no change; only a different one is impossible.
+      const bool affinity_on_fixed = !config.affinity.empty() && info->no_setaffinity;
+      if (
+        affinity_on_fixed &&
+        !same_cpu_set(
+          config.affinity,
+          agnocast_cie_thread_configurator::parse_manageable_cpu_list(info->affinity))) {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Failed to configure affinity (thread=%s, tid=%ld): per-CPU kernel thread "
+          "(PF_NO_SETAFFINITY); the kernel fixes its affinity. Set 'affinity' to %s for this "
+          "entry.",
+          config.comm.c_str(), info->tid,
+          std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+        outcome.failed.push_back(std::move(key));
+        continue;
+      }
+
+      bool ok = false;
+      if (shaped.has_value()) {
+        if (affinity_on_fixed) {
+          // sched_setaffinity returns EINVAL for such a thread even with the
+          // identical set, so issue only the policy part.
+          ThreadConfig policy_only = *shaped;
+          policy_only.affinity.clear();
+          ok = issue_syscalls(policy_only, info->tid);
+        } else {
+          ok = issue_syscalls(*shaped, info->tid);
+        }
+      } else {
+        // Branch on the observed policy: an affinity-only entry matching a
+        // thread currently under SCHED_DEADLINE needs the cgroup path.
+        ok = issue_affinity_syscalls(config.comm, info->policy, config.affinity, info->tid);
+      }
+
+      if (ok) {
+        RCLCPP_INFO(
+          this->get_logger(), "Configured kernel thread (comm=%s, tid=%ld)", config.comm.c_str(),
+          info->tid);
+        outcome.applied.push_back(std::move(key));
+      } else {
+        outcome.failed.push_back(std::move(key));
+      }
+    }
+  }
+  return outcome;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_configs() const
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    irq_configs_.begin(), irq_configs_.end(),
+    [](const IrqConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  // A running irqbalance would periodically rewrite smp_affinity, silently
+  // undoing whatever is applied here, so applying would only fake success.
+  // Checked immediately before the writes to keep the detection fresh.
+  if (agnocast_cie_thread_configurator::process_with_comm_exists("irqbalance")) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "IRQ affinity configuration is requested but irqbalance is running; it would periodically "
+      "overwrite the configured affinities, so nothing is applied. Disable it (sudo systemctl "
+      "disable --now irqbalance) and call ~/reapply_config to retry.");
+    for (const auto & config : irq_configs_) {
+      if (config.is_managed()) {
+        outcome.failed.push_back(std::to_string(config.irq));
+      }
+    }
+    return outcome;
+  }
+
+  for (const auto & config : irq_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    std::string key = std::to_string(config.irq);
+
+    const auto actions = agnocast_cie_thread_configurator::read_irq_actions(config.irq);
+    if (!actions) {
+      log_irq_vanished(this->get_logger(), config);
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+    if (!config.name.empty() && *actions != config.name) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "IRQ %d identity mismatch: expected actions '%s', current '%s'. IRQ numbers can change "
+        "across boots; re-run prerun_node and update the config.",
+        config.irq, config.name.c_str(), actions->c_str());
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+
+    std::string current;
+    {
+      std::ifstream file("/proc/irq/" + key + "/smp_affinity_list");
+      if (!std::getline(file, current)) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Could not read the current affinity of IRQ %d; attempting an unconditional write.",
+          config.irq);
+      }
+    }
+    if (same_cpu_set(
+          config.affinity, agnocast_cie_thread_configurator::parse_manageable_cpu_list(current))) {
+      // Also spares kernel-managed IRQs (which reject every write with EIO)
+      // from a spurious error when the recorded value is still current.
+      outcome.applied.push_back(std::move(key));
+      continue;
+    }
+
+    if (write_irq_affinity_file(config)) {
+      outcome.applied.push_back(std::move(key));
+    } else {
+      outcome.failed.push_back(std::move(key));
+    }
+  }
+  return outcome;
+}
+
+bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqConfig & config) const
+{
+  const std::string path = "/proc/irq/" + std::to_string(config.irq) + "/smp_affinity_list";
+  const std::string value = agnocast_cie_thread_configurator::format_cpu_list(config.affinity);
+
+  // Raw open/write instead of std::ofstream: the instructive messages below
+  // depend on which errno occurred, and EIO only appears at write(2) time.
+  const int fd = ::open(path.c_str(), O_WRONLY | O_CLOEXEC);
+  if (fd == -1) {
+    // The logging macro may clobber errno before its arguments are evaluated.
+    const int open_errno = errno;
+    if (open_errno == EACCES || open_errno == EPERM) {
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to configure IRQ %d affinity: %s. %s", config.irq,
+        strerror(open_errno), k_cap_guidance);
+    } else if (open_errno == ENOENT) {
+      log_irq_vanished(this->get_logger(), config);
+    } else {
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to configure IRQ %d affinity: %s", config.irq,
+        strerror(open_errno));
+    }
+    return false;
+  }
+
+  const ssize_t written = ::write(fd, value.c_str(), value.size());
+  const int write_errno = errno;
+  ::close(fd);
+  if (written == static_cast<ssize_t>(value.size())) {
+    RCLCPP_INFO(
+      this->get_logger(), "Configured IRQ %d affinity to [%s]", config.irq, value.c_str());
+    return true;
+  }
+
+  if (written == -1 && write_errno == EIO) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel does not allow user-space affinity "
+      "changes for this IRQ (e.g. IRQ 0 timer or kernel-managed MSI-X vectors). Set 'affinity' "
+      "to %s for this entry.",
+      config.irq, strerror(write_errno),
+      std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+  } else if (written == -1 && (write_errno == EACCES || write_errno == EPERM)) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to configure IRQ %d affinity: %s. %s", config.irq,
+      strerror(write_errno), k_cap_guidance);
+  } else if (written == -1) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel rejected CPU list '%s' (offline CPUs "
+      "or no valid CPU in the mask?).",
+      config.irq, strerror(write_errno), value.c_str());
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to configure IRQ %d affinity: short write to %s", config.irq,
+      path.c_str());
+  }
+  return false;
 }
 
 const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_nodes() const
@@ -556,8 +888,12 @@ void ThreadConfiguratorNode::on_reapply_config_request(
 
   std::vector<ThreadConfig> new_cb;
   std::vector<ThreadConfig> new_nrt;
+  std::vector<KernelThreadConfig> new_kernel_threads;
+  std::vector<IrqConfig> new_irqs;
   try {
     agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
+    new_kernel_threads = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+    new_irqs = agnocast_cie_thread_configurator::parse_irqs(yaml);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();
@@ -618,6 +954,11 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       std::memory_order_release);
   }
 
+  // No carry-over: kernel threads and IRQs are matched against a fresh /proc
+  // scan on every apply pass.
+  kernel_thread_configs_ = std::move(new_kernel_threads);
+  irq_configs_ = std::move(new_irqs);
+
   for (auto & cfg : callback_group_configs_) {
     if (cfg.is_wildcard()) {
       // One applied/failed key per known instance; the pattern itself is
@@ -677,18 +1018,33 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     }
   }
 
+  {
+    SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    SectionApplyOutcome irq_outcome = apply_irq_configs();
+    response->applied_kernel_threads = std::move(kernel_thread_outcome.applied);
+    response->failed_kernel_threads = std::move(kernel_thread_outcome.failed);
+    response->skipped_kernel_threads = std::move(kernel_thread_outcome.skipped);
+    response->applied_irqs = std::move(irq_outcome.applied);
+    response->failed_irqs = std::move(irq_outcome.failed);
+  }
+
   response->success = true;
   RCLCPP_INFO(
     this->get_logger(), "Reapply done: applied=%zu, failed=%zu, skipped=%zu",
-    response->applied_callback_groups.size() + response->applied_non_ros_threads.size(),
-    response->failed_callback_groups.size() + response->failed_non_ros_threads.size(),
-    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size());
+    response->applied_callback_groups.size() + response->applied_non_ros_threads.size() +
+      response->applied_kernel_threads.size() + response->applied_irqs.size(),
+    response->failed_callback_groups.size() + response->failed_non_ros_threads.size() +
+      response->failed_kernel_threads.size() + response->failed_irqs.size(),
+    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size() +
+      response->skipped_kernel_threads.size());
 
   // configured_at_least_once_ is one-shot, so the "all applied" log is not
   // re-emitted on reapply; operators need a dedicated reapply-complete signal.
   if (
     response->failed_callback_groups.empty() && response->failed_non_ros_threads.empty() &&
-    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty()) {
+    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty() &&
+    response->failed_kernel_threads.empty() && response->skipped_kernel_threads.empty() &&
+    response->failed_irqs.empty()) {
     RCLCPP_INFO(this->get_logger(), "Reapply: all entries successfully (re-)applied.");
   }
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <system_error>
 #include <utility>
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
@@ -361,7 +362,12 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
 {
   const int my_id = cgroup_num_.fetch_add(1, std::memory_order_relaxed);
   std::string cgroup_path = "/sys/fs/cgroup/cpuset/" + std::to_string(my_id);
-  if (!std::filesystem::create_directory(cgroup_path)) {
+  // Non-throwing overload: on a cgroup v2 host /sys/fs/cgroup/cpuset does not
+  // exist and mkdir fails with ENOENT; the caller's instructive message
+  // depends on a false return, not an exception.
+  std::error_code ec;
+  const bool created = std::filesystem::create_directory(cgroup_path, ec);
+  if (ec || !created) {
     return false;
   }
 
@@ -614,21 +620,14 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_co
   }
 
   // A running irqbalance would periodically rewrite smp_affinity, silently
-  // undoing whatever is applied here, so applying would only fake success.
-  // Checked immediately before the writes to keep the detection fresh.
-  if (agnocast_cie_thread_configurator::process_with_comm_exists("irqbalance")) {
-    RCLCPP_ERROR(
-      this->get_logger(),
-      "IRQ affinity configuration is requested but irqbalance is running; it would periodically "
-      "overwrite the configured affinities, so nothing is applied. Disable it (sudo systemctl "
-      "disable --now irqbalance) and call ~/reapply_config to retry.");
-    for (const auto & config : irq_configs_) {
-      if (config.is_managed()) {
-        outcome.failed.push_back(std::to_string(config.irq));
-      }
-    }
-    return outcome;
-  }
+  // undoing whatever is written here, so entries needing a write are failed
+  // instead of written. The gate sits after the per-entry compare-before-set:
+  // in-sync entries need no write and still count as applied, or every entry
+  // of an unedited template would be flagged on distros that enable
+  // irqbalance by default.
+  const bool irqbalance_detected =
+    agnocast_cie_thread_configurator::process_with_comm_exists("irqbalance");
+  bool irqbalance_reported = false;
 
   for (const auto & config : irq_configs_) {
     if (!config.is_managed()) {
@@ -658,7 +657,8 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_co
       if (!std::getline(file, current)) {
         RCLCPP_WARN(
           this->get_logger(),
-          "Could not read the current affinity of IRQ %d; attempting an unconditional write.",
+          "Could not read the current affinity of IRQ %d; treating it as out "
+          "of sync.",
           config.irq);
       }
     }
@@ -667,6 +667,19 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_co
       // Also spares kernel-managed IRQs (which reject every write with EIO)
       // from a spurious error when the recorded value is still current.
       outcome.applied.push_back(std::move(key));
+      continue;
+    }
+
+    if (irqbalance_detected) {
+      if (!irqbalance_reported) {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "IRQ affinity changes are needed but irqbalance is running; it would periodically "
+          "overwrite them, so the out-of-sync entries are failed instead of written. Disable it "
+          "(sudo systemctl disable --now irqbalance) and call ~/reapply_config to retry.");
+        irqbalance_reported = true;
+      }
+      outcome.failed.push_back(std::move(key));
       continue;
     }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
@@ -10,10 +11,13 @@
 #include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <error.h>
+#include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -22,6 +26,47 @@
 #include <utility>
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
+
+namespace
+{
+
+bool same_cpu_set(const std::vector<int> & desired, const std::optional<std::vector<int>> & current)
+{
+  if (!current) {
+    return false;
+  }
+  std::vector<int> normalized = desired;
+  std::sort(normalized.begin(), normalized.end());
+  normalized.erase(std::unique(normalized.begin(), normalized.end()), normalized.end());
+  return normalized == *current;  // parse_cpu_list output is sorted and deduplicated
+}
+
+// Compare-before-set: unedited templates (observed values as the desired
+// ones) stay no-ops, and threads the kernel refuses to modify even with
+// identical values (stop-class migration/N) are left alone. DEADLINE params
+// cannot be read back from stat, so a DEADLINE request is always applied.
+bool kernel_thread_in_sync(
+  const agnocast_cie_thread_configurator::KernelThreadConfig & config,
+  const agnocast_cie_thread_configurator::KernelThreadInfo & info)
+{
+  if (config.policy.has_value()) {
+    if (*config.policy == "SCHED_DEADLINE") {
+      return false;
+    }
+    if (*config.policy != info.policy || config.priority != info.priority) {
+      return false;
+    }
+  }
+  if (!config.affinity.empty()) {
+    if (!same_cpu_set(
+          config.affinity, agnocast_cie_thread_configurator::parse_cpu_list(info.affinity))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options),
@@ -51,6 +96,21 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   agnocast_cie_thread_configurator::parse_yaml(
     yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
+  kernel_thread_configs_ = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+  irq_configs_ = agnocast_cie_thread_configurator::parse_irqs(yaml);
+
+  // Kernel threads and IRQs never announce themselves: configure them here
+  // from a /proc scan, outside the announcement-driven accounting below.
+  {
+    const SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    const SectionApplyOutcome irq_outcome = apply_irq_configs();
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Kernel threads and IRQs configured: applied=%zu, failed=%zu, skipped=%zu",
+      kernel_thread_outcome.applied.size() + irq_outcome.applied.size(),
+      kernel_thread_outcome.failed.size() + irq_outcome.failed.size(),
+      kernel_thread_outcome.skipped.size() + irq_outcome.skipped.size());
+  }
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -379,12 +439,19 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     return false;
   }
 
-  if (config.affinity.size() > 0) {
-    if (config.policy == "SCHED_DEADLINE") {
-      if (!set_affinity_by_cgroup(thread_id, config.affinity)) {
+  return issue_affinity_syscalls(config.thread_str, config.policy, config.affinity, thread_id);
+}
+
+bool ThreadConfiguratorNode::issue_affinity_syscalls(
+  const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+  int64_t thread_id)
+{
+  if (affinity.size() > 0) {
+    if (policy == "SCHED_DEADLINE") {
+      if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id,
+          thread_str.c_str(), thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
         return false;
@@ -392,19 +459,237 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     } else {
       cpu_set_t set;
       CPU_ZERO(&set);
-      for (int cpu : config.affinity) {
+      for (int cpu : affinity) {
         CPU_SET(cpu, &set);
       }
       if (sched_setaffinity(thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
     }
   }
 
   return true;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel_thread_configs()
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    kernel_thread_configs_.begin(), kernel_thread_configs_.end(),
+    [](const KernelThreadConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  const auto scanned = agnocast_cie_thread_configurator::scan_kernel_threads();
+  for (const auto & config : kernel_thread_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    const auto matches =
+      agnocast_cie_thread_configurator::find_kernel_threads_by_comm(scanned, config.comm);
+    if (matches.empty()) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "No running kernel thread matches comm=%s; skipping. It may appear later; call "
+        "~/reapply_config to retry.",
+        config.comm.c_str());
+      outcome.skipped.push_back(config.comm);
+      continue;
+    }
+
+    for (const auto * info : matches) {
+      std::string key = config.comm + ":" + std::to_string(info->tid);
+      if (kernel_thread_in_sync(config, *info)) {
+        outcome.applied.push_back(std::move(key));
+        continue;
+      }
+      if (!config.affinity.empty() && info->no_setaffinity) {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Failed to configure affinity (thread=%s, tid=%ld): per-CPU kernel thread "
+          "(PF_NO_SETAFFINITY); the kernel fixes its affinity. Set 'affinity' to %s for this "
+          "entry.",
+          config.comm.c_str(), info->tid,
+          std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+        outcome.failed.push_back(std::move(key));
+        continue;
+      }
+
+      bool ok = false;
+      if (config.policy.has_value()) {
+        // Reuse the announcement-path syscall code (and its error wording)
+        // verbatim by shaping the entry as a ThreadConfig.
+        ThreadConfig tmp;
+        tmp.thread_str = config.comm;
+        tmp.policy = *config.policy;
+        tmp.priority = config.priority;
+        tmp.affinity = config.affinity;
+        tmp.runtime = config.runtime;
+        tmp.period = config.period;
+        tmp.deadline = config.deadline;
+        ok = issue_syscalls(tmp, info->tid);
+      } else {
+        ok = issue_affinity_syscalls(config.comm, "", config.affinity, info->tid);
+      }
+
+      if (ok) {
+        RCLCPP_INFO(
+          this->get_logger(), "Configured kernel thread (comm=%s, tid=%ld)", config.comm.c_str(),
+          info->tid);
+        outcome.applied.push_back(std::move(key));
+      } else {
+        outcome.failed.push_back(std::move(key));
+      }
+    }
+  }
+  return outcome;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_configs()
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    irq_configs_.begin(), irq_configs_.end(),
+    [](const IrqConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  // A running irqbalance would periodically rewrite smp_affinity, silently
+  // undoing whatever is applied here, so applying would only fake success.
+  if (agnocast_cie_thread_configurator::process_with_comm_exists("irqbalance")) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "IRQ affinity configuration is requested but irqbalance is running; it would periodically "
+      "overwrite the configured affinities, so nothing is applied. Disable it (sudo systemctl "
+      "disable --now irqbalance) and call ~/reapply_config to retry.");
+    for (const auto & config : irq_configs_) {
+      if (config.is_managed()) {
+        outcome.failed.push_back(std::to_string(config.irq));
+      }
+    }
+    return outcome;
+  }
+
+  for (const auto & config : irq_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    std::string key = std::to_string(config.irq);
+
+    const auto actions = agnocast_cie_thread_configurator::read_irq_actions(config.irq);
+    if (!actions) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
+        "change across boots or device changes; re-run prerun_node and update the config.",
+        config.irq, config.name.c_str());
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+    if (!config.name.empty() && *actions != config.name) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "IRQ %d identity mismatch: expected actions '%s', current '%s'. IRQ numbers can change "
+        "across boots; re-run prerun_node and update the config. Skipping.",
+        config.irq, config.name.c_str(), actions->c_str());
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+
+    std::string current;
+    {
+      std::ifstream file("/proc/irq/" + key + "/smp_affinity_list");
+      std::getline(file, current);
+    }
+    if (same_cpu_set(config.affinity, agnocast_cie_thread_configurator::parse_cpu_list(current))) {
+      // Also spares kernel-managed IRQs (which reject every write with EIO)
+      // from a spurious error when the recorded value is still current.
+      outcome.applied.push_back(std::move(key));
+      continue;
+    }
+
+    if (write_irq_affinity_file(config)) {
+      RCLCPP_INFO(
+        this->get_logger(), "Configured IRQ %d affinity to [%s]", config.irq,
+        agnocast_cie_thread_configurator::format_cpu_list(config.affinity).c_str());
+      outcome.applied.push_back(std::move(key));
+    } else {
+      outcome.failed.push_back(std::move(key));
+    }
+  }
+  return outcome;
+}
+
+bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqConfig & config)
+{
+  const std::string path = "/proc/irq/" + std::to_string(config.irq) + "/smp_affinity_list";
+  const std::string value = agnocast_cie_thread_configurator::format_cpu_list(config.affinity);
+
+  // Raw open/write instead of std::ofstream: the instructive messages below
+  // depend on which errno occurred, and EIO only appears at write(2) time.
+  const int fd = ::open(path.c_str(), O_WRONLY | O_CLOEXEC);
+  if (fd == -1) {
+    if (errno == EACCES || errno == EPERM) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d affinity: %s. Writing /proc/irq/<N>/smp_affinity_list "
+        "requires CAP_DAC_OVERRIDE in addition to CAP_SYS_NICE. Re-run "
+        "scripts/setup_thread_configurator.bash to grant 'cap_sys_nice,cap_dac_override=eip' to "
+        "thread_configurator_node.",
+        config.irq, strerror(errno));
+    } else if (errno == ENOENT) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
+        "change across boots or device changes; re-run prerun_node and update the config.",
+        config.irq, config.name.c_str());
+    } else {
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to configure IRQ %d affinity: %s", config.irq, strerror(errno));
+    }
+    return false;
+  }
+
+  const ssize_t written = ::write(fd, value.c_str(), value.size());
+  const int write_errno = errno;
+  ::close(fd);
+  if (written == static_cast<ssize_t>(value.size())) {
+    return true;
+  }
+
+  if (written == -1 && write_errno == EIO) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel does not allow user-space affinity "
+      "changes for this IRQ (e.g. IRQ 0 timer or kernel-managed MSI-X vectors). Set 'affinity' "
+      "to %s for this entry.",
+      config.irq, strerror(write_errno),
+      std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+  } else if (written == -1 && (write_errno == EACCES || write_errno == EPERM)) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. Writing /proc/irq/<N>/smp_affinity_list requires "
+      "CAP_DAC_OVERRIDE in addition to CAP_SYS_NICE. Re-run "
+      "scripts/setup_thread_configurator.bash to grant 'cap_sys_nice,cap_dac_override=eip' to "
+      "thread_configurator_node.",
+      config.irq, strerror(write_errno));
+  } else if (written == -1) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel rejected CPU list '%s' (offline CPUs "
+      "or no valid CPU in the mask?).",
+      config.irq, strerror(write_errno), value.c_str());
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to configure IRQ %d affinity: short write to %s", config.irq,
+      path.c_str());
+  }
+  return false;
 }
 
 const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_nodes() const
@@ -556,8 +841,12 @@ void ThreadConfiguratorNode::on_reapply_config_request(
 
   std::vector<ThreadConfig> new_cb;
   std::vector<ThreadConfig> new_nrt;
+  std::vector<KernelThreadConfig> new_kernel_threads;
+  std::vector<IrqConfig> new_irqs;
   try {
     agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
+    new_kernel_threads = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+    new_irqs = agnocast_cie_thread_configurator::parse_irqs(yaml);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();
@@ -618,6 +907,11 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       std::memory_order_release);
   }
 
+  // No carry-over: kernel threads and IRQs are matched against a fresh /proc
+  // scan on every apply pass.
+  kernel_thread_configs_ = std::move(new_kernel_threads);
+  irq_configs_ = std::move(new_irqs);
+
   for (auto & cfg : callback_group_configs_) {
     if (cfg.is_wildcard()) {
       // One applied/failed key per known instance; the pattern itself is
@@ -677,18 +971,33 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     }
   }
 
+  {
+    SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    SectionApplyOutcome irq_outcome = apply_irq_configs();
+    response->applied_kernel_threads = std::move(kernel_thread_outcome.applied);
+    response->failed_kernel_threads = std::move(kernel_thread_outcome.failed);
+    response->skipped_kernel_threads = std::move(kernel_thread_outcome.skipped);
+    response->applied_irqs = std::move(irq_outcome.applied);
+    response->failed_irqs = std::move(irq_outcome.failed);
+  }
+
   response->success = true;
   RCLCPP_INFO(
     this->get_logger(), "Reapply done: applied=%zu, failed=%zu, skipped=%zu",
-    response->applied_callback_groups.size() + response->applied_non_ros_threads.size(),
-    response->failed_callback_groups.size() + response->failed_non_ros_threads.size(),
-    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size());
+    response->applied_callback_groups.size() + response->applied_non_ros_threads.size() +
+      response->applied_kernel_threads.size() + response->applied_irqs.size(),
+    response->failed_callback_groups.size() + response->failed_non_ros_threads.size() +
+      response->failed_kernel_threads.size() + response->failed_irqs.size(),
+    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size() +
+      response->skipped_kernel_threads.size());
 
   // configured_at_least_once_ is one-shot, so the "all applied" log is not
   // re-emitted on reapply; operators need a dedicated reapply-complete signal.
   if (
     response->failed_callback_groups.empty() && response->failed_non_ros_threads.empty() &&
-    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty()) {
+    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty() &&
+    response->failed_kernel_threads.empty() && response->skipped_kernel_threads.empty() &&
+    response->failed_irqs.empty()) {
     RCLCPP_INFO(this->get_logger(), "Reapply: all entries successfully (re-)applied.");
   }
 }

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -1,8 +1,10 @@
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 
 #include <gtest/gtest.h>
+#include <sched.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <fstream>
@@ -387,4 +389,20 @@ TEST(ParseCpuList, RoundTripsWithFormat)
   const auto parsed = acie::parse_cpu_list(acie::format_cpu_list(cpus));
   ASSERT_TRUE(parsed.has_value());
   EXPECT_EQ(*parsed, cpus);
+}
+
+TEST(ParseManageableCpuList, DropsCpusAboveTheManageableBound)
+{
+  // "0-8191" spans every CPU number parse_cpu_list accepts, so the result
+  // must be exactly the manageable range of the machine running the test.
+  const long bound = std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF));
+  const auto trimmed = acie::parse_manageable_cpu_list("0-8191");
+  ASSERT_TRUE(trimmed.has_value());
+  EXPECT_EQ(static_cast<long>(trimmed->size()), bound);
+  EXPECT_EQ(trimmed->front(), 0);
+  EXPECT_EQ(trimmed->back(), static_cast<int>(bound) - 1);
+
+  // Nothing manageable left, and malformed input propagates as nullopt.
+  EXPECT_EQ(acie::parse_manageable_cpu_list("8191"), std::nullopt);
+  EXPECT_EQ(acie::parse_manageable_cpu_list(""), std::nullopt);
 }

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -92,6 +92,20 @@ def _write_config(cfg):
         yaml.safe_dump(cfg, f)
 
 
+def _irqbalance_running():
+    """Mirror the configurator's own detection (comm scan in its pid namespace)."""
+    for pid in os.listdir('/proc'):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(os.path.join('/proc', pid, 'comm')) as f:
+                if f.read().strip() == 'irqbalance':
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def _call_reapply(timeout_sec=10.0):
     """Call the reapply_config service synchronously and return the response."""
     rclpy.init()
@@ -377,6 +391,115 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         response = _call_reapply()
         self.assertFalse(response.success)
         self.assertIn('Unknown scheduling policy', response.error_message)
+
+    def test_template_contains_kernel_threads_and_irqs_sections(
+            self, proc_output, thread_configurator):
+        cfg = _read_config()
+        self.assertIn('kernel_threads', cfg)
+        self.assertIn('irqs', cfg)
+        # In CI pid namespaces host kthreads are invisible, so kernel_threads
+        # may legitimately be empty; entries that do exist must be fully
+        # formed, with observed values (never YAML null) as the initial ones.
+        for entry in cfg['kernel_threads'] or []:
+            for key in ('comm', 'policy', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+            # The emitter writes the policy-appropriate tunable: nice for CFS
+            # policies, priority for RT or UNMANAGEABLE policies.
+            if entry['policy'] in ('SCHED_OTHER', 'SCHED_BATCH', 'SCHED_IDLE'):
+                self.assertIn('nice', entry)
+                self.assertIsNotNone(entry['nice'])
+            else:
+                self.assertIn('priority', entry)
+                self.assertIsNotNone(entry['priority'])
+            self.assertFalse(entry['comm'].startswith('kworker/'))
+        for entry in cfg['irqs'] or []:
+            for key in ('irq', 'name', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+
+    def test_startup_logs_kernel_irq_summary(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Kernel threads and IRQs configured:',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_reports_unknown_kernel_thread_as_skipped(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        added_entry = {
+            'comm': 'fictitious_kthread',
+            # SCHED_OTHER + positive nice mirrors the CI-safe pattern above;
+            # no syscall happens anyway for a comm with no live match.
+            'policy': 'SCHED_OTHER',
+            'nice': 10,
+            'affinity': None,
+        }
+        if not cfg.get('kernel_threads'):
+            cfg['kernel_threads'] = []
+        cfg['kernel_threads'].append(added_entry)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        self.assertIn('fictitious_kthread', list(response.skipped_kernel_threads))
+        for arr in (response.applied_kernel_threads, response.failed_kernel_threads):
+            for key in list(arr):
+                self.assertFalse(key.startswith('fictitious_kthread:'))
+
+    def test_reapply_irq_outcome_depends_on_irqbalance(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        target = next(
+            (e for e in (cfg.get('irqs') or [])
+             if isinstance(e.get('affinity'), list)),
+            None,
+        )
+        if target is None:
+            self.skipTest('no IRQ with a readable affinity list in the template')
+
+        # The config is the untouched prerun output, so every desired value is
+        # still the observed one: without irqbalance the in-sync path must
+        # report the IRQ as applied WITHOUT writing (no privileges needed);
+        # with irqbalance running the validation must refuse the whole IRQ
+        # section and report it as failed instead. The configurator samples
+        # irqbalance at some point inside the call, so sample on both sides
+        # and skip when a state change makes the expected branch undecidable.
+        irqbalance_before = _irqbalance_running()
+        response = _call_reapply()
+        if _irqbalance_running() != irqbalance_before:
+            self.skipTest('irqbalance state changed during the reapply call')
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        key = str(target['irq'])
+        applied = list(response.applied_irqs)
+        failed = list(response.failed_irqs)
+        self.assertEqual(
+            applied.count(key) + failed.count(key), 1,
+            'each managed IRQ must be reported exactly once',
+        )
+        if irqbalance_before:
+            self.assertIn(key, failed)
+        else:
+            self.assertIn(key, applied)
 
 
 @launch_testing.post_shutdown_test()

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -92,18 +92,23 @@ def _write_config(cfg):
         yaml.safe_dump(cfg, f)
 
 
-def _irqbalance_running():
-    """Mirror the configurator's own detection (comm scan in its pid namespace)."""
-    for pid in os.listdir('/proc'):
-        if not pid.isdigit():
-            continue
-        try:
-            with open(os.path.join('/proc', pid, 'comm')) as f:
-                if f.read().strip() == 'irqbalance':
-                    return True
-        except OSError:
-            continue
-    return False
+def _read_irq_affinity_cpus(irq):
+    """Live /proc/irq/<N>/smp_affinity_list as a CPU set, mirroring the node's
+    parse_manageable_cpu_list (CPUs at or above the configured count dropped).
+    None when unreadable."""
+    try:
+        with open(f'/proc/irq/{irq}/smp_affinity_list') as f:
+            raw = f.read().strip()
+        cpus = set()
+        for token in raw.split(','):
+            if '-' in token:
+                first, last = token.split('-')
+                cpus.update(range(int(first), int(last) + 1))
+            else:
+                cpus.add(int(token))
+        return {c for c in cpus if c < os.cpu_count()}
+    except (OSError, ValueError):
+        return None
 
 
 def _call_reapply(timeout_sec=10.0):
@@ -457,7 +462,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             for key in list(arr):
                 self.assertFalse(key.startswith('fictitious_kthread:'))
 
-    def test_reapply_irq_outcome_depends_on_irqbalance(
+    def test_reapply_reports_in_sync_irq_as_applied(
             self, proc_output, thread_configurator):
         proc_output.assertWaitFor(
             'Received CallbackGroupInfo',
@@ -473,33 +478,36 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         )
         if target is None:
             self.skipTest('no IRQ with a readable affinity list in the template')
+        irq = target['irq']
 
-        # The config is the untouched prerun output, so every desired value is
-        # still the observed one: without irqbalance the in-sync path must
-        # report the IRQ as applied WITHOUT writing (no privileges needed);
-        # with irqbalance running the validation must refuse the whole IRQ
-        # section and report it as failed instead. The configurator samples
-        # irqbalance at some point inside the call, so sample on both sides
-        # and skip when a state change makes the expected branch undecidable.
-        irqbalance_before = _irqbalance_running()
+        # Compare-before-set precedes the irqbalance gate, so an entry whose
+        # live affinity still equals the template value must be reported as
+        # applied without any write (no privileges needed in CI, irqbalance
+        # running or not). Sample the live value on both sides of the call and
+        # skip when it moved mid-call, since the expectation is undecidable.
+        before = _read_irq_affinity_cpus(irq)
         response = _call_reapply()
-        if _irqbalance_running() != irqbalance_before:
-            self.skipTest('irqbalance state changed during the reapply call')
+        after = _read_irq_affinity_cpus(irq)
         self.assertTrue(
             response.success,
             f'reapply rejected unexpectedly: error_message={response.error_message!r}',
         )
-        key = str(target['irq'])
+        key = str(irq)
         applied = list(response.applied_irqs)
         failed = list(response.failed_irqs)
         self.assertEqual(
             applied.count(key) + failed.count(key), 1,
             'each managed IRQ must be reported exactly once',
         )
-        if irqbalance_before:
-            self.assertIn(key, failed)
-        else:
+        if before != after:
+            self.skipTest('IRQ affinity changed during the reapply call')
+        if before == set(target['affinity']):
             self.assertIn(key, applied)
+        else:
+            # A drifted entry needs a real write; whether that lands in
+            # applied or failed depends on privileges and irqbalance, both
+            # owned by the environment.
+            self.skipTest('live affinity no longer matches the template value')
 
 
 @launch_testing.post_shutdown_test()

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -92,6 +92,20 @@ def _write_config(cfg):
         yaml.safe_dump(cfg, f)
 
 
+def _irqbalance_running():
+    """Mirror the configurator's own detection (comm scan in its pid namespace)."""
+    for pid in os.listdir('/proc'):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(os.path.join('/proc', pid, 'comm')) as f:
+                if f.read().strip() == 'irqbalance':
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def _call_reapply(timeout_sec=10.0):
     """Call the reapply_config service synchronously and return the response."""
     rclpy.init()
@@ -377,6 +391,102 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         response = _call_reapply()
         self.assertFalse(response.success)
         self.assertIn('Unknown scheduling policy', response.error_message)
+
+    def test_template_contains_kernel_threads_and_irqs_sections(
+            self, proc_output, thread_configurator):
+        cfg = _read_config()
+        self.assertIn('kernel_threads', cfg)
+        self.assertIn('irqs', cfg)
+        # In CI pid namespaces host kthreads are invisible, so kernel_threads
+        # may legitimately be empty; entries that do exist must be fully
+        # formed, with observed values (never YAML null) as the initial ones.
+        for entry in cfg['kernel_threads'] or []:
+            for key in ('comm', 'policy', 'priority', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+            self.assertFalse(entry['comm'].startswith('kworker/'))
+        for entry in cfg['irqs'] or []:
+            for key in ('irq', 'name', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+
+    def test_startup_logs_kernel_irq_summary(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Kernel threads and IRQs configured:',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_reports_unknown_kernel_thread_as_skipped(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        added_entry = {
+            'comm': 'fictitious_kthread',
+            # SCHED_OTHER + positive nice mirrors the CI-safe pattern above;
+            # no syscall happens anyway for a comm with no live match.
+            'policy': 'SCHED_OTHER',
+            'priority': 10,
+            'affinity': None,
+        }
+        if not cfg.get('kernel_threads'):
+            cfg['kernel_threads'] = []
+        cfg['kernel_threads'].append(added_entry)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        self.assertIn('fictitious_kthread', list(response.skipped_kernel_threads))
+        for arr in (response.applied_kernel_threads, response.failed_kernel_threads):
+            for key in list(arr):
+                self.assertFalse(key.startswith('fictitious_kthread:'))
+
+    def test_reapply_irq_outcome_depends_on_irqbalance(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        target = next(
+            (e for e in (cfg.get('irqs') or [])
+             if isinstance(e.get('affinity'), list)),
+            None,
+        )
+        if target is None:
+            self.skipTest('no IRQ with a readable affinity list in the template')
+
+        # The config is the untouched prerun output, so every desired value is
+        # still the observed one: without irqbalance the in-sync path must
+        # report the IRQ as applied WITHOUT writing (no privileges needed);
+        # with irqbalance running the validation must refuse the whole IRQ
+        # section and report it as failed instead.
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        key = str(target['irq'])
+        applied = list(response.applied_irqs)
+        failed = list(response.failed_irqs)
+        self.assertEqual(
+            applied.count(key) + failed.count(key), 1,
+            'each managed IRQ must be reported exactly once',
+        )
+        if _irqbalance_running():
+            self.assertIn(key, failed)
+        else:
+            self.assertIn(key, applied)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Description

Part 4 of 4 splitting #1528 into reviewable units.

`thread_configurator_node` now applies the `kernel_threads` and `irqs` sections, both at startup and on every `~/reapply_config` request:

- Both sections are matched against a fresh `/proc` scan on every apply pass, with no carry-over: kernel threads and IRQs never announce themselves, so they live outside the announcement-driven accounting used for the other sections.
- Compare-before-set: an entry already in the desired state counts as applied without any syscall, so unedited template entries (part 3) stay no-ops and kernel-managed IRQs (which reject every write with EIO) see no spurious errors. Both sides of the comparison share the manageable-CPU bound (`parse_manageable_cpu_list`, moved from prerun into `system_scan`), so this holds even where the kernel's possible-CPU mask exceeds the present CPUs. One exception, documented in the srv: `SCHED_DEADLINE` parameters cannot be read back, so such entries are re-applied on every pass.
- Kernel threads: every running thread whose comm matches is configured through the existing syscall path (affinity factored out as `issue_affinity_syscalls` for affinity-only entries). An affinity request differing from a `PF_NO_SETAFFINITY` kthread's fixed one fails pointing at `UNMANAGEABLE`; an equal one is satisfied with only the policy applied. An unmatched comm is reported as skipped and can be retried via reapply.
- IRQs: the expected `actions` name is verified first to guard against IRQ renumbering across boots. If irqbalance is running, entries that need a write are failed instead of written, since irqbalance would silently rewrite them; in-sync entries still count as applied, so an unedited template stays a no-op even where irqbalance is enabled by default. The write uses raw open/write so errno-specific guidance is emitted (EIO: kernel-managed IRQ, EACCES/EPERM: missing capability, ENOENT: vanished IRQ).
- `ReapplyConfig.srv` gains `applied`/`failed`/`skipped` arrays for kernel threads and `applied`/`failed` for IRQs (an IRQ has no announce-later state, so a missing one is failed, not skipped).
- `setup_thread_configurator.bash` additionally grants `CAP_DAC_OVERRIDE`, required for writing `/proc/irq/<N>/smp_affinity_list`; an install by an older script version (only `cap_sys_nice`) is upgraded.
- E2E launch tests cover the reapply path for both sections.

## Related links

- Split from #1528
- Stacked on #1545 (merged)

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

The three main commits build up sequentially and each builds on its own: the `parse_manageable_cpu_list` refactor, the apply feature, then the capability grant. Within the feature commit, `apply_kernel_thread_configs()` and `apply_irq_configs()` are independent passes and can be reviewed function by function.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.