### PR TITLE
feat(agnocast): register domain bridge rules for services

### DIFF
--- a/scripts/test/e2e_test_domain_bridge_service.bash
+++ b/scripts/test/e2e_test_domain_bridge_service.bash
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Cross-domain zero-copy e2e for a *service*: sample server in one domain, sample clients in the
+# other, one IPC namespace, no DDS and no bridge node. One `services:` entry becomes an exact rule
+# for /AGNOCAST_SRV_REQUEST<svc> and a prefix rule for /AGNOCAST_SRV_RESPONSE<svc>%, whose
+# per-client names exist only at runtime.
+#
+# The cross-domain client and a same-named client in the server's domain run CONCURRENTLY: only
+# while both are live can a shared response topic show itself, as "bad entry id" in both logs.
+#
+# Two exchanges run in turn, plain and renamed, with different service names so neither rule
+# claims a cell of the other. Run on a freshly loaded kmod: a rule must precede its endpoints.
+
+set -uo pipefail
+
+if ! grep -q "^agnocast " /proc/modules; then
+    echo "ERROR: agnocast kernel module is not loaded." >&2
+    echo "Load it first: sudo insmod agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+if ! ros2 pkg prefix ros2agnocast_discovery_agent >/dev/null 2>&1; then
+    echo "ERROR: ros2agnocast_discovery_agent not found -- source the workspace first:" >&2
+    echo "  source /opt/ros/<distro>/setup.bash && source install/setup.bash" >&2
+    exit 1
+fi
+
+SERVICE="${E2E_SERVICE_NAME:-/srv/sum_int_array}"      # plain exchange: one name for both sides
+RENAMED_FROM=/srv/renamed_call                         # rename exchange: what the clients call
+RENAMED_TO=/srv/renamed_offer                          # ... and what the server offers
+CLIENT_DOMAIN="${E2E_CLIENT_DOMAIN:-2}"
+SERVER_DOMAIN="${E2E_SERVER_DOMAIN:-1}"
+RUN_SECONDS="${E2E_RUN_SECONDS:-10}"
+
+# minimal_client.cpp sends 1..100 and 0..99 every run. Assert the sums, not just the count, so a
+# response delivered to the wrong client cannot pass as this one's own.
+SUM1=5050
+SUM2=4950
+
+CLIENT_SECS=$((RUN_SECONDS + 3))       # one client: run + drain
+CLIENT_RUNS=3                          # cross-domain, its same-domain twin, cross-domain again
+CLIENT_PHASES=2                        # the twin shares its phase with the first cross-domain run
+SERVER_SECS=$((5 + CLIENT_PHASES * CLIENT_SECS + 3))
+
+# Both services in one config, the way an operator would write it, and registered before any node
+# starts: the kmod rejects a rule once an endpoint for its cells exists.
+cfg="$(mktemp --suffix=.yaml)"
+{
+    echo "from_domain: ${CLIENT_DOMAIN}"
+    echo "to_domain: ${SERVER_DOMAIN}"
+    echo "services:"
+    echo "  \"${SERVICE}\":"
+    echo "  \"${RENAMED_FROM}\":"
+    echo "    remap: \"${RENAMED_TO}\""
+} > "$cfg"
+
+echo ">>> registering ${SERVICE} and ${RENAMED_FROM} -> ${RENAMED_TO}" \
+     "(clients@${CLIENT_DOMAIN}, server@${SERVER_DOMAIN})"
+# Register through the same tool production uses, not an inline ioctl call.
+if ! ros2 run ros2agnocast_discovery_agent register_domain_bridge --config "$cfg"; then
+    echo "Rule registration failed (fresh kmod? a covered endpoint already exists?)." >&2
+    rm -f "$cfg"; exit 1
+fi
+rm -f "$cfg"
+
+# make_launch <exec> <node name> <service name>; echoes the generated launch file path. The
+# packaged launches hardcode one service name, and the rename path needs two.
+make_launch() {
+    local f; f="$(mktemp --suffix=.launch.xml)"
+    cat > "$f" <<XML
+<launch>
+  <node pkg="agnocast_sample_application" exec="$1" name="$2" output="screen">
+    <remap from="/sum_int_array" to="$3" />
+    <env name="LD_PRELOAD" value="libagnocast_heaphook.so:\$(env LD_PRELOAD '')" />
+  </node>
+</launch>
+XML
+    echo "$f"
+}
+
+# start_client <launch> <domain> <service> <label> <log>; leaves the pid in CLIENT_PID. Assigned
+# rather than echoed: a command substitution would background the job in an unwaitable subshell.
+start_client() {
+    local launch="$1" domain="$2" svc="$3" label="$4" log="$5"
+    echo ">>> client (${label}): calling ${svc} from domain ${domain} (~${CLIENT_SECS}s)"
+    timeout -s INT -k 5 "$CLIENT_SECS" \
+        env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$domain" \
+        ros2 launch "$launch" > "$log" 2>&1 &
+    CLIENT_PID=$!
+}
+
+# check_client <log> <label>; 0 if both responses arrived with the sums this client asked for.
+check_client() {
+    local log="$1" label="$2" ret=0
+    local got1 got2 bad_entry
+    got1=$(grep -cE "Result1: ${SUM1}\$" "$log" || true)
+    got2=$(grep -cE "Result2: ${SUM2}\$" "$log" || true)
+    bad_entry=$(grep -c "bad entry id" "$log" || true)
+    echo "  ${label}: Result1=${SUM1}x${got1} Result2=${SUM2}x${got2} bad_entry_id=${bad_entry}"
+    if [ "$got1" -lt 1 ] || [ "$got2" -lt 1 ]; then
+        echo "  FAIL (${label}): expected Result1: ${SUM1} and Result2: ${SUM2}." >&2
+        ret=1
+    fi
+    if [ "$bad_entry" -ne 0 ]; then
+        echo "  FAIL (${label}): a response could not be matched to its request." >&2
+        ret=1
+    fi
+    [ "$ret" -ne 0 ] && sed 's/^/    /' "$log" >&2
+    return "$ret"
+}
+
+# run_exchange <label> <client service> <server service>; 0 if every client got its own answers.
+run_exchange() {
+    local label="$1" client_service="$2" server_service="$3" bad=0
+    local server_launch client_launch twin_launch serverlog
+    local cross_log twin_log again_log cross_pid server_pid served1 served2
+
+    server_launch="$(make_launch server server_node "$server_service")"
+    client_launch="$(make_launch client client_node "$client_service")"
+    # The twin shares the client's node name but calls the server in its own domain. Under a
+    # rename that name is outside the bridged response prefix, so it only checks coexistence.
+    twin_launch="$(make_launch client client_node "$server_service")"
+
+    serverlog="$(mktemp)"
+    echo ">>> [${label}] server: ${server_service}@${SERVER_DOMAIN} (~${SERVER_SECS}s)"
+    timeout -s INT -k 5 "$SERVER_SECS" \
+        env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$SERVER_DOMAIN" \
+        ros2 launch "$server_launch" > "$serverlog" 2>&1 &
+    server_pid=$!
+    sleep 5
+
+    cross_log="$(mktemp)"; twin_log="$(mktemp)"; again_log="$(mktemp)"
+
+    # Same node name, one client in each bridged domain, both alive at once.
+    start_client "$client_launch" "$CLIENT_DOMAIN" "$client_service" "${label} cross-domain" \
+        "$cross_log"
+    cross_pid="$CLIENT_PID"
+    start_client "$twin_launch" "$SERVER_DOMAIN" "$server_service" "${label} same-domain twin" \
+        "$twin_log"
+    wait "$cross_pid" "$CLIENT_PID" 2>/dev/null || true
+    check_client "$cross_log" "${label} cross-domain" || bad=$((bad + 1))
+    check_client "$twin_log" "${label} same-domain twin" || bad=$((bad + 1))
+
+    start_client "$client_launch" "$CLIENT_DOMAIN" "$client_service" "${label} cross-domain again" \
+        "$again_log"
+    wait "$CLIENT_PID" 2>/dev/null || true
+    check_client "$again_log" "${label} cross-domain again" || bad=$((bad + 1))
+
+    wait "$server_pid" 2>/dev/null || true
+    sleep 1
+
+    served1=$(grep -c "Sending back response: \[${SUM1}\]" "$serverlog" || true)
+    served2=$(grep -c "Sending back response: \[${SUM2}\]" "$serverlog" || true)
+    echo "  [${label}] server: [${SUM1}]x${served1} [${SUM2}]x${served2} (expected ${CLIENT_RUNS} each)"
+    if [ "$served1" -lt "$CLIENT_RUNS" ] || [ "$served2" -lt "$CLIENT_RUNS" ]; then
+        echo "  FAIL (${label}): server served ${served1}/${served2} of the ${CLIENT_RUNS} of each kind." >&2
+        sed 's/^/    /' "$serverlog" >&2
+        bad=$((bad + 1))
+    fi
+
+    rm -f "$serverlog" "$cross_log" "$twin_log" "$again_log" \
+        "$server_launch" "$client_launch" "$twin_launch"
+
+    if [ "$bad" -ne 0 ]; then
+        echo "FAIL (${label}): ${bad} check(s) failed." >&2
+        return 1
+    fi
+    echo "PASS (${label}): ${server_service}@${SERVER_DOMAIN} served clients calling ${client_service}."
+    return 0
+}
+
+failed=0
+run_exchange plain "$SERVICE" "$SERVICE" || failed=$((failed + 1))
+run_exchange rename "$RENAMED_FROM" "$RENAMED_TO" || failed=$((failed + 1))
+
+if [ "$failed" -ne 0 ]; then
+    echo "FAIL: ${failed} of 2 exchange(s) failed." >&2
+    exit 1
+fi
+echo "PASS: the plain and the renamed service both bridged domains ${CLIENT_DOMAIN} and ${SERVER_DOMAIN}."

--- a/scripts/test/e2e_test_service_via_ros2_domain_bridge.bash
+++ b/scripts/test/e2e_test_service_via_ros2_domain_bridge.bash
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Cross-domain Agnocast service call relayed by the external ROS 2 `domain_bridge` node -- the
+# non-zero-copy path, with the kernel module bridging nothing:
+#
+#   agnocast client @CLIENT_DOMAIN
+#     -> A2R service bridge      (Agnocast service + ROS 2 client)
+#       -> domain_bridge         (ROS 2 service @CLIENT_DOMAIN <- client @SERVER_DOMAIN)
+#         -> R2A service bridge  (ROS 2 service + Agnocast client)
+#           -> agnocast server @SERVER_DOMAIN
+#
+# Both bridges rise on demand from the service name, so the YAML is the only configuration. Its
+# `from_domain` is the *server's* side -- the reverse of a `topics:` entry and of `services:`.
+#
+# One IPC namespace does not weaken the test: kmod topics are keyed by domain as well, and no
+# domain bridge rule is registered here, so DDS stays the only route. A real split needs
+# `unshare`, and privileges this script lacks.
+#
+# Needs AGNOCAST_BRIDGE_MODE on. Skipped when domain_bridge lacks generic service support.
+
+set -uo pipefail
+
+SERVICE="${E2E_SERVICE_NAME:-/srv/sum_int_array}"
+SERVICE_TYPE="${E2E_SERVICE_TYPE:-agnocast_sample_interfaces/srv/SumIntArray}"
+CLIENT_DOMAIN="${E2E_CLIENT_DOMAIN:-1}"
+SERVER_DOMAIN="${E2E_SERVER_DOMAIN:-2}"
+
+BRIDGE_SECS="${E2E_BRIDGE_SECONDS:-40}"
+SERVER_SECS="${E2E_SERVER_SECONDS:-32}"
+CLIENT_SECS="${E2E_CLIENT_SECONDS:-20}"
+
+if ! grep -q "^agnocast " /proc/modules; then
+    echo "ERROR: agnocast kernel module is not loaded." >&2
+    echo "Load it first: sudo insmod agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+if ! ros2 pkg prefix agnocast_sample_application >/dev/null 2>&1; then
+    echo "ERROR: agnocast_sample_application not found -- source the workspace first:" >&2
+    echo "  source /opt/ros/<distro>/setup.bash && source install/setup.bash" >&2
+    exit 1
+fi
+
+domain_bridge_prefix="$(ros2 pkg prefix domain_bridge 2>/dev/null)"
+if [ -z "$domain_bridge_prefix" ]; then
+    echo "SKIP: domain_bridge is not installed."
+    exit 0
+fi
+# Relaying a service from a YAML config needs generic (type-erased) service support, which a stock
+# build lacks; without this probe the run would fail on the assertions instead.
+if [ ! -f "${domain_bridge_prefix}/include/domain_bridge/generic_service.hpp" ]; then
+    echo "SKIP: domain_bridge at ${domain_bridge_prefix} was built without service support."
+    exit 0
+fi
+
+cfg="$(mktemp --suffix=.yaml)"
+bridgelog="$(mktemp)"; serverlog="$(mktemp)"; clientlog="$(mktemp)"
+cleanup() { rm -f "$cfg" "$bridgelog" "$serverlog" "$clientlog"; }
+trap cleanup EXIT
+
+{
+    echo "name: agnocast_e2e_service_bridge"
+    echo "from_domain: ${SERVER_DOMAIN}"
+    echo "to_domain: ${CLIENT_DOMAIN}"
+    echo "services:"
+    echo "  \"${SERVICE}\":"
+    echo "    type: ${SERVICE_TYPE}"
+} > "$cfg"
+
+# Started first so its ROS 2 client is already in the server's domain when the server appears:
+# that client is what a demand-gated R2A bridge waits for.
+echo ">>> domain_bridge: ${SERVICE} from domain ${SERVER_DOMAIN} to domain ${CLIENT_DOMAIN}"
+timeout -s INT -k 5 "$BRIDGE_SECS" ros2 run domain_bridge domain_bridge "$cfg" \
+    > "$bridgelog" 2>&1 &
+bridge_pid=$!
+sleep 4
+
+echo ">>> server: ${SERVICE}@${SERVER_DOMAIN}"
+timeout -s INT -k 5 "$SERVER_SECS" env ROS_DOMAIN_ID="$SERVER_DOMAIN" \
+    ros2 launch agnocast_sample_application server.launch.xml > "$serverlog" 2>&1 &
+server_pid=$!
+sleep 8
+
+# The relay service in the caller's domain is what distinguishes this route from the two Agnocast
+# ends having found each other some other way, and is what the caller-side A2R bridge keys off.
+exported=0
+for d in "$SERVER_DOMAIN" "$CLIENT_DOMAIN"; do
+    seen=$(ROS_DOMAIN_ID="$d" timeout 10 ros2 service list 2>/dev/null | grep -c "^${SERVICE}$")
+    echo "  ${SERVICE} visible in domain ${d}: ${seen}"
+    [ "$d" = "$CLIENT_DOMAIN" ] && exported="$seen"
+done
+if [ "$exported" -eq 0 ]; then
+    echo "FAIL: domain_bridge did not export ${SERVICE} into domain ${CLIENT_DOMAIN}." >&2
+    echo "--- domain_bridge:"; sed 's/^/  /' "$bridgelog" >&2
+    echo "--- server:"; sed 's/^/  /' "$serverlog" >&2
+    exit 1
+fi
+
+echo ">>> client: calling ${SERVICE} from domain ${CLIENT_DOMAIN}"
+timeout -s INT -k 5 "$CLIENT_SECS" env ROS_DOMAIN_ID="$CLIENT_DOMAIN" \
+    ros2 launch agnocast_sample_application client.launch.xml > "$clientlog" 2>&1
+sleep 1
+
+wait "$server_pid" "$bridge_pid" 2>/dev/null || true
+
+# The sample sums 1..100 and 0..99. Counting each answer apart rules out a response reaching the
+# wrong caller or being reordered by the relay; one combined count would accept a duplicate.
+got1=$(grep -c "Result1: 5050" "$clientlog" || true)
+got2=$(grep -c "Result2: 4950" "$clientlog" || true)
+served=$(grep -c "Sending back response: \[" "$serverlog" || true)
+echo "  Result1=${got1} Result2=${got2}  responses sent=${served}"
+
+if [ "$got1" -lt 1 ] || [ "$got2" -lt 1 ] || [ "$served" -lt 2 ]; then
+    echo "FAIL: the call did not complete across the domain bridge." >&2
+    echo "--- client:"; sed 's/^/  /' "$clientlog" >&2
+    echo "--- server:"; sed 's/^/  /' "$serverlog" >&2
+    echo "--- domain_bridge:"; sed 's/^/  /' "$bridgelog" >&2
+    exit 1
+fi
+
+echo "PASS: ${SERVICE}@${SERVER_DOMAIN} answered a caller in domain ${CLIENT_DOMAIN} via domain_bridge."

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -50,4 +50,42 @@ int add_agnocast_domain_bridge_rule(
   close(fd);
   return 0;
 }
+
+// Register a domain bridge for one service: the clients call service_name_from in from_domain,
+// the server offers service_name_to in to_domain. The kmod expands this into the request rule and
+// the response prefix rule and applies both atomically. Returns 0 on success, -1 on failure.
+int add_agnocast_domain_bridge_service_rule(
+  const char * service_name_from, const char * service_name_to, uint32_t from_domain,
+  uint32_t to_domain)
+{
+  if (service_name_from == nullptr || service_name_to == nullptr) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  int fd = open("/dev/agnocast", O_RDONLY);
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      fprintf(stderr, "%s", AGNOCAST_DEVICE_NOT_FOUND_MSG);
+    } else {
+      perror("Failed to open /dev/agnocast");
+    }
+    return -1;
+  }
+
+  ioctl_add_domain_bridge_service_args args = {};
+  args.service_name_from = {service_name_from, strlen(service_name_from)};
+  args.service_name_to = {service_name_to, strlen(service_name_to)};
+  args.from_domain = from_domain;
+  args.to_domain = to_domain;
+
+  if (ioctl(fd, AGNOCAST_ADD_DOMAIN_BRIDGE_SERVICE_CMD, &args) < 0) {
+    perror("AGNOCAST_ADD_DOMAIN_BRIDGE_SERVICE_CMD failed");
+    close(fd);
+    return -1;
+  }
+
+  close(fd);
+  return 0;
+}
 }

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,10 +1,13 @@
 """Parse a ROS 2 ``domain_bridge`` YAML into kmod rule tuples.
 
-Each rule is ``(from_topic, to_topic, from_domain, to_domain)``. The same YAML
-drives both the external ``domain_bridge`` node (cross-ECU, via DDS) and the kmod
-rule injection that opens same-IPC-namespace zero-copy cross-domain delivery. The
-topic name, its ``remap`` target, and the domain pair matter here; ``type`` and
-other fields are ignored.
+Each rule is ``(from_name, to_name, from_domain, to_domain)``; ``type`` and other
+fields are ignored. ``topics:`` and ``services:`` have the same shape, and a
+service's name is passed through untouched -- the kernel module derives its
+request and response topic rules.
+
+A ``services:`` block cannot be shared with the external ``domain_bridge`` node:
+that node puts the *server* in ``from_domain`` and renames the callers' side, the
+reverse of the rules here.
 """
 import yaml
 
@@ -24,58 +27,65 @@ def _as_domain_id(value):
     return domain
 
 
+def _parse_section(doc, section, default_from, default_to):
+    """Return ``(rules, skipped)`` for the ``section`` mapping of ``doc``."""
+    entries = doc.get(section)
+    if entries is None:
+        entries = {}
+    if not isinstance(entries, dict):
+        raise ValueError(f"'{section}' must be a mapping")
+
+    rules = []
+    skipped = []
+    for name, spec in entries.items():
+        if spec is None:
+            spec = {}
+        elif not isinstance(spec, dict):
+            raise ValueError(f'spec for {name!r} must be a mapping')
+        from_domain = spec.get('from_domain', default_from)
+        to_domain = spec.get('to_domain', default_to)
+        if from_domain is None or to_domain is None:
+            skipped.append(str(name))
+            continue
+        # Default to the source name (coerced like from_name below), so a non-string YAML key
+        # without a remap doesn't trip the "'remap' must be a string" check.
+        to_name = spec.get('remap', str(name))
+        if not isinstance(to_name, str):
+            raise ValueError(f"'remap' for {name!r} must be a string")
+        rules.append(
+            (str(name), to_name, _as_domain_id(from_domain), _as_domain_id(to_domain)))
+    return rules, skipped
+
+
 def parse_domain_bridge_config(text):
-    """Return ``(rules, skipped)``.
+    """Return ``(topic_rules, service_rules, skipped)``.
 
-    ``rules`` is a list of ``(from_topic, to_topic, from_domain, to_domain)``
-    tuples. ``to_topic`` is the per-topic ``remap`` target (same ``domain_bridge``
-    field the external node honors), or the source name when ``remap`` is absent.
-    ``skipped`` lists the topic names dropped for lack of a resolvable domain
-    pair, so the caller can surface them instead of dropping them silently.
-    ``from_domain`` / ``to_domain`` are taken from the top level and may be
-    overridden per topic.
+    ``to_name`` is the per-entry ``remap`` target, or the source name when absent.
+    ``skipped`` names the entries dropped for lack of a resolvable domain pair, so
+    the caller can surface them rather than drop them silently. Domains come from
+    the top level unless an entry overrides them; for a service ``from_domain`` is
+    the clients' side and ``to_domain`` the server's.
 
-    Raises ``ValueError`` / ``TypeError`` on a structurally malformed document
-    (non-mapping root, ``topics``, or topic spec), a non-string ``remap``, or an
-    out-of-range domain id. The caller catches these and skips the config rather
-    than crashing.
+    Raises ``ValueError`` / ``TypeError`` on a malformed document, a non-string
+    ``remap``, or an out-of-range domain id; the caller catches these and skips the
+    config rather than crashing.
     """
     doc = yaml.safe_load(text) or {}
     if not isinstance(doc, dict):
         raise ValueError('domain bridge config root must be a mapping')
 
-    topics = doc.get('topics')
-    if topics is None:
-        topics = {}
-    if not isinstance(topics, dict):
-        raise ValueError("'topics' must be a mapping")
-
     default_from = doc.get('from_domain')
     default_to = doc.get('to_domain')
 
-    rules = []
-    skipped = []
-    for topic_name, spec in topics.items():
-        if spec is None:
-            spec = {}
-        elif not isinstance(spec, dict):
-            raise ValueError(f'spec for topic {topic_name!r} must be a mapping')
-        from_domain = spec.get('from_domain', default_from)
-        to_domain = spec.get('to_domain', default_to)
-        if from_domain is None or to_domain is None:
-            skipped.append(str(topic_name))
-            continue
-        # Default to the source name (coerced like from_topic below), so a non-string YAML key
-        # without a remap doesn't trip the "'remap' must be a string" check.
-        to_topic = spec.get('remap', str(topic_name))
-        if not isinstance(to_topic, str):
-            raise ValueError(f"'remap' for topic {topic_name!r} must be a string")
-        rules.append(
-            (str(topic_name), to_topic, _as_domain_id(from_domain), _as_domain_id(to_domain)))
-    return rules, skipped
+    topic_rules, topic_skipped = _parse_section(doc, 'topics', default_from, default_to)
+    service_rules, service_skipped = _parse_section(doc, 'services', default_from, default_to)
+    return topic_rules, service_rules, topic_skipped + service_skipped
 
 
 def load_domain_bridge_rules(path):
-    """Read and parse the ``domain_bridge`` YAML at ``path``; return ``(rules, skipped)``."""
+    """Read and parse the ``domain_bridge`` YAML at ``path``.
+
+    Returns ``(topic_rules, service_rules, skipped)``.
+    """
     with open(path, encoding='utf-8') as f:
         return parse_domain_bridge_config(f.read())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -1,14 +1,14 @@
 """Register Agnocast domain bridge rules with the kernel module.
 
-Reads a ROS 2 ``domain_bridge`` YAML and registers each
-``(from_topic, to_topic, from_domain, to_domain)`` rule through the ioctl wrapper
-(``to_topic`` is the per-topic ``remap`` target, or the source name if absent).
+Reads a ROS 2 ``domain_bridge`` YAML and registers each entry through the ioctl
+wrapper. A ``topics:`` entry becomes one rule; a ``services:`` entry goes through
+its own ioctl, which takes the *service* name and expands it into the request and
+response rules -- the topic naming rule stays in the kmod and in agnocastlib.
 
-Run this once, before any application node for the bridged topics starts: the
-kmod rejects a rule once an endpoint exists in either domain. The tool is
-standalone and idempotent (the kmod folds duplicate rules), so it can run from
-a boot-time one-shot, a launch file, or by hand. It is independent of the
-discovery agent, which is observability-only and never registers rules.
+Run this once, before any application node for the bridged topics starts: the kmod
+rejects a rule once an endpoint exists in either domain. It is standalone and
+idempotent (the kmod folds duplicate rules), and independent of the discovery
+agent, which is observability-only and never registers rules.
 """
 import argparse
 import ctypes
@@ -20,13 +20,23 @@ import yaml
 from . import domain_bridge_config
 
 
-def _load_add_rule_symbol():
-    """Load the ioctl wrapper and return the bound add_agnocast_domain_bridge_rule."""
+def _load_symbol(name):
+    """Load the ioctl wrapper and return its bound ``name`` entry point."""
     lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
-    lib.add_agnocast_domain_bridge_rule.argtypes = [
-        ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
-    return lib.add_agnocast_domain_bridge_rule
+    fn = getattr(lib, name)
+    fn.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+    fn.restype = ctypes.c_int
+    return fn
+
+
+def _load_add_rule_symbol():
+    """Return the bound topic-rule entry point."""
+    return _load_symbol('add_agnocast_domain_bridge_rule')
+
+
+def _load_add_service_rule_symbol():
+    """Return the bound service-rule entry point."""
+    return _load_symbol('add_agnocast_domain_bridge_service_rule')
 
 
 def main(argv=None) -> int:
@@ -45,32 +55,48 @@ def main(argv=None) -> int:
             f'no config given; pass --config or set {domain_bridge_config.CONFIG_ENV}')
 
     try:
-        rules, skipped = domain_bridge_config.load_domain_bridge_rules(args.config)
+        topic_rules, service_rules, skipped = domain_bridge_config.load_domain_bridge_rules(
+            args.config)
     except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
         print(f'error: cannot load {args.config}: {e}', file=sys.stderr)
         return 1
 
-    for topic in skipped:
-        print(f'warning: skipping {topic}: no from_domain/to_domain resolved '
-              '(set them at the top level or on the topic)', file=sys.stderr)
+    for name in skipped:
+        print(f'warning: skipping {name}: no from_domain/to_domain resolved '
+              '(set them at the top level or on the entry)', file=sys.stderr)
 
     add_rule = _load_add_rule_symbol()
+    # Lazily resolved: an older wrapper has no service symbol, and a topic-only
+    # config must not need it.
+    add_service_rule = _load_add_service_rule_symbol() if service_rules else None
+
     failures = 0
-    for from_topic, to_topic, from_domain, to_domain in rules:
+    total = len(topic_rules) + len(service_rules)
+    for from_topic, to_topic, from_domain, to_domain in topic_rules:
         label = f'{from_topic}@{from_domain} -> {to_topic}@{to_domain}'
         if add_rule(
                 from_topic.encode('utf-8'), to_topic.encode('utf-8'),
                 from_domain, to_domain) == 0:
             print(f'registered: {label}')
             continue
-        # The wrapper prints the specific errno to stderr just above; the usual
-        # cause is that an endpoint already exists, since a rule must precede
-        # every node in either domain.
+        # The wrapper printed the errno just above; the usual cause is an endpoint
+        # that already exists, since a rule must precede every node in either domain.
+        failures += 1
+        print(f'error: failed to register {label}', file=sys.stderr)
+
+    for from_svc, to_svc, from_domain, to_domain in service_rules:
+        label = f'{from_svc}@{from_domain} -> {to_svc}@{to_domain} (service)'
+        # One ioctl covers both rules; the kmod applies them together or not at all.
+        if add_service_rule(
+                from_svc.encode('utf-8'), to_svc.encode('utf-8'),
+                from_domain, to_domain) == 0:
+            print(f'registered: {label}')
+            continue
         failures += 1
         print(f'error: failed to register {label}', file=sys.stderr)
 
     if failures:
-        print(f'error: {failures} of {len(rules)} rule(s) rejected', file=sys.stderr)
+        print(f'error: {failures} of {total} rule(s) rejected', file=sys.stderr)
         return 1
     return 0
 

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -29,3 +29,43 @@ satisfies the same ordering works just as well.
 The tool is idempotent (the kmod folds duplicate rules) and exits non-zero if
 any rule is rejected, so a misordering — a node started first — fails loudly
 instead of silently leaving topics unbridged.
+
+## Services
+
+A `services:` entry has the same shape as a `topics:` one, with `from_domain`
+naming the side the **clients** are on and `to_domain` the side the **server** is
+on:
+
+```yaml
+from_domain: 2   # clients
+to_domain: 1     # server
+services:
+  "/srv/sum_int_array":
+    # remap: "/srv/renamed"   # optional; the name on the server's side
+```
+
+Agnocast carries a service over a request topic plus one response topic per
+client, so one entry becomes **two** rules:
+
+| rule | name | direction |
+| --- | --- | --- |
+| request | `/AGNOCAST_SRV_REQUEST<svc>` | clients → server |
+| response | `/AGNOCAST_SRV_RESPONSE<svc>%` (a **prefix** rule) | server → clients |
+
+Each client appends its own node name and request-publisher id to the response
+topic, so those full names exist only at runtime; the prefix rule covers them all,
+whatever clients turn up later. Under a `remap` both response cells keep the
+**client-side** name, because the client dictates it and the server publishes to
+whatever the request asked for.
+
+The config names the *service*, not those two topics. The kernel module expands it
+and applies both rules under one lock, all or nothing: the response rule is only
+safe alongside its request rule, whose merged id space is what keeps two clients
+that share a node name off one response topic.
+
+### A `services:` block is not shared with the external `domain_bridge` node
+
+That node creates its ROS 2 **client** in `from_domain` and exports the relay
+**service** into `to_domain`, so there `from_domain` is the *server's* side and
+`remap` renames the name the *callers* see — the reverse of both rules above.
+Give the two a config file each.

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -16,7 +16,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [], [])
 
 
 def test_per_topic_domains_override_top_level():
@@ -30,7 +30,7 @@ topics:
     from_domain: 3
     to_domain: 4
 """
-    rules, skipped = parse_domain_bridge_config(text)
+    rules, _services, skipped = parse_domain_bridge_config(text)
     assert ('chatter', 'chatter', 1, 2) in rules
     assert ('special', 'special', 3, 4) in rules
     assert skipped == []
@@ -46,7 +46,7 @@ topics:
     type: std_msgs/msg/String
     remap: /chatter
 """
-    assert parse_domain_bridge_config(text) == ([('/in_sub/chatter', '/chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('/in_sub/chatter', '/chatter', 1, 2)], [], [])
 
 
 def test_absent_remap_reuses_the_source_name():
@@ -57,7 +57,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [], [])
 
 
 def test_non_string_topic_key_without_remap_is_coerced():
@@ -69,7 +69,7 @@ to_domain: 2
 topics:
   123:
 """
-    assert parse_domain_bridge_config(text) == ([('123', '123', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('123', '123', 1, 2)], [], [])
 
 
 def test_non_string_remap_raises():
@@ -90,14 +90,15 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    rules, skipped = parse_domain_bridge_config(text)
+    rules, _services, skipped = parse_domain_bridge_config(text)
     assert rules == []
     assert skipped == ['chatter']
 
 
 def test_empty_or_topicless_config_yields_no_rules():
-    assert parse_domain_bridge_config('') == ([], [])
-    assert parse_domain_bridge_config('topics:') == ([], [])
+    assert parse_domain_bridge_config('') == ([], [], [])
+    assert parse_domain_bridge_config('topics:') == ([], [], [])
+    assert parse_domain_bridge_config('services:') == ([], [], [])
 
 
 def test_non_integer_domain_raises():
@@ -157,6 +158,51 @@ def test_non_mapping_topic_spec_raises():
         parse_domain_bridge_config('from_domain: 1\nto_domain: 2\ntopics:\n  chatter: oops\n')
 
 
+def test_non_mapping_services_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('services:\n  - add_two_ints\n')
+
+
+def test_services_are_parsed_into_their_own_list():
+    # from_domain is the clients' side, to_domain the server's.
+    text = """
+from_domain: 2
+to_domain: 1
+topics:
+  chatter:
+services:
+  /add_two_ints:
+    type: example_interfaces/srv/AddTwoInts
+"""
+    topics, services, skipped = parse_domain_bridge_config(text)
+    assert topics == [('chatter', 'chatter', 2, 1)]
+    assert services == [('/add_two_ints', '/add_two_ints', 2, 1)]
+    assert skipped == []
+
+
+def test_service_remap_and_per_entry_domains_are_honored():
+    text = """
+from_domain: 2
+to_domain: 1
+services:
+  /add_two_ints:
+    remap: /renamed_add
+  /other:
+    from_domain: 4
+    to_domain: 3
+"""
+    _topics, services, skipped = parse_domain_bridge_config(text)
+    assert ('/add_two_ints', '/renamed_add', 2, 1) in services
+    assert ('/other', '/other', 4, 3) in services
+    assert skipped == []
+
+
+def test_service_without_resolvable_domain_pair_is_reported_as_skipped():
+    _topics, services, skipped = parse_domain_bridge_config('services:\n  /add_two_ints:\n')
+    assert services == []
+    assert skipped == ['/add_two_ints']
+
+
 def test_null_topic_spec_with_top_level_domains_is_used():
     # `chatter:` with no body is a None spec; it should fall back to the
     # top-level domains, not crash.
@@ -166,4 +212,4 @@ to_domain: 2
 topics:
   chatter:
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [], [])

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -6,15 +6,15 @@ from ros2agnocast_discovery_agent.domain_bridge_config import CONFIG_ENV
 
 
 class FakeAddRule:
-    """Stand-in for the ioctl wrapper symbol: records calls, returns a code per topic."""
+    """Stand-in for an ioctl wrapper rule symbol: records calls, returns a code per source name."""
 
     def __init__(self, codes=None):
         self.calls = []
         self._codes = codes or {}
 
-    def __call__(self, from_topic, to_topic, from_domain, to_domain):
-        from_name = from_topic.decode('utf-8')
-        to_name = to_topic.decode('utf-8')
+    def __call__(self, from_name, to_name, from_domain, to_domain):
+        from_name = from_name.decode('utf-8')
+        to_name = to_name.decode('utf-8')
         self.calls.append((from_name, to_name, from_domain, to_domain))
         return self._codes.get(from_name, 0)
 
@@ -81,3 +81,54 @@ def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
     monkeypatch.setenv(CONFIG_ENV, cfg)
     assert register_domain_bridge.main([]) == 0
     assert fake.calls == [('image', 'image', 3, 4)]
+
+
+def test_service_is_registered_through_the_service_ioctl(tmp_path, monkeypatch):
+    # The tool passes the service name straight through; it never builds /AGNOCAST_SRV_*.
+    fake = FakeAddRule()
+    fake_service = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_service_rule_symbol', lambda: fake_service)
+    cfg = _write_config(
+        tmp_path, 'from_domain: 2\nto_domain: 1\nservices:\n  /add_two_ints:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    # from_domain is the clients' domain, to_domain the server's.
+    assert fake_service.calls == [('/add_two_ints', '/add_two_ints', 2, 1)]
+    assert fake.calls == []
+
+
+def test_remapped_service_passes_both_names(tmp_path, monkeypatch):
+    # The clients call the from-name, the server offers the to-name.
+    fake = FakeAddRule()
+    fake_service = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_service_rule_symbol', lambda: fake_service)
+    cfg = _write_config(
+        tmp_path,
+        'from_domain: 2\nto_domain: 1\nservices:\n  /add_two_ints:\n    remap: /renamed_add\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    assert fake_service.calls == [('/add_two_ints', '/renamed_add', 2, 1)]
+
+
+def test_returns_nonzero_when_a_service_rule_is_rejected(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    fake_service = FakeAddRule(codes={'/add_two_ints': -16})  # -EBUSY
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_service_rule_symbol', lambda: fake_service)
+    cfg = _write_config(
+        tmp_path, 'from_domain: 2\nto_domain: 1\nservices:\n  /add_two_ints:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 1
+
+
+def test_topic_only_config_does_not_load_the_service_symbol(tmp_path, monkeypatch):
+    # An older wrapper has no service symbol at all.
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_service_rule_symbol',
+        lambda: pytest.fail('a topic-only config must not need the service symbol'))
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0


### PR DESCRIPTION
## Description

Agnocast's domain bridge relays topics between ROS domains within one IPC namespace, with no DDS and no bridge process. It covered pub/sub only. This PR extends it to services: a `services:` entry in the `domain_bridge` config, registered with the kmod at boot.

A service is not a kernel-module concept, so the config names the *service* and the kmod expands it into the two rules Agnocast needs:

| rule | topic | direction |
| --- | --- | --- |
| request | `/AGNOCAST_SRV_REQUEST<svc>` (exact) | clients → server |
| response | `/AGNOCAST_SRV_RESPONSE<svc>%` (prefix) | server → clients |

The response rule has to be a prefix: each client appends its node name and request-publisher id, so those full names exist only at runtime and cannot be listed in advance.

A `remap` renames the request topic only. The response prefix keeps the client-side name on both sides, because the client dictates that name and the server publishes to whatever the request asked for.

No kernel module change: the ioctl this calls arrives via the base branch.

## Related links

Stacked on #1569. Builds on #1533, #1535, #1539, #1542, #1547, #1555, #1557, #1564 and #1566, all merged.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`colcon test` for `ros2agnocast_discovery_agent` covers the config parsing and the registration. The kmod is not touched, so the kunit box does not apply.

Both new scripts pass:

- `e2e_test_domain_bridge_service.bash` — the plain and the renamed service in turn, three callers each with the sums matched and none unmatched.
- `e2e_test_service_via_ros2_domain_bridge.bash` — the service reaches both domains and both answers come back.

They were run against a kmod predating #1569, which is sound because nothing here depends on the separator: the config names the service and the kmod builds the topic names.

## Notes for reviewers

`e2e_test_service_via_ros2_domain_bridge.bash` covers a different path — the Agnocast service bridge (A2R / R2A) plus an external relay over DDS, for cross-IPC-namespace and cross-ECU services. That path needs no change to Agnocast. The script skips unless a `domain_bridge` with generic service support happens to be installed, and nothing here should be added to `package.xml`.

A `services:` block cannot be shared with the external `domain_bridge` node: that node puts the server in `from_domain` and renames the callers' side, the reverse of the rules here. The systemd README says so.

### Known gaps, tracked separately

- A server keeps one response publisher per caller and never drops it, so the map, the kernel-side registration and the shared memory each publisher reserves grow with every caller ever served. Pre-existing.
- `topic_local_id` is never reclaimed, so a long-lived server on a merged request topic exhausts the 4096-id space sooner.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
