### PR TITLE
fix(agnocastlib): break the cross-IPC-namespace service bridge deadlock

### DIFF
--- a/scripts/test/e2e_test_cross_ns_service.bash
+++ b/scripts/test/e2e_test_cross_ns_service.bash
@@ -1,0 +1,141 @@
+#!/bin/bash
+# E2E for an Agnocast service shared by two IPC namespaces: the service in one, the client in the
+# other. The kmod never pairs them, so the only path between the two is DDS -- an R2A bridge beside
+# the service and an A2R bridge beside the client -- and neither manager can observe the pairing
+# that makes its own half necessary. Bringing both up is the discovery agent's job.
+#
+# Only discriminating on Jazzy and newer. Pre-Jazzy rclcpp has no service-client count, so R2A is
+# ungated and its ROS 2 service alone satisfies the client side, without the agent ever being
+# involved. The test still passes there, it just proves less.
+#
+# No sudo: `unshare --user` supplies the capability `--ipc` wants. /dev/shm and the network stack
+# stay shared, since that is the DDS path the bridges are supposed to use.
+#
+# Requires the agnocast kernel module loaded and the workspace built.
+#
+# Usage:
+#   bash scripts/test/e2e_test_cross_ns_service.bash
+#
+# Exit codes: 0 pass, 1 prerequisite failure, 2 assertion failure
+
+set -uo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+DOMAIN="${E2E_DOMAIN_ID:-71}"
+CLIENT_SECS="${E2E_CLIENT_SECS:-40}"
+# Overridable so the test can run against an out-of-tree install (e.g. a second distro's build).
+INSTALL_SETUP="${AGNOCAST_INSTALL_SETUP:-$ROOT_DIR/install/setup.bash}"
+SERVER_SECS="${E2E_SERVER_SECS:-$((CLIENT_SECS + 10))}"
+
+# minimal_client.cpp sends 1..100 and 0..99. Assert the sums, not just that something came back.
+SUM1=5050
+SUM2=4950
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+if ! grep -q "^agnocast " /proc/modules; then
+    red "ERROR: agnocast kernel module is not loaded."
+    echo "  -> sudo insmod $ROOT_DIR/agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+if [ ! -f "$INSTALL_SETUP" ]; then
+    red "ERROR: workspace not built ($INSTALL_SETUP missing)."
+    echo "  -> bash $ROOT_DIR/scripts/dev/build_all.bash" >&2
+    exit 1
+fi
+
+# With CAP_SYS_ADMIN (root in a container) --ipc is enough; without it, a new user namespace
+# supplies the capability, which is what lets an ordinary user run this.
+if unshare --ipc --fork true 2>/dev/null; then
+    UNSHARE_ARGS=(--ipc --fork)
+elif unshare --user --map-root-user --ipc --fork true 2>/dev/null; then
+    UNSHARE_ARGS=(--user --map-root-user --ipc --fork)
+else
+    red "ERROR: cannot create an IPC namespace on this host."
+    echo "  -> needs CAP_SYS_ADMIN, or unprivileged user namespaces" >&2
+    exit 1
+fi
+
+set +u
+# shellcheck disable=SC1090,SC1091
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+# shellcheck disable=SC1091
+source "$INSTALL_SETUP"
+set -u
+
+LOG_DIR=$(mktemp -d)
+cleanup() {
+    pkill -P $$ 2>/dev/null
+    rm -rf "$LOG_DIR"
+}
+trap cleanup EXIT
+
+# start_in_new_ipc_ns <log> <secs> <exec>; leaves the pid in NS_PID. The first log line records the
+# namespace so the run can prove the two halves really were isolated.
+#
+# LD_PRELOAD is applied inside the namespace, never around unshare: the heaphook starts threads on
+# load, and unshare(CLONE_NEWUSER) refuses a multi-threaded caller with EINVAL.
+start_in_new_ipc_ns() {
+    local log="$1" secs="$2" exec_name="$3"
+    timeout -s INT -k 5 "$secs" \
+        unshare "${UNSHARE_ARGS[@]}" \
+        bash -c 'echo "ipc-ns $(readlink /proc/self/ns/ipc)"
+                 exec env LD_PRELOAD=libagnocast_heaphook.so \
+                     ros2 run agnocast_sample_application "$1"' _ "$exec_name" \
+        > "$log" 2>&1 &
+    NS_PID=$!
+}
+
+export ROS_DOMAIN_ID="$DOMAIN"
+
+server_log="$LOG_DIR/server.log"
+client_log="$LOG_DIR/client.log"
+
+echo ">>> server: Agnocast service in its own IPC namespace (~${SERVER_SECS}s)"
+start_in_new_ipc_ns "$server_log" "$SERVER_SECS" server
+server_pid=$NS_PID
+sleep 5
+
+echo ">>> client: Agnocast client in a second IPC namespace (~${CLIENT_SECS}s)"
+start_in_new_ipc_ns "$client_log" "$CLIENT_SECS" client
+client_pid=$NS_PID
+
+wait "$client_pid" 2>/dev/null
+kill -INT "$server_pid" 2>/dev/null
+wait "$server_pid" 2>/dev/null
+
+bad=0
+
+server_ns=$(sed -n 's/^ipc-ns //p' "$server_log" | head -1)
+client_ns=$(sed -n 's/^ipc-ns //p' "$client_log" | head -1)
+echo "  namespaces: server=${server_ns:-?} client=${client_ns:-?}"
+if [ -z "$server_ns" ] || [ "$server_ns" = "$client_ns" ]; then
+    red "  FAIL: the two halves did not land in distinct IPC namespaces."
+    bad=$((bad + 1))
+fi
+
+got1=$(grep -cE "Result1: ${SUM1}\$" "$client_log")
+got2=$(grep -cE "Result2: ${SUM2}\$" "$client_log")
+echo "  client: Result1=${SUM1}x${got1} Result2=${SUM2}x${got2}"
+if [ "$got1" -lt 1 ] || [ "$got2" -lt 1 ]; then
+    red "  FAIL: the client never got an answer across the namespace boundary."
+    bad=$((bad + 1))
+fi
+
+served1=$(grep -c "Sending back response: \[${SUM1}\]" "$server_log")
+served2=$(grep -c "Sending back response: \[${SUM2}\]" "$server_log")
+echo "  server: [${SUM1}]x${served1} [${SUM2}]x${served2} (expected 1 each)"
+if [ "$served1" -ne 1 ] || [ "$served2" -ne 1 ]; then
+    red "  FAIL: the server served ${served1}/${served2} requests, expected 1 of each."
+    bad=$((bad + 1))
+fi
+
+if [ "$bad" -ne 0 ]; then
+    echo "----- server -----" >&2; sed 's/^/    /' "$server_log" >&2
+    echo "----- client -----" >&2; sed 's/^/    /' "$client_log" >&2
+    exit 2
+fi
+
+green "PASS: the service in ${server_ns} answered the client in ${client_ns}."

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_manager.hpp
@@ -91,6 +91,7 @@ private:
   std::string on_socket_request() const;
 
   void register_daemon_pubsub_request(const BridgeMsgDaemonPubSubPayload & req);
+  void register_daemon_service_request(const BridgeMsgDaemonServicePayload & req);
   bool is_daemon_forced(const std::string & topic_name, BridgeDirection direction) const;
   void create_daemon_forced_bridges();
   void activate_daemon_forced_bridge(

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
@@ -18,6 +18,7 @@ enum class BridgeMsgType : uint32_t {
   PubSub = 0,
   Service = 1,
   DaemonPubSub = 2,
+  DaemonService = 3,
 };
 
 struct BridgeMsgPubSubPayload
@@ -48,6 +49,15 @@ struct BridgeMsgDaemonPubSubPayload
   bool qos_is_reliable;
 };
 
+// A cross-IPC-namespace R2A service bridge lease from the per-NS discovery agent. It carries no
+// type because an Agnocast service registers none: its request topic carries
+// ServiceRequestWrapper<T>, which has no rosidl message name. Type and shadow node identity come
+// from the local Agnocast endpoint's own BridgeMsgServicePayload.
+struct BridgeMsgDaemonServicePayload
+{
+  char service_name[SERVICE_NAME_BUFFER_SIZE];
+};
+
 struct BridgeMsg
 {
   BridgeMsgType type;
@@ -55,6 +65,7 @@ struct BridgeMsg
     BridgeMsgPubSubPayload pubsub;
     BridgeMsgServicePayload service;
     BridgeMsgDaemonPubSubPayload daemon_pubsub;
+    BridgeMsgDaemonServicePayload daemon_service;
   } payload;
 };
 

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
@@ -150,7 +150,7 @@ public:
   void check_and_update(const ServiceBridgeDeps & deps);
 
   void handle_request(const BridgeMsgServicePayload & payload);
-  void handle_daemon_request(const BridgeMsgDaemonServicePayload & payload);
+  void handle_daemon_request();
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
@@ -6,6 +6,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -41,20 +42,22 @@ struct ServiceBridgeDeps
 //           │          └──▲───────▲──┘          │
 //           │             │       │             │
 //       (3) │         (4) │       │ (6)         │ (5)
-//     ROS 2 │       ROS 2 │       │ Agnocast    │ Agnocast service
-//   service │     service │       │ service or  │ and external
-//  detected │        gone │       │ last client │ ROS 2 client
-//           │             │       │ gone        │ both exist
+//  Agnocast │       ROS 2 │       │ Agnocast    │ Agnocast service
+//    client │  service or │       │ service or  │ and external
+// and ROS 2 │ last client │       │ last client │ ROS 2 client
+//   service │        gone │       │ gone        │ both exist
 //       ┌───▼───┐         │       │         ┌───▼───┐
 //       │  A2R  ├─────────┘       └─────────┤  R2A  │
 //       └───────┘                           └───────┘
 //
 // (1) an Agnocast service or client registered
-// (2) !agno_client_exists(), (3) false, and !(may_start_r2a_bridge_ && agno_service_exists())
-// (3) may_start_a2r_bridge_ && ros2_service_exists()
-// (4) !ros2_service_exists() || (may_start_r2a_bridge_ && agno_service_exists())
-// (5) may_start_r2a_bridge_ && agno_service_exists() && ros2_client_exists()
-// (6) !agno_service_exists() || !ros2_client_exists()
+// (2) !agno_client_exists(), no daemon-forced R2A, (3) false, and !(may_start_r2a_bridge_ &&
+//     agno_service_exists())
+// (3) may_start_a2r_bridge_ && ros2_service_exists() && agno_client_exists()
+// (4) !(ros2_service_exists() && agno_client_exists()) || (may_start_r2a_bridge_ &&
+//     agno_service_exists())
+// (5) may_start_r2a_bridge_ && agno_service_exists() && (ros2_client_exists() || daemon-forced R2A)
+// (6) !agno_service_exists() || !(ros2_client_exists() || daemon-forced R2A)
 //
 // Direction lives in flags, not in the state. handle_request() latches may_start_r2a_bridge_ (an
 // Agnocast service registered) and may_start_a2r_bridge_ (an Agnocast client registered), and
@@ -82,6 +85,16 @@ struct ServiceBridgeDeps
 // still running. may_start_r2a_bridge_ is set only by a ServiceRole::Default service, so a
 // BridgeInternal one never guards anything; and agno_service_exists() reads at most one entry, so
 // it reports false when two or more Agnocast services share the name.
+//
+// The daemon-forced lease in (2), (5) and (6) exists because two IPC namespaces sharing one
+// service deadlock without it: the service side's (5) wants a ROS 2 client that only the client
+// side's A2R creates, and the client side's (3) wants a ROS 2 service that only the service side's
+// R2A creates. Only the discovery agent sees both namespaces, so it grants the lease.
+//
+// The lease covers R2A only, and that is enough to break the cycle: once (5) runs here, the ROS 2
+// service it publishes is the one term (3) was missing over on the client side. Leasing A2R too
+// would let it run before that service exists, and a request arriving in that window could be
+// neither forwarded nor refused -- an Agnocast client cannot observe a dropped request.
 enum class ServiceBridgeState { NONE, PENDING, A2R, R2A };
 
 class ServiceBridgeItem
@@ -94,6 +107,8 @@ class ServiceBridgeItem
   // Held, never read: an agnocast::Node creates no rcl_node_t of its own, so this stands in for one
   // under its name, in this process. Lifetime is decided in check_and_update_pending().
   std::shared_ptr<rcl_node_t> shadow_node_ = nullptr;
+
+  std::optional<std::chrono::steady_clock::time_point> r2a_forced_until_ = std::nullopt;
 
   // Configuration members; set once and never modified.
   std::string service_name_;
@@ -115,6 +130,8 @@ class ServiceBridgeItem
 
   bool ros2_service_exists(const ServiceBridgeDeps & deps);
   bool ros2_client_exists(const ServiceBridgeDeps & deps);
+
+  bool r2a_forced() const;
   bool agno_service_exists();
   bool agno_client_exists();
 
@@ -134,6 +151,7 @@ public:
   void check_and_update(const ServiceBridgeDeps & deps);
 
   void handle_request(const BridgeMsgServicePayload & payload);
+  void handle_daemon_request(const BridgeMsgDaemonServicePayload & payload);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
@@ -51,8 +51,7 @@ struct ServiceBridgeDeps
 //       └───────┘                           └───────┘
 //
 // (1) an Agnocast service or client registered
-// (2) !agno_client_exists(), no daemon-forced R2A, (3) false, and !(may_start_r2a_bridge_ &&
-//     agno_service_exists())
+// (2) !agno_client_exists(), (3) false, and !(may_start_r2a_bridge_ && agno_service_exists())
 // (3) may_start_a2r_bridge_ && ros2_service_exists() && agno_client_exists()
 // (4) !(ros2_service_exists() && agno_client_exists()) || (may_start_r2a_bridge_ &&
 //     agno_service_exists())
@@ -86,10 +85,10 @@ struct ServiceBridgeDeps
 // BridgeInternal one never guards anything; and agno_service_exists() reads at most one entry, so
 // it reports false when two or more Agnocast services share the name.
 //
-// The daemon-forced lease in (2), (5) and (6) exists because two IPC namespaces sharing one
-// service deadlock without it: the service side's (5) wants a ROS 2 client that only the client
-// side's A2R creates, and the client side's (3) wants a ROS 2 service that only the service side's
-// R2A creates. Only the discovery agent sees both namespaces, so it grants the lease.
+// The daemon-forced lease in (5) and (6) exists because two IPC namespaces sharing one service
+// deadlock without it: the service side's (5) wants a ROS 2 client that only the client side's A2R
+// creates, and the client side's (3) wants a ROS 2 service that only the service side's R2A
+// creates. Only the discovery agent sees both namespaces, so it grants the lease.
 //
 // The lease covers R2A only, and that is enough to break the cycle: once (5) runs here, the ROS 2
 // service it publishes is the one term (3) was missing over on the client side. Leasing A2R too

--- a/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
@@ -305,7 +305,7 @@ void BridgeManager::register_daemon_service_request(const BridgeMsgDaemonService
   if (it == active_service_bridges_.end()) {
     return;
   }
-  it->second.handle_daemon_request(req);
+  it->second.handle_daemon_request();
 }
 
 bool BridgeManager::is_daemon_forced(

--- a/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
@@ -206,6 +206,11 @@ void BridgeManager::parse_and_enqueue(const void * data, std::size_t size)
         return;
       }
       break;
+    case BridgeMsgType::DaemonService:
+      if (!validate_variant_size(bridge_msg_wire_size<BridgeMsgDaemonServicePayload>())) {
+        return;
+      }
+      break;
     default:
       RCLCPP_WARN(
         logger_, "Received bridge message with unknown type: %u", static_cast<uint32_t>(msg.type));
@@ -264,6 +269,10 @@ void BridgeManager::dispatch_bridge_message(const BridgeMsg & msg)
       register_daemon_pubsub_request(msg.payload.daemon_pubsub);
       break;
     }
+    case BridgeMsgType::DaemonService: {
+      register_daemon_service_request(msg.payload.daemon_service);
+      break;
+    }
     default: {
       // parse_and_enqueue() must reject every unknown type before enqueuing,
       // so reaching here means the two switches drifted out of sync.
@@ -286,6 +295,17 @@ void BridgeManager::register_daemon_pubsub_request(const BridgeMsgDaemonPubSubPa
     (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? daemon_forced_r2a_ : daemon_forced_a2r_;
   forced.insert_or_assign(
     topic_name, DaemonForcedRequest{message_type, daemon_request_qos(req), forced_until});
+}
+
+void BridgeManager::register_daemon_service_request(const BridgeMsgDaemonServicePayload & req)
+{
+  const std::string service_name = static_cast<const char *>(req.service_name);
+
+  auto it = active_service_bridges_.find(service_name);
+  if (it == active_service_bridges_.end()) {
+    it = active_service_bridges_.emplace(service_name, ServiceBridgeItem{}).first;
+  }
+  it->second.handle_daemon_request(req);
 }
 
 bool BridgeManager::is_daemon_forced(

--- a/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
@@ -303,7 +303,7 @@ void BridgeManager::register_daemon_service_request(const BridgeMsgDaemonService
 
   auto it = active_service_bridges_.find(service_name);
   if (it == active_service_bridges_.end()) {
-    it = active_service_bridges_.emplace(service_name, ServiceBridgeItem{}).first;
+    return;
   }
   it->second.handle_daemon_request(req);
 }

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -517,7 +517,7 @@ void ServiceBridgeItem::handle_request(const BridgeMsgServicePayload & payload)
   }
 }
 
-void ServiceBridgeItem::handle_daemon_request(const BridgeMsgDaemonServicePayload &)
+void ServiceBridgeItem::handle_daemon_request()
 {
   r2a_forced_until_ = daemon_force_deadline(std::chrono::steady_clock::now());
 }

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -230,6 +230,12 @@ bool ServiceBridgeItem::ros2_client_exists(const ServiceBridgeDeps & deps)
   }
 }
 
+bool ServiceBridgeItem::r2a_forced() const
+{
+  return r2a_forced_until_.has_value() &&
+         is_daemon_force_active(*r2a_forced_until_, std::chrono::steady_clock::now());
+}
+
 // Returns false if the target Agnocast service does not exist or if an error occurs while checking
 // it (the reason will be set in the error string). "Two or more services share this name" is one
 // such error: the probe below reads at most one entry, so a name collision reads as absence rather
@@ -382,7 +388,7 @@ void ServiceBridgeItem::update_configuration(const BridgeMsgServicePayload & pay
 // Stays in R2A, or takes arrow (6) back to PENDING.
 void ServiceBridgeItem::check_and_update_r2a(const ServiceBridgeDeps & deps)
 {
-  if (agno_service_exists() && ros2_client_exists(deps)) {
+  if (agno_service_exists() && (ros2_client_exists(deps) || r2a_forced())) {
     return;
   }
 
@@ -412,7 +418,7 @@ void ServiceBridgeItem::check_and_update_a2r(const ServiceBridgeDeps & deps)
 {
   if (may_start_r2a_bridge_ && agno_service_exists()) {
     set_error_string("An Agnocast service now owns this name");
-  } else if (ros2_service_exists(deps)) {
+  } else if (ros2_service_exists(deps) && agno_client_exists()) {
     return;
   }
 
@@ -450,7 +456,7 @@ void ServiceBridgeItem::check_and_update_pending(const ServiceBridgeDeps & deps)
     }
 
     // Arrow (5).
-    if (ros2_client_exists(deps) && start_r2a_bridge(deps) != 0) {
+    if ((ros2_client_exists(deps) || r2a_forced()) && start_r2a_bridge(deps) != 0) {
       RCLCPP_WARN(
         deps.logger, "Failed to start R2A service bridge for '%s': %s", service_name_.c_str(),
         get_error_string());
@@ -462,7 +468,7 @@ void ServiceBridgeItem::check_and_update_pending(const ServiceBridgeDeps & deps)
   release_shadow_node();
 
   // Arrow (3).
-  if (may_start_a2r_bridge_ && ros2_service_exists(deps)) {
+  if (may_start_a2r_bridge_ && ros2_service_exists(deps) && agno_client_exists()) {
     if (start_a2r_bridge(deps) != 0) {
       RCLCPP_WARN(
         deps.logger, "Failed to start A2R service bridge for '%s': %s", service_name_.c_str(),
@@ -471,8 +477,9 @@ void ServiceBridgeItem::check_and_update_pending(const ServiceBridgeDeps & deps)
     return;
   }
 
-  // Arrow (2).
-  if (!agno_client_exists()) {
+  // Arrow (2). A forced item survives with no local Agnocast client: the daemon vouches for a
+  // remote one.
+  if (!agno_client_exists() && !r2a_forced()) {
     RCLCPP_DEBUG(
       deps.logger, "Removing service bridge state-machine for '%s': %s", service_name_.c_str(),
       get_error_string());
@@ -505,6 +512,22 @@ void ServiceBridgeItem::check_and_update(const ServiceBridgeDeps & deps)
 void ServiceBridgeItem::handle_request(const BridgeMsgServicePayload & payload)
 {
   update_configuration(payload);
+
+  if (state_ == ServiceBridgeState::NONE) {
+    state_ = ServiceBridgeState::PENDING;
+  }
+}
+
+void ServiceBridgeItem::handle_daemon_request(const BridgeMsgDaemonServicePayload & payload)
+{
+  if (service_name_.empty()) {
+    service_name_ = static_cast<const char *>(payload.service_name);
+  }
+
+  // Latch the permission the local Agnocast service's own request would have set: only the daemon
+  // can see the remote Agnocast client that makes R2A legitimate.
+  may_start_r2a_bridge_ = true;
+  r2a_forced_until_ = daemon_force_deadline(std::chrono::steady_clock::now());
 
   if (state_ == ServiceBridgeState::NONE) {
     state_ = ServiceBridgeState::PENDING;

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -477,9 +477,8 @@ void ServiceBridgeItem::check_and_update_pending(const ServiceBridgeDeps & deps)
     return;
   }
 
-  // Arrow (2). A forced item survives with no local Agnocast client: the daemon vouches for a
-  // remote one.
-  if (!agno_client_exists() && !r2a_forced()) {
+  // Arrow (2).
+  if (!agno_client_exists()) {
     RCLCPP_DEBUG(
       deps.logger, "Removing service bridge state-machine for '%s': %s", service_name_.c_str(),
       get_error_string());
@@ -518,20 +517,9 @@ void ServiceBridgeItem::handle_request(const BridgeMsgServicePayload & payload)
   }
 }
 
-void ServiceBridgeItem::handle_daemon_request(const BridgeMsgDaemonServicePayload & payload)
+void ServiceBridgeItem::handle_daemon_request(const BridgeMsgDaemonServicePayload &)
 {
-  if (service_name_.empty()) {
-    service_name_ = static_cast<const char *>(payload.service_name);
-  }
-
-  // Latch the permission the local Agnocast service's own request would have set: only the daemon
-  // can see the remote Agnocast client that makes R2A legitimate.
-  may_start_r2a_bridge_ = true;
   r2a_forced_until_ = daemon_force_deadline(std::chrono::steady_clock::now());
-
-  if (state_ == ServiceBridgeState::NONE) {
-    state_ = ServiceBridgeState::PENDING;
-  }
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
@@ -54,11 +54,22 @@ TEST(DaemonBridgeUdsTest, DaemonPayloadWireLayout)
   EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_reliable), 521u);
 }
 
+// Same contract for the service variant, whose layout the daemon mirrors as
+// `_SERVICE_MSG_PACK_FORMAT`.
+TEST(DaemonBridgeUdsTest, DaemonServicePayloadWireLayout)
+{
+  using agnocast::BridgeMsgDaemonServicePayload;
+  EXPECT_EQ(sizeof(BridgeMsgDaemonServicePayload), 256u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonServicePayload, service_name), 0u);
+  EXPECT_EQ(agnocast::bridge_msg_wire_size<BridgeMsgDaemonServicePayload>(), 260u);
+}
+
 TEST(DaemonBridgeUdsTest, BridgeMsgTypeNumeric)
 {
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::PubSub), 0u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::Service), 1u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::DaemonPubSub), 2u);
+  EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::DaemonService), 3u);
 }
 
 TEST(DaemonBridgeUdsTest, BridgeMsgWireLayout)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -486,6 +486,11 @@ class DiscoveryAgent(Node):
             bridge_decider.dispatch_requests(
                 requests, self._ipc_ns_inode, logger=self.get_logger())
 
+        service_requests = bridge_decider.decide_service_bridges(local_state, remote_states)
+        if service_requests:
+            bridge_decider.dispatch_service_requests(
+                service_requests, self._ipc_ns_inode, logger=self.get_logger())
+
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()
         msg.schema_version = SCHEMA_VERSION

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -8,6 +8,9 @@ so the two reach each other through ROS 2 (DDS):
   * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
   * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
 
+Agnocast services ride on an internal request topic, so the same comparison decides them; see
+``decide_service_bridges``, which emits type=DaemonService instead.
+
 The domain bridge rule config is a second, gossip-independent source of requests.
 
 The request is sent as a ``BridgeMsg`` (type=DaemonPubSub) to the per-namespace
@@ -27,9 +30,15 @@ from typing import Iterable, Optional
 
 TOPIC_NAME_BUFFER_SIZE = 256
 MESSAGE_TYPE_BUFFER_SIZE = 256
+SERVICE_NAME_BUFFER_SIZE = 256
 
-# BridgeMsgType::DaemonPubSub discriminator value (matches the C++ enum).
+# BridgeMsgType discriminator values (match the C++ enum).
 _BRIDGE_MSG_TYPE_DAEMON_PUBSUB = 2
+_BRIDGE_MSG_TYPE_DAEMON_SERVICE = 3
+
+# Only the request topic identifies a service; response topics are per-client.
+SRV_REQUEST_PREFIX = '/AGNOCAST_SRV_REQUEST'
+SRV_RESPONSE_PREFIX = '/AGNOCAST_SRV_RESPONSE'
 
 # BridgeMsg wire format for a DaemonPubSub-variant message (528 bytes total).
 # The C++ BridgeMsg is `uint32_t type` + union { pubsub | service | daemon_pubsub }.
@@ -50,10 +59,26 @@ _BRIDGE_MSG_TYPE_DAEMON_PUBSUB = 2
 # Must stay in sync with bridge_msg_wire_size<BridgeMsgDaemonPubSubPayload>() == 528.
 _MSG_PACK_FORMAT = '=I256s256sIIBB2x'
 
+# BridgeMsg wire format for a DaemonService-variant message (260 bytes total). It always means
+# "lease R2A for this service".
+#
+#   uint32 type                             [0..3]   = _BRIDGE_MSG_TYPE_DAEMON_SERVICE
+#   BridgeMsgDaemonServicePayload at union offset 4..259:
+#     char[256] service_name                [4..259]
+#
+# Must stay in sync with bridge_msg_wire_size<BridgeMsgDaemonServicePayload>() == 260.
+_SERVICE_MSG_PACK_FORMAT = '=I256s'
+
 DIRECTION_ROS2_TO_AGNOCAST = 0
 DIRECTION_AGNOCAST_TO_ROS2 = 1
 
 _BRIDGE_UDS_BASE = 'agnocast_bridge_manager'
+
+
+@dataclass(frozen=True)
+class ServiceBridgeRequest:
+    service_name: str
+    domain_id: int = 0
 
 
 @dataclass(frozen=True)
@@ -82,6 +107,20 @@ def serialize_request(req: BridgeRequest) -> bytes:
         1 if req.qos_is_transient_local else 0,
         1 if req.qos_is_reliable else 0,
     )
+
+
+def serialize_service_request(req: ServiceBridgeRequest) -> bytes:
+    name = req.service_name.encode('utf-8')[: SERVICE_NAME_BUFFER_SIZE - 1]
+    return struct.pack(_SERVICE_MSG_PACK_FORMAT, _BRIDGE_MSG_TYPE_DAEMON_SERVICE, name)
+
+
+def _service_name_of(topic_name: str) -> Optional[str]:
+    """Return the service a request topic belongs to, or None if it is not one."""
+    if not topic_name.startswith(SRV_REQUEST_PREFIX):
+        return None
+    service_name = topic_name[len(SRV_REQUEST_PREFIX):]
+    # A bare prefix names no service; anything else must be an absolute service name.
+    return service_name if service_name.startswith('/') else None
 
 
 def _resolve_types(local_state, remote_states) -> dict:
@@ -117,6 +156,11 @@ def decide_bridges(local_state, remote_states) -> list:
         if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
             continue
         for remote_topic in remote.topics:
+            # Handled by decide_service_bridges(), not as plain pub/sub.
+            if remote_topic.topic_name.startswith(
+                    (SRV_REQUEST_PREFIX, SRV_RESPONSE_PREFIX)):
+                continue
+
             local_topic = local_by_topic.get((remote_topic.topic_name, remote_topic.domain_id))
             if local_topic is None:
                 continue
@@ -156,6 +200,48 @@ def decide_bridges(local_state, remote_states) -> list:
                     qos_is_reliable=sub.qos_is_reliable,
                     domain_id=domain_id,
                 ))
+
+    return list(requests.values())
+
+
+def decide_service_bridges(local_state, remote_states) -> list:
+    """Return the service bridge requests this namespace should issue this tick.
+
+    Roles come from the request topic, which every Agnocast service subscribes to and every
+    Agnocast client publishes on: a local subscriber means the service lives here, and only that
+    side is leased. The client side's A2R comes up on the ordinary demand rule once the leased R2A
+    publishes the ROS 2 service it was waiting for, and must not be forced ahead of it --
+    ``agnocast_service_bridge.hpp`` has the argument.
+
+    Requests are collapsed to one per ``(service, domain)``, and matched within a domain only, as
+    for pub/sub.
+    """
+    requests = {}
+
+    local_by_topic = {(t.topic_name, t.domain_id): t for t in local_state.topics}
+
+    for (host_uuid, ipc_ns_inode), remote in remote_states.items():
+        if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
+            continue
+        for remote_topic in remote.topics:
+            service_name = _service_name_of(remote_topic.topic_name)
+            if service_name is None:
+                continue
+
+            local_topic = local_by_topic.get((remote_topic.topic_name, remote_topic.domain_id))
+            if local_topic is None:
+                continue
+
+            domain_id = local_topic.domain_id
+
+            # Counting a bridge's own endpoints would keep every lease alive off its own bridge.
+            local_subs = [s for s in local_topic.subscribers if not s.is_bridge]
+            remote_pubs = [p for p in remote_topic.publishers if not p.is_bridge]
+
+            if local_subs and remote_pubs:
+                key = (service_name, domain_id)
+                requests.setdefault(
+                    key, ServiceBridgeRequest(service_name=service_name, domain_id=domain_id))
 
     return list(requests.values())
 
@@ -303,6 +389,20 @@ def send_request(uds_addr: str, payload: bytes) -> Optional[str]:
     finally:
         sock.close()
     return None
+
+
+def dispatch_service_requests(
+        requests: Iterable[ServiceBridgeRequest], ipc_ns_inode: int, logger=None) -> None:
+    """Deliver each service request to the per-namespace bridge_manager UDS.
+
+    Same delivery contract as ``dispatch_requests``: best-effort, re-issued idempotently every
+    tick, and a missing peer never stalls the daemon.
+    """
+    for req in requests:
+        err = send_request(
+            _bridge_uds_addr(ipc_ns_inode, req.domain_id), serialize_service_request(req))
+        if err is not None and logger is not None:
+            logger.warn(f'daemon service bridge dispatch failed: {err}')
 
 
 def dispatch_requests(

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -9,15 +9,25 @@ bytes) in ``agnocast_bridge_msg.hpp``.
 import struct
 from unittest.mock import MagicMock
 
+import pytest
+
+from rclpy.impl.rcutils_logger import RcutilsLogger
+
 from ros2agnocast_discovery_agent.bridge_decider import (
     BridgeRequest,
-    UNFORCED_WARN_AFTER_TICKS,
     decide_bridges,
     decide_domain_rule_bridges,
+    decide_service_bridges,
     DIRECTION_AGNOCAST_TO_ROS2,
     DIRECTION_ROS2_TO_AGNOCAST,
     dispatch_requests,
+    dispatch_service_requests,
     serialize_request,
+    serialize_service_request,
+    ServiceBridgeRequest,
+    SRV_REQUEST_PREFIX,
+    SRV_RESPONSE_PREFIX,
+    UNFORCED_WARN_AFTER_TICKS,
 )
 from ros2agnocast_discovery_msgs.msg import (
     AgnocastDaemonState,
@@ -450,3 +460,107 @@ def test_dispatch_routes_to_per_domain_uds(monkeypatch):
         '\x00agnocast_bridge_manager_12345',
         '\x00agnocast_bridge_manager_12345_d5',
     ]
+
+
+# --- cross-namespace service bridging -------------------------------------------------
+#
+# An Agnocast service subscribes to the request topic and an Agnocast client publishes on it, so
+# the roles below are the mirror image of the pub/sub ones: a local *subscriber* means the service
+# lives here and needs R2A.
+
+
+def _srv_topic(service_name, pubs=None, subs=None, domain=0):
+    # A service's internal topics carry no type name.
+    return _topic(SRV_REQUEST_PREFIX + service_name, type_name='',
+                  pubs=pubs, subs=subs, domain=domain)
+
+
+def test_service_decide_emits_r2a_when_local_service_remote_client():
+    local = _state(topics=[_srv_topic('/add', subs=[_endpoint('/svc')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_srv_topic('/add', pubs=[_endpoint('/cli')])])
+
+    reqs = decide_service_bridges(local, {('OTHER', 222): remote})
+
+    assert len(reqs) == 1
+    assert reqs[0].service_name == '/add'
+
+
+def test_service_decide_leaves_the_client_side_alone():
+    """The client side needs no lease: the peer's R2A publishes the service (3) waits for."""
+    local = _state(topics=[_srv_topic('/add', pubs=[_endpoint('/cli')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_srv_topic('/add', subs=[_endpoint('/svc')])])
+
+    assert decide_service_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_service_decide_skips_self_namespace():
+    local = _state(topics=[_srv_topic('/add', subs=[_endpoint('/svc')])])
+    same = _state(topics=[_srv_topic('/add', pubs=[_endpoint('/cli')])])
+
+    assert decide_service_bridges(local, {('HOST', 111): same}) == []
+
+
+def test_service_decide_skips_bridge_endpoints():
+    """A bridge-created endpoint must not keep its own lease alive."""
+    local = _state(topics=[_srv_topic('/add', subs=[_endpoint('/svc')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_srv_topic('/add', pubs=[_endpoint('/br', is_bridge=True)])])
+
+    assert decide_service_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_service_decide_skips_cross_domain_match():
+    local = _state(topics=[_srv_topic('/add', subs=[_endpoint('/svc')], domain=0)])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_srv_topic('/add', pubs=[_endpoint('/cli')], domain=5)])
+
+    assert decide_service_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_service_decide_emits_one_lease_when_both_roles_local():
+    """Holding a client of the name too changes nothing: the service side still drives it."""
+    local = _state(topics=[_srv_topic('/add', pubs=[_endpoint('/cli')],
+                                      subs=[_endpoint('/svc')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_srv_topic('/add', pubs=[_endpoint('/rcli')],
+                                       subs=[_endpoint('/rsvc')])])
+
+    reqs = decide_service_bridges(local, {('OTHER', 222): remote})
+
+    assert [r.service_name for r in reqs] == ['/add']
+
+
+@pytest.mark.parametrize('prefix', [SRV_REQUEST_PREFIX, SRV_RESPONSE_PREFIX])
+def test_pubsub_decider_ignores_service_topics(prefix):
+    """Relaying either half as plain pub/sub would drop request/response correlation."""
+    local = _state(topics=[_topic(prefix + '/add', pubs=[_endpoint('/cli')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic(prefix + '/add', subs=[_endpoint('/svc')])])
+
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_serialize_service_request_wire_layout():
+    """4-byte tag + 256-byte payload = 260 bytes, matching the C++ struct."""
+    payload = serialize_service_request(ServiceBridgeRequest(service_name='/add'))
+
+    assert len(payload) == 260
+    msg_type, name = struct.unpack('=I256s', payload)
+    assert msg_type == 3  # BridgeMsgType::DaemonService
+    assert name.split(b'\0', 1)[0] == b'/add'
+
+
+def test_dispatch_service_reports_a_failure_through_a_real_logger(monkeypatch):
+    """The rclpy logger takes no format arguments: a %s-style call raises instead of logging.
+
+    The assertion is that the call returns: a TypeError here escapes rclpy.spin() and ends the
+    agent.
+    """
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: 'no such socket')
+
+    dispatch_service_requests(
+        [ServiceBridgeRequest(service_name='/add')], ipc_ns_inode=12345,
+        logger=RcutilsLogger('test_bridge_decider'))

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -519,17 +519,17 @@ def test_service_decide_skips_cross_domain_match():
     assert decide_service_bridges(local, {('OTHER', 222): remote}) == []
 
 
-def test_service_decide_emits_one_lease_when_both_roles_local():
-    """Holding a client of the name too changes nothing: the service side still drives it."""
-    local = _state(topics=[_srv_topic('/add', pubs=[_endpoint('/cli')],
-                                      subs=[_endpoint('/svc')])])
-    remote = _state(host_uuid='OTHER', ipc_ns=222,
-                    topics=[_srv_topic('/add', pubs=[_endpoint('/rcli')],
-                                       subs=[_endpoint('/rsvc')])])
+def test_service_decide_collapses_clients_in_several_remotes():
+    """One bridge serves every remote client, so the request is emitted once."""
+    local = _state(topics=[_srv_topic('/add', subs=[_endpoint('/svc')])])
+    remotes = {
+        ('OTHER', 222): _state(host_uuid='OTHER', ipc_ns=222,
+                               topics=[_srv_topic('/add', pubs=[_endpoint('/cli_a')])]),
+        ('OTHER', 333): _state(host_uuid='OTHER', ipc_ns=333,
+                               topics=[_srv_topic('/add', pubs=[_endpoint('/cli_b')])]),
+    }
 
-    reqs = decide_service_bridges(local, {('OTHER', 222): remote})
-
-    assert [r.service_name for r in reqs] == ['/add']
+    assert [r.service_name for r in decide_service_bridges(local, remotes)] == ['/add']
 
 
 @pytest.mark.parametrize('prefix', [SRV_REQUEST_PREFIX, SRV_RESPONSE_PREFIX])


### PR DESCRIPTION
## Description

Two IPC namespaces sharing one Agnocast service deadlock: the service side needs an **R2A** bridge but waits for a ROS 2 client that only the client side's A2R creates, and the client side needs **A2R** but waits for the ROS 2 service that only R2A creates. Pub/sub breaks the same cycle with a TTL'd forced lease from the per-namespace discovery agent (`DAEMON_FORCE_TTL`); services never got one.

### Change

- **`BridgeMsgType::DaemonService`** — the service counterpart of `DaemonPubSub`, carrying a service name and nothing else (260 bytes, size-checked on both sides). The type comes from the local endpoint's own `BridgeMsgType::Service` request, since an Agnocast service registers none.
- **Only the R2A half is leased.** That is enough: the ROS 2 service it publishes is the term the client side's (3) was missing, so A2R follows on the ordinary demand rule. Leasing A2R too would let it run before its peer's ROS 2 service exists, and a request dropped in that window hangs the caller (#1576).
- **A2R bridges are now demand-gated on a local Agnocast client**, finishing on that side what #1533 started on R2A. Without it a cross-namespace pair holds itself up, each bridge counting the other's DDS endpoint as demand.

Drive-by: `bridge_decider.py` now skips `/AGNOCAST_SRV_*` in the pub/sub path — defensive only, since those topics carry no type name and `decide_bridges()` already dropped them.

## Related links

- #1576 — leasing the A2R half too becomes safe once an undeliverable request is retried instead of dropped.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] `bash scripts/test/e2e_test_cross_ns_service.bash` 

## Notes for reviewers

**Only Jazzy and newer deadlock** — pre-Jazzy rclcpp has no service-client count, so `ros2_client_exists()` is unconditionally `true` and R2A is ungated.

**The A2R demand gate changes pre-existing behaviour** — an A2R bridge used to outlive its Agnocast clients while a same-named ROS 2 service stayed on the graph, and now goes with them; a client created after the last one left can meet the same window the first client already meets at startup (#1576).

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`

