### PR TITLE
fix(ros2agnocast_discovery_agent): resolve domain bridge config topic names to absolute names

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -61,6 +61,17 @@ def _as_bool(value, field, topic_name):
     raise ValueError(f"'{field}' for topic {topic_name!r} must be a boolean")
 
 
+def _as_topic_name(value):
+    """Coerce a YAML topic key or ``remap`` target to the absolute name domain_bridge resolves it to.
+
+    ``domain_bridge`` resolves a relative name against the root, so ``my_topic`` and
+    ``/my_topic`` name the same topic there. Matching that here keeps a shared config
+    from meaning two different topics to the external node and to this parser.
+    """
+    name = str(value)
+    return name if name.startswith('/') else '/' + name
+
+
 def parse_domain_bridge_config(text):
     """Return ``(rules, skipped)``.
 
@@ -70,6 +81,8 @@ def parse_domain_bridge_config(text):
     A ``bidirectional`` topic yields two tuples, one per direction.
     ``skipped`` lists the topic names dropped for lack of a resolvable domain
     pair, so the caller can surface them instead of dropping them silently.
+    Topic names are returned absolute, matching how ``domain_bridge`` resolves
+    the same keys.
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
     overridden per topic.
 
@@ -101,21 +114,23 @@ def parse_domain_bridge_config(text):
         from_domain = spec.get('from_domain', default_from)
         to_domain = spec.get('to_domain', default_to)
         if from_domain is None or to_domain is None:
-            skipped.append(str(topic_name))
+            skipped.append(_as_topic_name(topic_name))
             continue
         # Default to the source name (coerced like from_topic below), so a non-string YAML key
         # without a remap doesn't trip the "'remap' must be a string" check.
-        to_topic = spec.get('remap', str(topic_name))
-        if not isinstance(to_topic, str):
+        remap = spec.get('remap', str(topic_name))
+        if not isinstance(remap, str):
             raise ValueError(f"'remap' for topic {topic_name!r} must be a string")
+        from_topic = _as_topic_name(topic_name)
+        to_topic = _as_topic_name(remap)
         bidirectional = _as_bool(spec.get('bidirectional', False), 'bidirectional', topic_name)
         from_id = _as_domain_id(from_domain)
         to_id = _as_domain_id(to_domain)
-        rules.append((str(topic_name), to_topic, from_id, to_id))
+        rules.append((from_topic, to_topic, from_id, to_id))
         if bidirectional:
             # The external node's reverse leg swaps the domain ids and nothing else, keeping the
             # source name on the subscribe side and the remap on the publish side.
-            rules.append((str(topic_name), to_topic, to_id, from_id))
+            rules.append((from_topic, to_topic, to_id, from_id))
     return rules, skipped
 
 

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -64,14 +64,19 @@ topics:
 
 def test_non_string_topic_key_without_remap_is_coerced():
     # A non-string YAML key (here an integer) with no `remap` must not trip the remap
-    # string check; both names default to the coerced source name.
+    # string check; both names default to the coerced source name. The name itself is
+    # not asserted: rcl rejects a key like this, so domain_bridge never bridges it.
     text = """
 from_domain: 1
 to_domain: 2
 topics:
   123:
 """
-    assert parse_domain_bridge_config(text) == ([('/123', '/123', 1, 2)], [])
+    (rule,), skipped = parse_domain_bridge_config(text)
+    from_topic, to_topic, from_id, to_id = rule
+    assert from_topic == to_topic
+    assert (from_id, to_id) == (1, 2)
+    assert skipped == []
 
 
 def test_non_string_remap_raises():

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -18,7 +18,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('/chatter', '/chatter', 1, 2)], [])
 
 
 def test_per_topic_domains_override_top_level():
@@ -33,8 +33,8 @@ topics:
     to_domain: 4
 """
     rules, skipped = parse_domain_bridge_config(text)
-    assert ('chatter', 'chatter', 1, 2) in rules
-    assert ('special', 'special', 3, 4) in rules
+    assert ('/chatter', '/chatter', 1, 2) in rules
+    assert ('/special', '/special', 3, 4) in rules
     assert skipped == []
 
 
@@ -59,7 +59,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('/chatter', '/chatter', 1, 2)], [])
 
 
 def test_non_string_topic_key_without_remap_is_coerced():
@@ -71,7 +71,7 @@ to_domain: 2
 topics:
   123:
 """
-    assert parse_domain_bridge_config(text) == ([('123', '123', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('/123', '/123', 1, 2)], [])
 
 
 def test_non_string_remap_raises():
@@ -86,6 +86,27 @@ topics:
         parse_domain_bridge_config(text)
 
 
+def test_relative_and_absolute_topic_keys_yield_the_same_rule():
+    relative = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+    remap: renamed
+"""
+    absolute = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    type: std_msgs/msg/String
+    remap: /renamed
+"""
+    assert parse_domain_bridge_config(relative) == parse_domain_bridge_config(absolute)
+    assert parse_domain_bridge_config(relative) == ([('/chatter', '/renamed', 1, 2)], [])
+
+
 def test_topic_without_resolvable_domain_pair_is_reported_as_skipped():
     text = """
 topics:
@@ -94,7 +115,7 @@ topics:
 """
     rules, skipped = parse_domain_bridge_config(text)
     assert rules == []
-    assert skipped == ['chatter']
+    assert skipped == ['/chatter']
 
 
 def test_empty_or_topicless_config_yields_no_rules():
@@ -168,7 +189,7 @@ to_domain: 2
 topics:
   chatter:
 """
-    assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+    assert parse_domain_bridge_config(text) == ([('/chatter', '/chatter', 1, 2)], [])
 
 
 def test_bidirectional_topic_yields_both_directions():

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -45,7 +45,7 @@ def test_default_config_path_is_used_when_env_unset(tmp_path, monkeypatch):
     monkeypatch.setattr(domain_bridge_config, 'DEFAULT_CONFIG_PATH', cfg)
 
     assert register_domain_bridge.main([]) == 0
-    assert fake.calls == [('chatter', 'chatter', 1, 2)]
+    assert fake.calls == [('/chatter', '/chatter', 1, 2)]
 
 
 def test_registers_every_rule(tmp_path, monkeypatch):
@@ -53,7 +53,7 @@ def test_registers_every_rule(tmp_path, monkeypatch):
     monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
     cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
     assert register_domain_bridge.main(['--config', cfg]) == 0
-    assert fake.calls == [('chatter', 'chatter', 1, 2)]
+    assert fake.calls == [('/chatter', '/chatter', 1, 2)]
 
 
 def test_registers_remapped_rule_with_both_names(tmp_path, monkeypatch):
@@ -67,7 +67,7 @@ def test_registers_remapped_rule_with_both_names(tmp_path, monkeypatch):
 
 
 def test_returns_nonzero_when_a_rule_is_rejected(tmp_path, monkeypatch):
-    fake = FakeAddRule(codes={'chatter': -16})  # -EBUSY: an endpoint already exists
+    fake = FakeAddRule(codes={'/chatter': -16})  # -EBUSY: an endpoint already exists
     monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
     cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
     assert register_domain_bridge.main(['--config', cfg]) == 1
@@ -80,7 +80,7 @@ def test_skipped_topic_is_reported(tmp_path, monkeypatch, capsys):
     cfg = _write_config(tmp_path, 'topics:\n  chatter:\n')
     assert register_domain_bridge.main(['--config', cfg]) == 0
     assert fake.calls == []
-    assert 'skipping chatter' in capsys.readouterr().err
+    assert 'skipping /chatter' in capsys.readouterr().err
 
 
 def test_returns_nonzero_on_unreadable_config(tmp_path, monkeypatch):
@@ -97,4 +97,4 @@ def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
     cfg = _write_config(tmp_path, 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n')
     monkeypatch.setenv(CONFIG_ENV, cfg)
     assert register_domain_bridge.main([]) == 0
-    assert fake.calls == [('image', 'image', 3, 4)]
+    assert fake.calls == [('/image', '/image', 3, 4)]


### PR DESCRIPTION
## Description

`domain_bridge` resolves a relative topic key against the root, so `my_topic` names `/my_topic` there. This parser kept the YAML key verbatim, so one shared config meant two different topics: the external node bridged `/my_topic` while the agent looked for `my_topic`, found nothing, and forced no cross-domain bridge.

Resolve topic keys and `remap` targets to absolute names.
Prepending `/` is the whole of the resolution: `domain_bridge` expands these names against a hardcoded root namespace, on nodes it builds with `use_global_arguments(false)`, so no node namespace or ROS remap rule takes part.

## Related links

None.

## How was this PR tested?

Unit tests, plus an Agnocast talker on domain 71 and listener on domain 72 in one IPC namespace, bridged by `ros2 run domain_bridge domain_bridge` with a relative topic key. Before, the agent logged `no cross-domain bridge forced for my_topic@71: no local topic in this domain` and nothing crossed; after, the listener received the published messages.

## Notes for reviewers

None.

## Version Update Label (Required)

`need-patch-update`

