### PR TITLE
feat(agnocastlib): support service introspection on the client side

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -193,6 +193,7 @@ private:
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
 #if AGNOCAST_HAS_SERVICE_INTROSPECTION
+  // Declared before subscriber_ so that it outlives the callback that uses it.
   std::unique_ptr<ServiceEventPublisher> event_publisher_;
 #endif
   typename ServiceResponseSubscriber::SharedPtr subscriber_;

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -26,6 +26,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -198,6 +199,27 @@ private:
 #endif
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+  // Must be called before publish(). Only CONTENTS puts the payload in the event, so the other
+  // states pay nothing; raising to CONTENTS in between costs that one event its payload.
+  std::optional<typename ServiceT::Request> copy_request_if_contents(
+    const ipc_shared_ptr<RequestT> & request)
+  {
+    if (event_publisher_->introspection_state() != RCL_SERVICE_INTROSPECTION_CONTENTS) {
+      return std::nullopt;
+    }
+    return static_cast<const typename ServiceT::Request &>(*request);
+  }
+
+  void publish_request_sent_event(
+    const int64_t seqno, const std::optional<typename ServiceT::Request> & request)
+  {
+    event_publisher_->publish_service_event_message(
+      service_msgs::msg::ServiceEventInfo::REQUEST_SENT, request ? &*request : nullptr, seqno,
+      get_gid().data);
+  }
+#endif
+
   template <typename Func>
   int64_t send_request_impl(
     ipc_shared_ptr<typename ServiceT::Request> && request, ResponseCallInfo && call_info,
@@ -213,14 +235,15 @@ private:
     }
 
 #if AGNOCAST_HAS_SERVICE_INTROSPECTION
-    // Must precede the publish, which leaves `internal_request` empty.
-    event_publisher_->publish_service_event_message(
-      service_msgs::msg::ServiceEventInfo::REQUEST_SENT,
-      static_cast<const typename ServiceT::Request *>(internal_request.get()), seqno,
-      get_gid().data);
+    const auto sent_request = copy_request_if_contents(internal_request);
 #endif
 
     publisher_->publish(std::move(internal_request));
+
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+    publish_request_sent_event(seqno, sent_request);
+#endif
+
     return seqno;
   }
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -279,6 +279,7 @@ private:
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
         RCLCPP_ERROR(get_logger(), "Agnocast internal implementation error: bad entry id");
+        // No RESPONSE_RECEIVED either: the event follows the pairing, not the arrival.
         return;
       }
       ResponseCallInfo info = std::move(it->second);

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -3,6 +3,7 @@
 #include "agnocast/agnocast_ioctl.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_service_event_publisher.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
@@ -12,6 +13,10 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+#include <service_msgs/msg/service_event_info.hpp>
+#endif
 
 #include <atomic>
 #include <chrono>
@@ -187,6 +192,9 @@ private:
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+  std::unique_ptr<ServiceEventPublisher> event_publisher_;
+#endif
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
   template <typename Func>
@@ -202,6 +210,14 @@ private:
       take_future(
         seqno2_response_call_info_.try_emplace(seqno, std::move(call_info)).first->second);
     }
+
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+    // Must precede the publish, which leaves `internal_request` empty.
+    event_publisher_->publish_service_event_message(
+      service_msgs::msg::ServiceEventInfo::REQUEST_SENT,
+      static_cast<const typename ServiceT::Request *>(internal_request.get()), seqno,
+      get_gid().data);
+#endif
 
     publisher_->publish(std::move(internal_request));
     return seqno;
@@ -225,6 +241,12 @@ private:
     response_topic_name_ =
       create_service_response_topic_name(service_name_, node_name_, publisher_->get_id());
 
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+    // Must precede the subscription: its callback is runnable as soon as it is registered.
+    event_publisher_ = std::make_unique<ServiceEventPublisher>(
+      node_, service_name_, rosidl_generator_traits::name<ServiceT>());
+#endif
+
     auto subscriber_callback = [this](ipc_shared_ptr<ResponseT> && response) {
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
       /* --- critical section begin --- */
@@ -239,6 +261,14 @@ private:
       seqno2_response_call_info_.erase(it);
       /* --- critical section end --- */
       lock.unlock();
+
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+      // Must precede the move into the promise, which leaves `response` empty.
+      event_publisher_->publish_service_event_message(
+        service_msgs::msg::ServiceEventInfo::RESPONSE_RECEIVED,
+        static_cast<const typename ServiceT::Response *>(response.get()),
+        response->ResponseMeta::seqno, get_gid().data);
+#endif
 
       info.promise.set_value(ipc_shared_ptr<typename ServiceT::Response>(std::move(response)));
       if (info.callback.has_value()) {
@@ -294,6 +324,28 @@ public:
 
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
+
+#if AGNOCAST_HAS_SERVICE_INTROSPECTION
+  /**
+   * @brief Configure service introspection. Publishes REQUEST_SENT and RESPONSE_RECEIVED; the
+   * server reports its own two events through agnocast::Service::configure_introspection.
+   * @param clock The clock to use to generate introspection timestamps.
+   * @param qos_service_event_pub The QoS settings to use when creating the introspection publisher.
+   * @param introspection_state The state to set introspection to.
+   * @throws std::invalid_argument if @p clock is null, including when disabling, as in rcl, or if
+   * @p qos_service_event_pub cannot be used by Agnocast. The QoS is only checked when a publisher
+   * is about to be created, so disabling never rejects it.
+   * @throws std::runtime_error if the typesupport libraries for the event message cannot be
+   * loaded. Only the first transition out of OFF loads them.
+   */
+  AGNOCAST_PUBLIC
+  void configure_introspection(
+    const rclcpp::Clock::SharedPtr & clock, const rclcpp::QoS & qos_service_event_pub,
+    rcl_service_introspection_state_t introspection_state)
+  {
+    event_publisher_->configure(clock, qos_service_event_pub, introspection_state);
+  }
+#endif
 
   /** @brief Send a request asynchronously and invoke a callback when the response arrives.
    *  @param request Request from borrow_loaned_request(). Must be moved in.

--- a/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
@@ -35,6 +35,14 @@ using Event = std_srvs::srv::SetBool_Event;
 constexpr const char * kServiceName = "test_introspected_service";
 constexpr const char * kEventTopicName = "/test_introspected_service/_service_event";
 
+const Event * find_event(const std::vector<Event> & events, const uint8_t event_type)
+{
+  const auto it = std::find_if(events.begin(), events.end(), [event_type](const Event & event) {
+    return event.info.event_type == event_type;
+  });
+  return it == events.end() ? nullptr : &*it;
+}
+
 class IntrospectionFixture : public ::testing::Test
 {
 protected:
@@ -354,16 +362,18 @@ TEST_F(ServiceIntrospectionTest, ContentsPublishesRequestSentAndResponseReceived
   ASSERT_TRUE(call_service(true));
   const auto events = wait_for_events(2);
 
-  // Assert
+  // Assert: the two events are published from different threads, so look them up by type.
   ASSERT_EQ(events.size(), 2u);
-  EXPECT_EQ(events[0].info.event_type, ServiceEventInfo::REQUEST_SENT);
-  EXPECT_EQ(events[1].info.event_type, ServiceEventInfo::RESPONSE_RECEIVED);
+  const auto * sent = find_event(events, ServiceEventInfo::REQUEST_SENT);
+  const auto * received = find_event(events, ServiceEventInfo::RESPONSE_RECEIVED);
+  ASSERT_NE(sent, nullptr);
+  ASSERT_NE(received, nullptr);
 
-  ASSERT_EQ(events[0].request.size(), 1u);
-  EXPECT_TRUE(events[0].request[0].data);
-  ASSERT_EQ(events[1].response.size(), 1u);
-  EXPECT_TRUE(events[1].response[0].success);
-  EXPECT_EQ(events[1].response[0].message, "ok");
+  ASSERT_EQ(sent->request.size(), 1u);
+  EXPECT_TRUE(sent->request[0].data);
+  ASSERT_EQ(received->response.size(), 1u);
+  EXPECT_TRUE(received->response[0].success);
+  EXPECT_EQ(received->response[0].message, "ok");
 }
 
 TEST_F(ServiceIntrospectionTest, BothSidesTogetherCoverTheWholeExchange)

--- a/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
@@ -200,22 +200,23 @@ TEST_F(ServiceIntrospectionTest, ContentsPublishesRequestReceivedAndResponseSent
   EXPECT_EQ(events[1].response[0].message, "ok");
 }
 
-TEST_F(ServiceIntrospectionTest, BothEventsOfOneCallCarryTheSameCallerAndSequenceNumber)
+TEST_F(ServiceIntrospectionTest, BothEventsOfACallCarryTheSequenceNumberOfThatCall)
 {
-  // Arrange
+  // Arrange: two calls, so a constant cannot pass for a real sequence number.
   set_introspection(RCL_SERVICE_INTROSPECTION_METADATA);
+  ASSERT_TRUE(call_service(true));
+  const auto first = wait_for_events(2);
+  ASSERT_EQ(first.size(), 2u);
+  forget_events();
 
   // Act
   ASSERT_TRUE(call_service(true));
   const auto events = wait_for_events(2);
 
-  // Assert: a consumer pairs the two events by (client_gid, sequence_number).
+  // Assert: a consumer pairs the two events of a call by its sequence number.
   ASSERT_EQ(events.size(), 2u);
   EXPECT_EQ(events[0].info.sequence_number, events[1].info.sequence_number);
-  EXPECT_EQ(events[0].info.client_gid, events[1].info.client_gid);
-  const auto & gid = events[0].info.client_gid;
-  EXPECT_NE(std::count(gid.begin(), gid.end(), 0), static_cast<long>(gid.size()))
-    << "client_gid is all zeros, so the caller cannot be identified";
+  EXPECT_NE(events[0].info.sequence_number, first[0].info.sequence_number);
 }
 
 TEST_F(ServiceIntrospectionTest, MetadataPublishesEventsWithoutPayload)
@@ -367,9 +368,13 @@ TEST_F(ServiceIntrospectionTest, ContentsPublishesRequestSentAndResponseReceived
 
 TEST_F(ServiceIntrospectionTest, BothSidesTogetherCoverTheWholeExchange)
 {
-  // Arrange
+  // Arrange: two calls, so a constant cannot pass for a real sequence number.
   set_introspection(RCL_SERVICE_INTROSPECTION_METADATA);
   set_client_introspection(RCL_SERVICE_INTROSPECTION_METADATA);
+  ASSERT_TRUE(call_service(true));
+  const auto first = wait_for_events(4);
+  ASSERT_EQ(first.size(), 4u);
+  forget_events();
 
   // Act
   ASSERT_TRUE(call_service(true));
@@ -381,6 +386,7 @@ TEST_F(ServiceIntrospectionTest, BothSidesTogetherCoverTheWholeExchange)
     EXPECT_EQ(event.info.sequence_number, events[0].info.sequence_number);
     EXPECT_EQ(event.info.client_gid, events[0].info.client_gid);
   }
+  EXPECT_NE(events[0].info.sequence_number, first[0].info.sequence_number);
 
   std::vector<uint8_t> types;
   types.reserve(events.size());

--- a/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
@@ -94,6 +94,11 @@ protected:
     service_->configure_introspection(node_->get_clock(), rclcpp::ServicesQoS(), state);
   }
 
+  void set_client_introspection(rcl_service_introspection_state_t state)
+  {
+    client_->configure_introspection(node_->get_clock(), rclcpp::ServicesQoS(), state);
+  }
+
   [[nodiscard]] bool call_service(bool data)
   {
     auto request = client_->borrow_loaned_request();
@@ -337,6 +342,56 @@ TEST_F(DeferredServiceIntrospectionTest, ADeferredResponsePublishesBothEvents)
   EXPECT_EQ(events[1].info.event_type, ServiceEventInfo::RESPONSE_SENT);
   ASSERT_EQ(events[1].response.size(), 1u);
   EXPECT_TRUE(events[1].response[0].success);
+}
+
+TEST_F(ServiceIntrospectionTest, ContentsPublishesRequestSentAndResponseReceivedWithPayload)
+{
+  // Arrange
+  set_client_introspection(RCL_SERVICE_INTROSPECTION_CONTENTS);
+
+  // Act
+  ASSERT_TRUE(call_service(true));
+  const auto events = wait_for_events(2);
+
+  // Assert
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0].info.event_type, ServiceEventInfo::REQUEST_SENT);
+  EXPECT_EQ(events[1].info.event_type, ServiceEventInfo::RESPONSE_RECEIVED);
+
+  ASSERT_EQ(events[0].request.size(), 1u);
+  EXPECT_TRUE(events[0].request[0].data);
+  ASSERT_EQ(events[1].response.size(), 1u);
+  EXPECT_TRUE(events[1].response[0].success);
+  EXPECT_EQ(events[1].response[0].message, "ok");
+}
+
+TEST_F(ServiceIntrospectionTest, BothSidesTogetherCoverTheWholeExchange)
+{
+  // Arrange
+  set_introspection(RCL_SERVICE_INTROSPECTION_METADATA);
+  set_client_introspection(RCL_SERVICE_INTROSPECTION_METADATA);
+
+  // Act
+  ASSERT_TRUE(call_service(true));
+  const auto events = wait_for_events(4);
+
+  // Assert: one call, so the four events share the correlation key a consumer pairs them by.
+  ASSERT_EQ(events.size(), 4u);
+  for (const auto & event : events) {
+    EXPECT_EQ(event.info.sequence_number, events[0].info.sequence_number);
+    EXPECT_EQ(event.info.client_gid, events[0].info.client_gid);
+  }
+
+  std::vector<uint8_t> types;
+  types.reserve(events.size());
+  for (const auto & event : events) {
+    types.push_back(event.info.event_type);
+  }
+  std::sort(types.begin(), types.end());
+  EXPECT_EQ(
+    types, (std::vector<uint8_t>{
+             ServiceEventInfo::REQUEST_SENT, ServiceEventInfo::REQUEST_RECEIVED,
+             ServiceEventInfo::RESPONSE_SENT, ServiceEventInfo::RESPONSE_RECEIVED}));
 }
 
 #endif  // AGNOCAST_HAS_SERVICE_INTROSPECTION

--- a/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_service_introspection.cpp
@@ -271,14 +271,14 @@ TEST_F(ServiceIntrospectionTest, LoweringFromContentsToMetadataStopsIncludingThe
   EXPECT_TRUE(events[1].response.empty());
 }
 
-TEST_F(ServiceIntrospectionTest, ATransitionThatKeepsThePublisherKeepsTheClockItWasCreatedWith)
+TEST_F(ServiceIntrospectionTest, ChangingOnlyTheStateKeepsTheClockIntrospectionWasEnabledWith)
 {
   // Arrange: steady time runs from boot, so its stamps cannot be mistaken for system time.
   auto steady_clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
   service_->configure_introspection(
     steady_clock, rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
-  // Act: this transition keeps the publisher, so this clock must be ignored.
+  // Act: this call only changes the state, so this clock must be ignored.
   service_->configure_introspection(
     std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME), rclcpp::ServicesQoS(),
     RCL_SERVICE_INTROSPECTION_CONTENTS);


### PR DESCRIPTION
## Description

Publishes `REQUEST_SENT` and `RESPONSE_RECEIVED` from `agnocast::Client<T>`, so `<service>/_service_event` carries both sides of a completed call rather than only the server's half. Introspection stays off until `configure_introspection(clock, qos, state)` is called, the same entry point the server side already has.

`REQUEST_SENT` is published after `publish()` has handed the request over, and `RESPONSE_RECEIVED` once the response has been taken, so each event reports something that has already happened. This matches `rcl_send_request` and `rcl_take_response_with_info`.

Follow-up to #1551, which covered the server side.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

The integration test gains two cases: the client's two events with their contents, and one that enables both sides and checks that the four events of a single call share `(client_gid, sequence_number)`. Run on a Jazzy build with the kernel module loaded: 12 cases pass.

Also checked by hand in a Jazzy container against the host kernel module: with both sides enabled, `ros2 service echo` receives all four event types.

## Notes for reviewers

The integration test is labelled `requires_kernel_module`, so the standard build matrix skips it.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)




