### PR TITLE
feat(agnocastlib): add create_take_subscription() factories

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -306,6 +306,7 @@ The following tables compare methods that are **directly defined** in each class
 |-----|:------------:|:--------------:|-------|
 | `create_publisher<MessageT>()` | ✓ | ✓ | Return type differs (rclcpp::Publisher vs agnocast::Publisher) |
 | `create_subscription<MessageT>()` | ✓ | ✓ | Return type differs (rclcpp::Subscription vs agnocast::Subscription) |
+| `create_take_subscription<MessageT>()` | ✗ | ✓ | Agnocast-only. rclcpp takes from a callback subscription, while Agnocast fixes the mode at construction |
 | `create_generic_publisher()` | ✓ | ✗ | |
 | `create_generic_subscription()` | ✓ | ✗ | |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ Each script is a thin wrapper that runs `source install/setup.bash` followed by 
 |---|---|
 | `run_no_rclcpp_talker.bash` | `no_rclcpp_talker.launch.xml` |
 | `run_no_rclcpp_listener.bash` | `no_rclcpp_listener.launch.xml` |
-| `run_no_rclcpp_take_listener.bash` | `no_rclcpp_take_listener.launch.xml` (polling-style subscription) |
+| `run_no_rclcpp_take_listener.bash` | `no_rclcpp_take_listener.launch.xml` (take-style subscription) |
 | `run_no_rclcpp_pubsub.bash` | `no_rclcpp_pubsub.launch.xml` |
 | `run_no_rclcpp_client.bash` | `no_rclcpp_client.launch.xml` |
 | `run_no_rclcpp_server.bash` | `no_rclcpp_server.launch.xml` |

--- a/src/agnocast_e2e_test/src/test_take_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_take_subscriber.cpp
@@ -52,8 +52,7 @@ public:
       qos.transient_local();
     }
 
-    sub_ =
-      std::make_shared<agnocast::TakeSubscription<std_msgs::msg::Int64>>(this, topic_name, qos);
+    sub_ = agnocast::create_take_subscription<std_msgs::msg::Int64>(this, topic_name, qos);
     timer_ = this->create_wall_timer(10ms, std::bind(&TestTakeSubscriber::timer_callback, this));
   }
 };

--- a/src/agnocast_sample_application/src/no_rclcpp_take_subscriber.cpp
+++ b/src/agnocast_sample_application/src/no_rclcpp_take_subscriber.cpp
@@ -7,12 +7,12 @@ using namespace std::chrono_literals;
 
 class NoRclcppTakeSubscriber : public agnocast::Node
 {
-  agnocast::PollingSubscriber<agnocast_sample_interfaces::msg::DynamicSizeArray>::SharedPtr sub_;
+  agnocast::TakeSubscription<agnocast_sample_interfaces::msg::DynamicSizeArray>::SharedPtr sub_;
   agnocast::TimerBase::SharedPtr timer_;
 
   void timer_callback()
   {
-    auto message = sub_->take_data();
+    auto message = sub_->take();
     if (message) {
       RCLCPP_INFO(
         get_logger(), "I heard dynamic size array message with id: %ld, size: %zu", message->id,
@@ -23,7 +23,7 @@ class NoRclcppTakeSubscriber : public agnocast::Node
 public:
   explicit NoRclcppTakeSubscriber() : agnocast::Node("no_rclcpp_take_subscriber")
   {
-    sub_ = this->create_subscription<agnocast_sample_interfaces::msg::DynamicSizeArray>(
+    sub_ = this->create_take_subscription<agnocast_sample_interfaces::msg::DynamicSizeArray>(
       "/my_topic", rclcpp::QoS(rclcpp::KeepLast(1)));
 
     timer_ = this->create_wall_timer(1s, std::bind(&NoRclcppTakeSubscriber::timer_callback, this));

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -191,6 +191,47 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
     std::forward<Func>(callback), options);
 }
 
+/// @brief Create an Agnocast take-subscription (Stage 1 free function, QoS overload).
+/// @tparam MessageT ROS message type.
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param qos Quality of service profile.
+/// @param options Subscription options.
+/// @return Shared pointer to the created take-subscription.
+AGNOCAST_PUBLIC
+template <typename MessageT, typename NodeT>
+typename TakeSubscription<MessageT>::SharedPtr create_take_subscription(
+  NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
+  agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options);
+}
+
+/// @brief Create an Agnocast take-subscription (Stage 1 free function, history-depth overload).
+/// @tparam MessageT ROS message type.
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param qos_history_depth History depth for the QoS profile.
+/// @param options Subscription options.
+/// @return Shared pointer to the created take-subscription.
+AGNOCAST_PUBLIC
+template <typename MessageT, typename NodeT>
+typename TakeSubscription<MessageT>::SharedPtr create_take_subscription(
+  NodeT * node, const std::string & topic_name, const size_t qos_history_depth,
+  agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<TakeSubscription<MessageT>>(
+    node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
+}
+
 /// @brief Create an Agnocast polling subscription (Stage 1 free function, history-depth overload).
 /// @tparam MessageT ROS message type.
 /// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
@@ -202,8 +243,8 @@ AGNOCAST_PUBLIC
 template <typename MessageT, typename NodeT>
 [[deprecated(
   "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed from "
-  "agnocast. Obtain a polling subscriber from the wrapper, or use agnocast::TakeSubscription "
-  "directly.")]]
+  "agnocast. Obtain a polling subscriber from the wrapper, or use "
+  "agnocast::create_take_subscription().")]]
 typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   NodeT * node, const std::string & topic_name, const size_t qos_history_depth)
 {
@@ -225,8 +266,8 @@ AGNOCAST_PUBLIC
 template <typename MessageT, typename NodeT>
 [[deprecated(
   "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed from "
-  "agnocast. Obtain a polling subscriber from the wrapper, or use agnocast::TakeSubscription "
-  "directly.")]]
+  "agnocast. Obtain a polling subscriber from the wrapper, or use "
+  "agnocast::create_take_subscription().")]]
 typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos)
 {

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -225,10 +225,7 @@ typename TakeSubscription<MessageT>::SharedPtr create_take_subscription(
   NodeT * node, const std::string & topic_name, const size_t qos_history_depth,
   agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
 {
-  static_assert(
-    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
-    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<TakeSubscription<MessageT>>(
+  return create_take_subscription<MessageT>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -208,7 +208,7 @@ typename TakeSubscription<MessageT>::SharedPtr create_take_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options);
+  return std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, std::move(options));
 }
 
 /// @brief Create an Agnocast take-subscription (Stage 1 free function, history-depth overload).
@@ -226,7 +226,7 @@ typename TakeSubscription<MessageT>::SharedPtr create_take_subscription(
   agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
 {
   return create_take_subscription<MessageT>(
-    node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
+    node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::move(options));
 }
 
 /// @brief Create an Agnocast polling subscription (Stage 1 free function, history-depth overload).

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -304,6 +304,14 @@ private:
       type_name = rosidl_generator_traits::name<MessageT>();
     }
     init_base(node, qos, type_name, true, options, role);
+
+    if (options.callback_group) {
+      RCLCPP_WARN(
+        logger,
+        "SubscriptionOptions::callback_group is ignored for the take-subscription on topic '%s': "
+        "it has no callback to dispatch.",
+        topic_name_.c_str());
+    }
   }
 
 public:

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -494,7 +494,8 @@ public:
   [[deprecated(
     "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
     "from agnocast. Obtain a polling subscriber from the wrapper, or use "
-    "agnocast::create_take_subscription().")]]
+    "agnocast::create_take_subscription(): its take() returns each message at most once, so keep "
+    "the last returned message on the caller side to keep the latched behaviour.")]]
   const agnocast::ipc_shared_ptr<const MessageT> takeData()
   {
     return subscriber_->take(true);
@@ -510,7 +511,8 @@ public:
   [[deprecated(
     "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
     "from agnocast. Obtain a polling subscriber from the wrapper, or use "
-    "agnocast::create_take_subscription().")]]
+    "agnocast::create_take_subscription(): its take() returns each message at most once, so keep "
+    "the last returned message on the caller side to keep the latched behaviour.")]]
   const agnocast::ipc_shared_ptr<const MessageT> take_data()
   {
     return subscriber_->take(true);

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -489,9 +489,12 @@ public:
       std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options, role);
   };
 
-  /// @deprecated Use take_data() instead. Behaves identically, including the history-depth
-  /// caveat documented there.
-  [[deprecated("Use take_data() instead.")]]
+  /// @deprecated Behaves identically to take_data(), including the history-depth caveat
+  /// documented there.
+  [[deprecated(
+    "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
+    "from agnocast. Obtain a polling subscriber from the wrapper, or use "
+    "agnocast::create_take_subscription().")]]
   const agnocast::ipc_shared_ptr<const MessageT> takeData()
   {
     return subscriber_->take(true);

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -507,7 +507,7 @@ public:
   [[deprecated(
     "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
     "from agnocast. Obtain a polling subscriber from the wrapper, or use "
-    "agnocast::TakeSubscription directly.")]]
+    "agnocast::create_take_subscription().")]]
   const agnocast::ipc_shared_ptr<const MessageT> take_data()
   {
     return subscriber_->take(true);

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -276,7 +276,7 @@ public:
  *
  * Does not use a callback; the caller retrieves one message per call by calling take(), which
  * returns the newest message only with a history depth of 1. See take() for the behaviour with a
- * greater depth.
+ * greater depth. Allocate instances with `agnocast::create_take_subscription<MessageT>()`.
  *
  * @tparam MessageT  ROS message type.
  */

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -511,6 +511,37 @@ public:
       options);
   }
 
+  /// Create a take-subscription (QoS overload).
+  /// @tparam MessageT ROS message type.
+  /// @param topic_name Topic name.
+  /// @param qos Quality of service profile.
+  /// @param options Subscription options.
+  /// @return Shared pointer to the created take-subscription.
+  AGNOCAST_PUBLIC
+  template <typename MessageT>
+  typename agnocast::TakeSubscription<MessageT>::SharedPtr create_take_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+  {
+    return std::make_shared<TakeSubscription<MessageT>>(this, topic_name, qos, options);
+  }
+
+  /// Create a take-subscription (queue-size overload).
+  /// @tparam MessageT ROS message type.
+  /// @param topic_name Topic name.
+  /// @param queue_size History depth for the QoS profile.
+  /// @param options Subscription options.
+  /// @return Shared pointer to the created take-subscription.
+  AGNOCAST_PUBLIC
+  template <typename MessageT>
+  typename agnocast::TakeSubscription<MessageT>::SharedPtr create_take_subscription(
+    const std::string & topic_name, size_t queue_size,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+  {
+    return create_take_subscription<MessageT>(
+      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);
+  }
+
   /// Create a polling subscription (history-depth overload).
   /// @tparam MessageT ROS message type.
   /// @param topic_name Topic name.
@@ -521,7 +552,7 @@ public:
   [[deprecated(
     "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
     "from agnocast. Obtain a polling subscriber from the wrapper, or use "
-    "agnocast::TakeSubscription directly.")]]
+    "agnocast::create_take_subscription().")]]
   typename agnocast::PollingSubscriber<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const size_t qos_history_depth)
   {
@@ -539,7 +570,7 @@ public:
   [[deprecated(
     "agnocast::PollingSubscriber is planned to move to autoware_agnocast_wrapper and be removed "
     "from agnocast. Obtain a polling subscriber from the wrapper, or use "
-    "agnocast::TakeSubscription directly.")]]
+    "agnocast::create_take_subscription().")]]
   typename agnocast::PollingSubscriber<MessageT>::SharedPtr create_subscription(
     const std::string & topic_name, const rclcpp::QoS & qos)
   {

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -523,7 +523,7 @@ public:
     const std::string & topic_name, const rclcpp::QoS & qos,
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
   {
-    return std::make_shared<TakeSubscription<MessageT>>(this, topic_name, qos, options);
+    return std::make_shared<TakeSubscription<MessageT>>(this, topic_name, qos, std::move(options));
   }
 
   /// Create a take-subscription (queue-size overload).
@@ -539,7 +539,7 @@ public:
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
   {
     return create_take_subscription<MessageT>(
-      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), options);
+      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), std::move(options));
   }
 
   /// Create a polling subscription (history-depth overload).

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -143,7 +143,7 @@ TEST_F(GetActualQosTest, get_actual_qos_reports_the_depth_of_a_take_subscription
   auto sub = node->create_take_subscription<StringMsg>("/test_actual_qos_take_agnocast_node", 4);
 
   // Assert
-  EXPECT_EQ(sub->get_actual_qos().depth(), 4u);
+  EXPECT_EQ(sub->get_actual_qos(), rclcpp::QoS(rclcpp::KeepLast(4)));
 }
 
 TEST_F(GetActualQosTest, get_actual_qos_reports_the_depth_of_a_take_subscription_free_function)

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -146,6 +146,40 @@ TEST_F(GetActualQosTest, get_actual_qos_reports_the_depth_of_a_take_subscription
   EXPECT_EQ(sub->get_actual_qos().depth(), 4u);
 }
 
+TEST_F(GetActualQosTest, get_actual_qos_reports_the_depth_of_a_take_subscription_free_function)
+{
+  // Arrange
+  rclcpp::NodeOptions node_options;
+  node_options.start_parameter_services(false);
+  auto node = std::make_shared<agnocast::Node>("test_actual_qos_take_free", node_options);
+
+  // Act
+  auto sub =
+    agnocast::create_take_subscription<StringMsg>(node.get(), "/test_actual_qos_take_free", 4);
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos(), rclcpp::QoS(rclcpp::KeepLast(4)));
+}
+
+TEST_F(GetActualQosTest, a_take_subscription_forwards_the_options_to_the_qos_override)
+{
+  // Arrange: a node that overrides the subscription depth to 9.
+  rclcpp::NodeOptions node_options;
+  node_options.parameter_overrides(
+    {rclcpp::Parameter("qos_overrides./test_actual_qos_take_override.subscription.depth", 9)});
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos_take_override", node_options);
+
+  agnocast::SubscriptionOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions({rclcpp::QosPolicyKind::Depth});
+
+  // Act: construct with depth 1, which the override is expected to replace.
+  auto sub = agnocast::create_take_subscription<StringMsg>(
+    node.get(), "/test_actual_qos_take_override", rclcpp::QoS{1}, options);
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos().depth(), 9u);
+}
+
 TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_polling_subscriber)
 {
   // Arrange

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -125,10 +125,25 @@ TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_take_subscription)
   const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(4)).best_effort();
 
   // Act
-  agnocast::TakeSubscription<StringMsg> sub(node.get(), "/test_actual_qos_take", qos);
+  auto sub =
+    agnocast::create_take_subscription<StringMsg>(node.get(), "/test_actual_qos_take", qos);
 
   // Assert
-  EXPECT_EQ(sub.get_actual_qos(), qos);
+  EXPECT_EQ(sub->get_actual_qos(), qos);
+}
+
+TEST_F(GetActualQosTest, get_actual_qos_reports_the_depth_of_a_take_subscription_of_agnocast_node)
+{
+  // Arrange
+  rclcpp::NodeOptions options;
+  options.start_parameter_services(false);
+  auto node = std::make_shared<agnocast::Node>("test_actual_qos_take_agnocast_node", options);
+
+  // Act
+  auto sub = node->create_take_subscription<StringMsg>("/test_actual_qos_take_agnocast_node", 4);
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos().depth(), 4u);
 }
 
 TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_polling_subscriber)


### PR DESCRIPTION
## Description

Add `create_take_subscription()` as a node method and as a Stage 1 free function, so a `TakeSubscription` is obtained from a factory like every other Agnocast entity instead of being constructed with `std::make_shared` by the caller. The deprecation messages on the callback-less `create_subscription()` overloads now point at it, and the sample application, the e2e take subscriber and the unit test go through it.

Returning one `Subscription` for both modes, as rclcpp does, was considered and dropped (#1522). Making callback delivery and `take()` actually work on one subscription needs a large design change — the kernel reference is one bit per (subscriber, entry) and the read cursor is one per subscriber — and no application uses both modes on the same subscription, so the split types stay.

Given the split, changing the callback-less `create_subscription()` to return a `TakeSubscription` was rejected: overloads cannot differ by return type alone, so old and new cannot coexist. It would break user code at once with no migration period, hence a major version bump. A new name keeps the change additive and lets the deprecated overloads live until `PollingSubscriber` moves to `autoware_agnocast_wrapper`. It is not rclcpp-aligned, but it states at the call site that the subscription is polled, which I consider the better trade.

## Related links

- #1522 — the rejected unification of `Subscription` and `TakeSubscription`
- #1506 — deprecated the `PollingSubscriber` entry points

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Built `agnocastlib`, `agnocast_sample_application` and `agnocast_e2e_test`, and ran the `GetActualQosTest` unit tests (8 passed), which now cover the free function with `rclcpp::Node` and the node method with `agnocast::Node`.

## Notes for reviewers

`agnocast_sample_application`'s `no_rclcpp_take_subscriber` was the only remaining in-tree user of the deprecated `PollingSubscriber` API and emitted deprecation warnings on every build.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

