### PR TITLE
fix(agnocast_kmod): track the unlink daemon instead of inferring it from the process count

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentati
 
 ### Shared memory cleanup
 
-Agnocast spawns a background daemon process (forked from the first Agnocast process) that automatically cleans up shared memory when processes exit. The daemon inherits the parent's process name, so broad kill commands like `killall` or `kill -9 $(pgrep -f ...)` may accidentally kill it along with application processes. If the daemon dies, cleanup stops and resources will leak. To avoid this, stop application processes individually (e.g., with `Ctrl+C` or by targeting specific PIDs).
+Agnocast spawns a background daemon process that automatically cleans up shared memory when processes exit. It is forked by any Agnocast process that finds no daemon running, so the first process in an IPC namespace starts one, and so does the next process to start after the daemon is gone. The daemon inherits the parent's process name, so broad kill commands like `killall` or `kill -9 $(pgrep -f ...)` may accidentally kill it along with application processes; cleanup then stops until an Agnocast process starts again, which spawns a replacement and unlinks what was left behind in the meantime.
 
 If shared memory is left behind, you can remove it manually:
 

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <linux/ipc_namespace.h>
+#include <linux/limits.h>
 #include <linux/types.h>
 
 #define MAX_PUBLISHER_NUM 1024   // Maximum number of publishers per topic
@@ -45,10 +46,19 @@ union ioctl_get_node_names_args {
   uint32_t ret_node_num;
 };
 
+// The unlink daemon has no domain of its own.
+#define AGNOCAST_DOMAIN_ID_NONE U32_MAX
+
+enum process_role {
+  PROCESS_ROLE_APPLICATION = 0,
+  PROCESS_ROLE_BRIDGE_MANAGER = 1,
+  PROCESS_ROLE_UNLINK_DAEMON = 2,
+};
+
 union ioctl_add_process_args {
   struct
   {
-    bool is_bridge_manager;
+    uint32_t role;       // enum process_role
     uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct
@@ -454,7 +464,7 @@ int agnocast_ioctl_take_msg(
   union ioctl_take_msg_args * ioctl_ret);
 
 int agnocast_ioctl_add_process(
-  const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_bridge_manager,
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const enum process_role role,
   const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret);
 
 int agnocast_ioctl_get_subscriber_num(
@@ -547,7 +557,8 @@ pid_t agnocast_ioctl_get_exit_process(
   const struct ipc_namespace * ipc_ns, struct ioctl_get_exit_process_args * ioctl_ret);
 
 void agnocast_commit_exit_process(
-  const struct ipc_namespace * ipc_ns, pid_t global_pid, bool * ret_daemon_should_exit);
+  const struct ipc_namespace * ipc_ns, pid_t global_pid, pid_t caller_pid,
+  bool * ret_daemon_should_exit);
 
 void agnocast_process_exit_cleanup(const pid_t pid);
 

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -349,8 +349,14 @@ void agnocast_process_exit_cleanup(const pid_t pid)
     return;
   }
 
-  // This proc_info will be removed from proc_info_htable later by the unlink daemon.
-  proc_info->exited = true;
+  // No daemon can drain the daemon's own entry, so for this role registered means alive.
+  if (proc_info->role == PROCESS_ROLE_UNLINK_DAEMON) {
+    hash_del_rcu(&proc_info->node);
+    kfree_rcu(proc_info, rcu_head);
+  } else {
+    // This proc_info will be removed from proc_info_htable later by the unlink daemon.
+    proc_info->exited = true;
+  }
 
   free_memory(pid);
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -81,8 +81,7 @@ static inline void agnocast_eventfd_put(struct eventfd_ctx * ctx)
 struct process_info
 {
   bool exited;
-  // Tracks whether this process is the alive Bridge Manager for the IPC namespace.
-  bool is_bridge_manager;
+  enum process_role role;
   pid_t global_pid;
   pid_t local_pid;
   struct mempool_entry * mempool_entry;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -586,9 +586,10 @@ static struct entry_node * find_message_entry(
 }
 
 // Forward declaration
-static int get_process_num(const struct ipc_namespace * ipc_ns);
-static int get_process_num_in_domain(const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
-static int get_alive_process_num_in_domain(
+static int get_process_num_except_unlink_daemon(const struct ipc_namespace * ipc_ns);
+static int get_process_num_in_domain_except_unlink_daemon(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
+static int get_alive_process_num_in_domain_except_unlink_daemon(
   const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
 
 // Release subscriber reference from message entry (set boolean flag to false).
@@ -794,7 +795,23 @@ static bool has_alive_bridge_manager(const struct ipc_namespace * ipc_ns, const 
   {
     if (
       ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
-      proc_info->is_bridge_manager && !proc_info->exited) {
+      proc_info->role == PROCESS_ROLE_BRIDGE_MANAGER && !proc_info->exited) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Namespace-scoped, unlike the bridge manager.
+static bool has_alive_unlink_daemon(const struct ipc_namespace * ipc_ns)
+{
+  struct process_info * proc_info;
+  int bkt;
+  hash_for_each(proc_info_htable, bkt, proc_info, node)
+  {
+    if (
+      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->role == PROCESS_ROLE_UNLINK_DAEMON &&
+      !proc_info->exited) {
       return true;
     }
   }
@@ -802,10 +819,22 @@ static bool has_alive_bridge_manager(const struct ipc_namespace * ipc_ns, const 
 }
 
 int agnocast_ioctl_add_process(
-  const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_bridge_manager,
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const enum process_role role,
   const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret)
 {
   int ret = 0;
+
+  if (
+    role != PROCESS_ROLE_APPLICATION && role != PROCESS_ROLE_BRIDGE_MANAGER &&
+    role != PROCESS_ROLE_UNLINK_DAEMON) {
+    return -EINVAL;
+  }
+
+  // Keeps the unlink daemon the only holder of AGNOCAST_DOMAIN_ID_NONE, which the domain-scoped
+  // counters rely on. The daemon's own domain_id is assigned below regardless of what it sends.
+  if (role != PROCESS_ROLE_UNLINK_DAEMON && domain_id == AGNOCAST_DOMAIN_ID_NONE) {
+    return -EINVAL;
+  }
 
   down_write(&global_htables_rwsem);
 
@@ -814,11 +843,16 @@ int agnocast_ioctl_add_process(
     ret = -EINVAL;
     goto unlock;
   }
-  ioctl_ret->ret_unlink_daemon_exist = (get_process_num(ipc_ns) > 0);
+  ioctl_ret->ret_unlink_daemon_exist = has_alive_unlink_daemon(ipc_ns);
   ioctl_ret->ret_bridge_daemon_exist = has_alive_bridge_manager(ipc_ns, domain_id);
   ioctl_ret->ret_discovery_agent_exist = (agnocast_find_discovery_agent(ipc_ns, domain_id) != NULL);
 
-  if (is_bridge_manager && ioctl_ret->ret_bridge_daemon_exist) {
+  // Deciding under the write lock add_process already holds is what stops two daemons starting
+  // at once from both registering.
+  if (role == PROCESS_ROLE_BRIDGE_MANAGER && ioctl_ret->ret_bridge_daemon_exist) {
+    goto unlock;
+  }
+  if (role == PROCESS_ROLE_UNLINK_DAEMON && ioctl_ret->ret_unlink_daemon_exist) {
     goto unlock;
   }
 
@@ -829,7 +863,7 @@ int agnocast_ioctl_add_process(
   }
 
   new_proc_info->exited = false;
-  new_proc_info->is_bridge_manager = is_bridge_manager;
+  new_proc_info->role = role;
   new_proc_info->global_pid = pid;
 #ifndef KUNIT_BUILD
   new_proc_info->local_pid = convert_pid_to_local(pid);
@@ -845,7 +879,8 @@ int agnocast_ioctl_add_process(
   }
 
   new_proc_info->ipc_ns = ipc_ns;
-  new_proc_info->domain_id = domain_id;
+  new_proc_info->domain_id =
+    (role == PROCESS_ROLE_UNLINK_DAEMON) ? AGNOCAST_DOMAIN_ID_NONE : domain_id;
 
   INIT_HLIST_NODE(&new_proc_info->node);
   uint32_t hash_val = hash_min(new_proc_info->global_pid, PROC_INFO_HASH_BITS);
@@ -1600,7 +1635,8 @@ pid_t agnocast_ioctl_get_exit_process(
 }
 
 void agnocast_commit_exit_process(
-  const struct ipc_namespace * ipc_ns, pid_t global_pid, bool * ret_daemon_should_exit)
+  const struct ipc_namespace * ipc_ns, pid_t global_pid, pid_t caller_pid,
+  bool * ret_daemon_should_exit)
 {
   down_write(&global_htables_rwsem);
 
@@ -1612,7 +1648,18 @@ void agnocast_commit_exit_process(
     }
   }
 
-  *ret_daemon_should_exit = (get_process_num(ipc_ns) == 0);
+  *ret_daemon_should_exit = (get_process_num_except_unlink_daemon(ipc_ns) == 0);
+
+  // Deregistering only on death would leave a window where a starting process is told a daemon
+  // exists and skips spawning its replacement.
+  if (*ret_daemon_should_exit && caller_pid >= 0) {
+    struct process_info * caller_info = agnocast_find_process_info(caller_pid);
+    if (caller_info && caller_info->role == PROCESS_ROLE_UNLINK_DAEMON) {
+      hash_del_rcu(&caller_info->node);
+      kfree_rcu(caller_info, rcu_head);
+      free_memory(caller_pid);
+    }
+  }
 
   up_write(&global_htables_rwsem);
 }
@@ -2763,38 +2810,22 @@ unlock:
   return ret;
 }
 
-static int get_process_num(const struct ipc_namespace * ipc_ns)
+// Counting the unlink daemon would keep it from ever deciding the namespace is done.
+static int get_process_num_except_unlink_daemon(const struct ipc_namespace * ipc_ns)
 {
   int count = 0;
   struct process_info * proc_info;
   int bkt_proc_info;
   hash_for_each(proc_info_htable, bkt_proc_info, proc_info, node)
   {
-    if (ipc_eq(ipc_ns, proc_info->ipc_ns)) {
+    if (ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->role != PROCESS_ROLE_UNLINK_DAEMON) {
       count++;
     }
   }
   return count;
 }
 
-static int get_process_num_in_domain(const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
-{
-  int count = 0;
-  struct process_info * proc_info;
-  int bkt_proc_info;
-  hash_for_each(proc_info_htable, bkt_proc_info, proc_info, node)
-  {
-    if (ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id) {
-      count++;
-    }
-  }
-  return count;
-}
-
-// Like get_process_num_in_domain() but excludes processes that have exited and are still
-// pending cleanup. The discovery agent tracks live endpoints, so an exited entry that lingers
-// until the unlink daemon drains it must not gate the agent's spawn or self-exit.
-static int get_alive_process_num_in_domain(
+static int get_process_num_in_domain_except_unlink_daemon(
   const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
 {
   int count = 0;
@@ -2804,7 +2835,28 @@ static int get_alive_process_num_in_domain(
   {
     if (
       ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
-      !proc_info->exited) {
+      proc_info->role != PROCESS_ROLE_UNLINK_DAEMON) {
+      count++;
+    }
+  }
+  return count;
+}
+
+// Like get_process_num_in_domain_except_unlink_daemon() but also excludes processes that have
+// exited and are still pending cleanup. The discovery agent tracks live endpoints, so an exited
+// entry that lingers until the unlink daemon drains it must not gate the agent's spawn or
+// self-exit.
+static int get_alive_process_num_in_domain_except_unlink_daemon(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
+{
+  int count = 0;
+  struct process_info * proc_info;
+  int bkt_proc_info;
+  hash_for_each(proc_info_htable, bkt_proc_info, proc_info, node)
+  {
+    if (
+      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
+      !proc_info->exited && proc_info->role != PROCESS_ROLE_UNLINK_DAEMON) {
       count++;
     }
   }
@@ -2816,7 +2868,7 @@ int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
   down_write(&global_htables_rwsem);
   struct process_info * proc_info = agnocast_find_process_info(pid);
   if (proc_info) {
-    proc_info->is_bridge_manager = false;
+    proc_info->role = PROCESS_ROLE_APPLICATION;
   }
   up_write(&global_htables_rwsem);
   return 0;
@@ -2850,13 +2902,14 @@ int agnocast_ioctl_discovery_agent_should_exit(
 {
   if (!commit) {
     down_read(&global_htables_rwsem);
-    *ret_should_exit = (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0);
+    *ret_should_exit =
+      (get_alive_process_num_in_domain_except_unlink_daemon(ipc_ns, domain_id) == 0);
     up_read(&global_htables_rwsem);
     return 0;
   }
 
   down_write(&global_htables_rwsem);
-  if (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0) {
+  if (get_alive_process_num_in_domain_except_unlink_daemon(ipc_ns, domain_id) == 0) {
     agnocast_remove_discovery_agent_by_pid(pid);
     *ret_should_exit = true;
   } else {
@@ -2919,12 +2972,11 @@ int agnocast_ioctl_check_and_request_bridge_shutdown(
   down_write(&global_htables_rwsem);
   // A bridge manager is per (ipc_ns, domain), so it must shut down once its
   // own domain is empty -- counting the whole namespace would keep it alive while an
-  // unrelated domain is busy. The manager itself is the remaining process (count == 1),
-  // and poll_for_unlink is not registered here, so it is excluded.
-  if (get_process_num_in_domain(ipc_ns, get_process_domain_id(pid)) <= 1) {
+  // unrelated domain is busy. The manager itself is the remaining process (count == 1).
+  if (get_process_num_in_domain_except_unlink_daemon(ipc_ns, get_process_domain_id(pid)) <= 1) {
     struct process_info * proc_info = agnocast_find_process_info(pid);
     if (proc_info) {
-      proc_info->is_bridge_manager = false;
+      proc_info->role = PROCESS_ROLE_APPLICATION;
     }
     ioctl_ret->ret_should_shutdown = true;
   } else {
@@ -2953,9 +3005,9 @@ static long add_process_cmd(union ioctl_add_process_args __user * arg)
 
   union ioctl_add_process_args add_process_args;
   if (copy_from_user(&add_process_args, arg, sizeof(add_process_args))) return -EFAULT;
-  bool is_bridge_manager = add_process_args.is_bridge_manager;
+  enum process_role role = (enum process_role)add_process_args.role;
   uint32_t domain_id = add_process_args.domain_id;
-  ret = agnocast_ioctl_add_process(pid, ipc_ns, is_bridge_manager, domain_id, &add_process_args);
+  ret = agnocast_ioctl_add_process(pid, ipc_ns, role, domain_id, &add_process_args);
   if (ret == 0) {
     if (copy_to_user(arg, &add_process_args, sizeof(add_process_args))) return -EFAULT;
   }
@@ -3199,7 +3251,7 @@ static long get_exit_process_cmd(struct ioctl_get_exit_process_args __user * arg
 
   // Commit: free proc_info. Safe because user-space already has ret_pid.
   bool daemon_should_exit = false;
-  agnocast_commit_exit_process(ipc_ns, global_pid, &daemon_should_exit);
+  agnocast_commit_exit_process(ipc_ns, global_pid, current->tgid, &daemon_should_exit);
 
   // Patch ret_daemon_should_exit. Not fatal: when a pid was returned, its proc_info has already
   // been committed, so -EFAULT would make the daemon exit while discarding the ret_pid whose shm

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -811,9 +811,7 @@ static bool has_alive_unlink_daemon(const struct ipc_namespace * ipc_ns)
   int bkt;
   hash_for_each(proc_info_htable, bkt, proc_info, node)
   {
-    if (
-      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->role == PROCESS_ROLE_UNLINK_DAEMON &&
-      !proc_info->exited) {
+    if (ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->role == PROCESS_ROLE_UNLINK_DAEMON) {
       return true;
     }
   }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -827,12 +827,18 @@ int agnocast_ioctl_add_process(
   if (
     role != PROCESS_ROLE_APPLICATION && role != PROCESS_ROLE_BRIDGE_MANAGER &&
     role != PROCESS_ROLE_UNLINK_DAEMON) {
+    dev_warn(
+      agnocast_device, "Process (pid=%d) has an unknown role (%u). (%s)\n", pid, (uint32_t)role,
+      __func__);
     return -EINVAL;
   }
 
   // Keeps the unlink daemon the only holder of AGNOCAST_DOMAIN_ID_NONE, which the domain-scoped
   // counters rely on. The daemon's own domain_id is assigned below regardless of what it sends.
   if (role != PROCESS_ROLE_UNLINK_DAEMON && domain_id == AGNOCAST_DOMAIN_ID_NONE) {
+    dev_warn(
+      agnocast_device, "Process (pid=%d) cannot use the reserved domain_id (%u). (%s)\n", pid,
+      domain_id, __func__);
     return -EINVAL;
   }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -802,7 +802,9 @@ static bool has_alive_bridge_manager(const struct ipc_namespace * ipc_ns, const 
   return false;
 }
 
-// Namespace-scoped, unlike the bridge manager.
+// Namespace-scoped, unlike the bridge manager. Liveness lags the exit worker: a daemon killed
+// abruptly still reads as alive until the worker drains its pid, so a process registering in that
+// window is not told to spawn a replacement.
 static bool has_alive_unlink_daemon(const struct ipc_namespace * ipc_ns)
 {
   struct process_info * proc_info;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1651,8 +1651,9 @@ void agnocast_commit_exit_process(
   *ret_daemon_should_exit = (get_process_num_except_unlink_daemon(ipc_ns) == 0);
 
   // Deregistering only on death would leave a window where a starting process is told a daemon
-  // exists and skips spawning its replacement.
-  if (*ret_daemon_should_exit && caller_pid >= 0) {
+  // exists and skips spawning its replacement. Restricted to the idle poll because that is the
+  // only call whose flag poll_for_unlink() acts on; the drain loop discards the rest.
+  if (*ret_daemon_should_exit && global_pid < 0 && caller_pid >= 0) {
     struct process_info * caller_info = agnocast_find_process_info(caller_pid);
     if (caller_info && caller_info->role == PROCESS_ROLE_UNLINK_DAEMON) {
       hash_del_rcu(&caller_info->node);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -833,8 +833,8 @@ int agnocast_ioctl_add_process(
     return -EINVAL;
   }
 
-  // Keeps the unlink daemon the only holder of AGNOCAST_DOMAIN_ID_NONE, which the domain-scoped
-  // counters rely on. The daemon's own domain_id is assigned below regardless of what it sends.
+  // AGNOCAST_DOMAIN_ID_NONE marks the daemon as belonging to no domain, so no other process may
+  // hold it. The daemon's own domain_id is assigned below regardless of what it sends.
   if (role != PROCESS_ROLE_UNLINK_DAEMON && domain_id == AGNOCAST_DOMAIN_ID_NONE) {
     dev_warn(
       agnocast_device, "Process (pid=%d) cannot use the reserved domain_id (%u). (%s)\n", pid,
@@ -2852,7 +2852,8 @@ static int get_process_num_in_domain_except_unlink_daemon(
 // Like get_process_num_in_domain_except_unlink_daemon() but also excludes processes that have
 // exited and are still pending cleanup. The discovery agent tracks live endpoints, so an exited
 // entry that lingers until the unlink daemon drains it must not gate the agent's spawn or
-// self-exit.
+// self-exit. Its domain_id reaches this unvalidated from user space, so the daemon has to be
+// excluded by role: a caller passing AGNOCAST_DOMAIN_ID_NONE would otherwise match it.
 static int get_alive_process_num_in_domain_except_unlink_daemon(
   const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
 {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
@@ -15,7 +15,10 @@ static void setup_process_in_domain(struct kunit * test, const pid_t pid, const 
 {
   union ioctl_add_process_args args;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+    test,
+    agnocast_ioctl_add_process(
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &args),
+    0);
 }
 
 static void add_publisher_named(struct kunit * test, const pid_t pid, const char * topic_name)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -14,7 +14,8 @@ void test_case_add_process_normal(struct kunit * test)
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret = agnocast_ioctl_add_process(
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
@@ -32,12 +33,14 @@ void test_case_add_process_many(struct kunit * test)
   for (int i = 0; i < mempool_num - 1; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+    agnocast_ioctl_add_process(
+      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
   }
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret = agnocast_ioctl_add_process(
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
 
   // ================================================
   // Assert
@@ -55,8 +58,10 @@ void test_case_add_process_twice(struct kunit * test)
 
   pid_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret1 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
-  int ret2 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret1 = agnocast_ioctl_add_process(
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+  int ret2 = agnocast_ioctl_add_process(
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, ret2, -EINVAL);
@@ -72,25 +77,271 @@ void test_case_add_process_bridge_manager_per_domain(struct kunit * test)
   KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
 
   union ioctl_add_process_args args_d0;
-  int ret_d0 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0);
+  int ret_d0 = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &args_d0);
   KUNIT_EXPECT_EQ(test, ret_d0, 0);
   KUNIT_EXPECT_FALSE(test, args_d0.ret_bridge_daemon_exist);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
 
   // Different domain: not suppressed, so it is added and sees no existing manager.
   union ioctl_add_process_args args_d1;
-  int ret_d1 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 1, &args_d1);
+  int ret_d1 = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, &args_d1);
   KUNIT_EXPECT_EQ(test, ret_d1, 0);
   KUNIT_EXPECT_FALSE(test, args_d1.ret_bridge_daemon_exist);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
 
   // Same domain as the first: a manager already exists, so it is suppressed.
   union ioctl_add_process_args args_d0_again;
-  int ret_d0_again =
-    agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0_again);
+  int ret_d0_again = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &args_d0_again);
   KUNIT_EXPECT_EQ(test, ret_d0_again, 0);
   KUNIT_EXPECT_TRUE(test, args_d0_again.ret_bridge_daemon_exist);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+}
+
+// ret_unlink_daemon_exist reports a registered daemon, not a non-empty namespace.
+void test_case_add_process_unlink_daemon_registration(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  union ioctl_add_process_args app_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+    0);
+  KUNIT_ASSERT_FALSE(test, app_args.ret_unlink_daemon_exist);
+
+  // Act
+  union ioctl_add_process_args daemon_args;
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_FALSE(test, daemon_args.ret_unlink_daemon_exist);
+  union ioctl_add_process_args later_args;
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &later_args),
+    0);
+  KUNIT_EXPECT_TRUE(test, later_args.ret_unlink_daemon_exist);
+}
+
+// Two processes starting at once can both decide to spawn a daemon; only one may register.
+void test_case_add_process_unlink_daemon_duplicate_refused(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  union ioctl_add_process_args first_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &first_args),
+    0);
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 1);
+
+  // Act
+  union ioctl_add_process_args second_args;
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &second_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_TRUE(test, second_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+}
+
+// A dead daemon is observable, so the exited entries it left behind must not stand in for it.
+void test_case_add_process_unlink_daemon_respawns_after_death(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  const pid_t app_pid = pid++;
+  union ioctl_add_process_args app_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+    0);
+  const pid_t daemon_pid = pid++;
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+  agnocast_process_exit_cleanup(app_pid);
+  agnocast_process_exit_cleanup(daemon_pid);
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(app_pid));
+
+  // Act
+  union ioctl_add_process_args next_args;
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_FALSE(test, next_args.ret_unlink_daemon_exist);
+}
+
+// The daemon is what drains the table, so on its own it has to be told the namespace is done.
+void test_case_add_process_unlink_daemon_is_not_counted_as_work(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+
+  // Act
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, -1, -1, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+}
+
+// An application's entry is left pending for the daemon to drain; the daemon's own is not.
+void test_case_add_process_unlink_daemon_removed_on_death(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  const pid_t app_pid = pid++;
+  union ioctl_add_process_args app_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+    0);
+  const pid_t daemon_pid = pid++;
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+
+  // Act
+  agnocast_process_exit_cleanup(app_pid);
+  agnocast_process_exit_cleanup(daemon_pid);
+
+  // Assert
+  struct ioctl_get_exit_process_args exit_args = {};
+  KUNIT_EXPECT_EQ(
+    test, agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &exit_args), app_pid);
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, app_pid, -1, &daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &exit_args), -1);
+}
+
+// A process starting between the exit decision and the daemon's death spawns a replacement.
+void test_case_add_process_unlink_daemon_deregisters_when_told_to_exit(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  const pid_t daemon_pid = pid++;
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+
+  // Act
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, -1, daemon_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  // The daemon process is still running at this point.
+  union ioctl_add_process_args next_args;
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args),
+    0);
+  KUNIT_EXPECT_FALSE(test, next_args.ret_unlink_daemon_exist);
+}
+
+// Deregistering the daemon early must release its mempool slot too, which nothing else will:
+// its exit no longer reaches agnocast_process_exit_cleanup().
+void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  const pid_t daemon_pid = pid++;
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, -1, daemon_pid, &daemon_should_exit);
+  KUNIT_ASSERT_TRUE(test, daemon_should_exit);
+
+  // Act
+  int ret = 0;
+  for (int i = 0; i < mempool_num; i++) {
+    union ioctl_add_process_args args;
+    ret = agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    if (ret != 0) break;
+  }
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), mempool_num);
+}
+
+void test_case_add_process_rejects_unknown_role(struct kunit * test)
+{
+  // Arrange
+  union ioctl_add_process_args args;
+
+  // Act
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, (enum process_role)(PROCESS_ROLE_UNLINK_DAEMON + 1), 0, &args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 0);
+}
+
+void test_case_add_process_rejects_the_daemon_domain_id(struct kunit * test)
+{
+  // Arrange
+  union ioctl_add_process_args args;
+
+  // Act
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, AGNOCAST_DOMAIN_ID_NONE, &args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 0);
+}
+
+// The daemon's domain_id is assigned by role, so whatever it sends is accepted and ignored.
+void test_case_add_process_daemon_may_send_the_daemon_domain_id(struct kunit * test)
+{
+  // Arrange
+  union ioctl_add_process_args args;
+
+  // Act
+  int ret = agnocast_ioctl_add_process(
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, AGNOCAST_DOMAIN_ID_NONE, &args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
 }
 
 void test_case_add_process_too_many(struct kunit * test)
@@ -103,11 +354,13 @@ void test_case_add_process_too_many(struct kunit * test)
   for (int i = 0; i < mempool_num; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+    agnocast_ioctl_add_process(
+      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
   }
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret = agnocast_ioctl_add_process(
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
 
   // ================================================
   // Assert

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -240,6 +240,44 @@ void test_case_add_process_unlink_daemon_removed_on_death(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &exit_args), -1);
 }
 
+// poll_for_unlink()'s drain loop discards the flag from a commit that returned a pid, so
+// deregistering there would leave the daemon polling on as an unregistered ghost.
+void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  const pid_t app_pid = pid++;
+  union ioctl_add_process_args app_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+    0);
+  const pid_t daemon_pid = pid++;
+  union ioctl_add_process_args daemon_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+    0);
+  agnocast_process_exit_cleanup(app_pid);
+
+  // Act
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, app_pid, daemon_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+  union ioctl_add_process_args next_args;
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args),
+    0);
+  KUNIT_EXPECT_TRUE(test, next_args.ret_unlink_daemon_exist);
+}
+
 // A process starting between the exit decision and the daemon's death spawns a replacement.
 void test_case_add_process_unlink_daemon_deregisters_when_told_to_exit(struct kunit * test)
 {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -2,21 +2,22 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_ADD_PROCESS                                                      \
-  KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
-    KUNIT_CASE(test_case_add_process_twice),                                        \
-    KUNIT_CASE(test_case_add_process_bridge_manager_per_domain),                    \
-    KUNIT_CASE(test_case_add_process_too_many),                                     \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_registration),                   \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_duplicate_refused),              \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_respawns_after_death),           \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_is_not_counted_as_work),         \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_removed_on_death),               \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_deregisters_when_told_to_exit),  \
-    KUNIT_CASE(test_case_add_process_rejects_unknown_role),                         \
-    KUNIT_CASE(test_case_add_process_rejects_the_daemon_domain_id),                 \
-    KUNIT_CASE(test_case_add_process_daemon_may_send_the_daemon_domain_id),         \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot)
+#define TEST_CASES_ADD_PROCESS                                                             \
+  KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many),        \
+    KUNIT_CASE(test_case_add_process_twice),                                               \
+    KUNIT_CASE(test_case_add_process_bridge_manager_per_domain),                           \
+    KUNIT_CASE(test_case_add_process_too_many),                                            \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_registration),                          \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_duplicate_refused),                     \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_respawns_after_death),                  \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_is_not_counted_as_work),                \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_removed_on_death),                      \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_deregisters_when_told_to_exit),         \
+    KUNIT_CASE(test_case_add_process_rejects_unknown_role),                                \
+    KUNIT_CASE(test_case_add_process_rejects_the_daemon_domain_id),                        \
+    KUNIT_CASE(test_case_add_process_daemon_may_send_the_daemon_domain_id),                \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot), \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_stays_registered_while_draining)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
@@ -33,3 +34,4 @@ void test_case_add_process_rejects_unknown_role(struct kunit * test);
 void test_case_add_process_rejects_the_daemon_domain_id(struct kunit * test);
 void test_case_add_process_daemon_may_send_the_daemon_domain_id(struct kunit * test);
 void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(struct kunit * test);
+void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -6,10 +6,30 @@
   KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
     KUNIT_CASE(test_case_add_process_twice),                                        \
     KUNIT_CASE(test_case_add_process_bridge_manager_per_domain),                    \
-    KUNIT_CASE(test_case_add_process_too_many)
+    KUNIT_CASE(test_case_add_process_too_many),                                     \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_registration),                   \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_duplicate_refused),              \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_respawns_after_death),           \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_is_not_counted_as_work),         \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_removed_on_death),               \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_deregisters_when_told_to_exit),  \
+    KUNIT_CASE(test_case_add_process_rejects_unknown_role),                         \
+    KUNIT_CASE(test_case_add_process_rejects_the_daemon_domain_id),                 \
+    KUNIT_CASE(test_case_add_process_daemon_may_send_the_daemon_domain_id),         \
+    KUNIT_CASE(test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
 void test_case_add_process_twice(struct kunit * test);
 void test_case_add_process_bridge_manager_per_domain(struct kunit * test);
 void test_case_add_process_too_many(struct kunit * test);
+void test_case_add_process_unlink_daemon_registration(struct kunit * test);
+void test_case_add_process_unlink_daemon_duplicate_refused(struct kunit * test);
+void test_case_add_process_unlink_daemon_respawns_after_death(struct kunit * test);
+void test_case_add_process_unlink_daemon_is_not_counted_as_work(struct kunit * test);
+void test_case_add_process_unlink_daemon_removed_on_death(struct kunit * test);
+void test_case_add_process_unlink_daemon_deregisters_when_told_to_exit(struct kunit * test);
+void test_case_add_process_rejects_unknown_role(struct kunit * test);
+void test_case_add_process_rejects_the_daemon_domain_id(struct kunit * test);
+void test_case_add_process_daemon_may_send_the_daemon_domain_id(struct kunit * test);
+void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -18,15 +18,16 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
 static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret =
-    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
@@ -7,20 +7,22 @@
 
 static pid_t pid_bs = 8000;
 
-// Registering with is_bridge_manager=true should succeed and set the flag
+// Registering as a bridge manager should succeed and record the role
 // so that subsequent processes see ret_bridge_daemon_exist=true
 void test_case_bridge_manager_flag_set_on_registration(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
+  int ret = agnocast_ioctl_add_process(
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Verify the flag was set by checking a new process sees it
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
+  ret = agnocast_ioctl_add_process(
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_bridge_daemon_exist);
 }
@@ -32,25 +34,28 @@ void test_case_bridge_manager_detected_by_new_process(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
+  int ret = agnocast_ioctl_add_process(
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register normal process - should see bridge manager exists
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
+  ret = agnocast_ioctl_add_process(
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_bridge_daemon_exist);
 }
 
-// notify_bridge_shutdown clears is_bridge_manager, so a new process
+// notify_bridge_shutdown clears the bridge manager role, so a new process
 // should receive ret_bridge_daemon_exist=false
 void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
+  int ret = agnocast_ioctl_add_process(
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Notify shutdown
@@ -59,7 +64,8 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   // Register normal process - should see no bridge manager
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
+  ret = agnocast_ioctl_add_process(
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_bridge_daemon_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -8,13 +8,14 @@
 static pid_t pid_carbs = 9000;
 
 // When only the bridge manager exists, check_and_request_bridge_shutdown
-// should return ret_should_shutdown=true and clear is_bridge_manager
+// should return ret_should_shutdown=true and clear the bridge manager role
 void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
 {
   // Register bridge manager only
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
+  int ret = agnocast_ioctl_add_process(
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - only bridge manager exists (process_num == 1)
@@ -24,28 +25,31 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, shutdown_args.ret_should_shutdown);
 
-  // Verify is_bridge_manager was cleared - new process should not see bridge manager
+  // Verify the role was cleared - new process should not see bridge manager
   pid_t normal_pid = pid_carbs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
+  ret = agnocast_ioctl_add_process(
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_bridge_daemon_exist);
 }
 
 // When other processes exist, check_and_request_bridge_shutdown
-// should return ret_should_shutdown=false and keep is_bridge_manager set
+// should return ret_should_shutdown=false and keep the bridge manager role
 void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
+  int ret = agnocast_ioctl_add_process(
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register another process
   pid_t other_pid = pid_carbs++;
   union ioctl_add_process_args other_args = {};
-  ret = agnocast_ioctl_add_process(other_pid, current->nsproxy->ipc_ns, false, 0, &other_args);
+  ret = agnocast_ioctl_add_process(
+    other_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - other process exists (process_num > 1)
@@ -55,10 +59,11 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, shutdown_args.ret_should_shutdown);
 
-  // Verify is_bridge_manager is still set - new process should see bridge manager
+  // Verify the role is unchanged - new process should see bridge manager
   pid_t new_pid = pid_carbs++;
   union ioctl_add_process_args new_args = {};
-  ret = agnocast_ioctl_add_process(new_pid, current->nsproxy->ipc_ns, false, 0, &new_args);
+  ret = agnocast_ioctl_add_process(
+    new_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &new_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, new_args.ret_bridge_daemon_exist);
 }
@@ -70,13 +75,15 @@ void test_case_check_and_request_bridge_shutdown_per_domain(struct kunit * test)
   // Manager is the only process in domain 1.
   pid_t mgr_d1 = pid_carbs++;
   union ioctl_add_process_args mgr_args = {};
-  int ret = agnocast_ioctl_add_process(mgr_d1, current->nsproxy->ipc_ns, true, 1, &mgr_args);
+  int ret = agnocast_ioctl_add_process(
+    mgr_d1, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, &mgr_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // A normal process keeps domain 2 busy.
   pid_t other_d2 = pid_carbs++;
   union ioctl_add_process_args other_args = {};
-  ret = agnocast_ioctl_add_process(other_d2, current->nsproxy->ipc_ns, false, 2, &other_args);
+  ret = agnocast_ioctl_add_process(
+    other_d2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 2, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Domain 1 holds only the manager, so it should shut down despite domain 2 being busy.

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.c
@@ -68,7 +68,10 @@ void test_case_discovery_agent_exist_reflects_registration(struct kunit * test)
 
   union ioctl_add_process_args before;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 12, &before), 0);
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, &before),
+    0);
   KUNIT_EXPECT_FALSE(test, before.ret_discovery_agent_exist);  // process alive, no agent yet
 
   struct ioctl_add_discovery_agent_args reg;
@@ -77,7 +80,10 @@ void test_case_discovery_agent_exist_reflects_registration(struct kunit * test)
 
   union ioctl_add_process_args after;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 12, &after), 0);
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, &after),
+    0);
   KUNIT_EXPECT_TRUE(test, after.ret_discovery_agent_exist);  // now an agent is registered
 }
 
@@ -113,7 +119,10 @@ void test_case_discovery_agent_commit_exit_vetoed_when_busy(struct kunit * test)
 
   union ioctl_add_process_args proc;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 14, &proc), 0);
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 14, &proc),
+    0);
 
   bool should_exit = true;
   KUNIT_ASSERT_EQ(
@@ -165,7 +174,9 @@ void test_case_discovery_agent_orphan_race(struct kunit * test)
 
   union ioctl_add_process_args p2;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 16, &p2), 0);
+    test,
+    agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 16, &p2),
+    0);
   KUNIT_EXPECT_FALSE(test, p2.ret_discovery_agent_exist);  // A is gone -> P2 must spawn one
 
   const pid_t agent_b = pid++;
@@ -214,7 +225,10 @@ void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test
   const pid_t app_pid = pid++;
   union ioctl_add_process_args app;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(app_pid, current->nsproxy->ipc_ns, false, 19, &app), 0);
+    test,
+    agnocast_ioctl_add_process(
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 19, &app),
+    0);
 
   agnocast_enqueue_exit_pid(app_pid);
   msleep(20);  // let exit_worker_thread mark it exited (still present, not yet drained)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -24,7 +24,8 @@ static void setup_processes(struct kunit * test, const int process_num)
   union ioctl_add_process_args ioctl_ret;
   for (int i = 0; i < process_num; i++) {
     const pid_t pid = PID_BASE + i;
-    int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+    int ret = agnocast_ioctl_add_process(
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));
   }
@@ -34,7 +35,8 @@ static void setup_processes(struct kunit * test, const int process_num)
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -29,7 +29,10 @@ static uint64_t setup_process_in_domain(
 {
   union ioctl_add_process_args args;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+    test,
+    agnocast_ioctl_add_process(
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &args),
+    0);
   return args.ret_addr;
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.c
@@ -19,7 +19,8 @@ static const uint32_t QOS_DEPTH = 1;
 static void setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -16,7 +16,8 @@ static const pid_t PID = 1000;
 static void setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
@@ -30,7 +31,7 @@ void test_case_get_exit_process_idle_poll_empty_namespace(struct kunit * test)
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
 
   bool daemon_should_exit = false;
-  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, -1, &daemon_should_exit);
 
   // Assert
   KUNIT_EXPECT_EQ(test, global_pid, -1);
@@ -49,7 +50,7 @@ void test_case_get_exit_process_idle_poll_process_remains(struct kunit * test)
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
 
   bool daemon_should_exit = true;
-  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, -1, &daemon_should_exit);
 
   // Assert
   KUNIT_EXPECT_EQ(test, global_pid, -1);
@@ -69,14 +70,15 @@ void test_case_get_exit_process_commit_last_process(struct kunit * test)
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
 
   bool daemon_should_exit = false;
-  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, -1, &daemon_should_exit);
 
   struct ioctl_get_exit_process_args next_args = {};
   const pid_t next_global_pid =
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &next_args);
 
   bool next_daemon_should_exit = false;
-  agnocast_commit_exit_process(current->nsproxy->ipc_ns, next_global_pid, &next_daemon_should_exit);
+  agnocast_commit_exit_process(
+    current->nsproxy->ipc_ns, next_global_pid, -1, &next_daemon_should_exit);
 
   // Assert: the flag is still derived on the idle poll that follows the commit.
   KUNIT_EXPECT_EQ(test, global_pid, PID);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
@@ -20,8 +20,8 @@ static const uint32_t OTHER_DOMAIN_ID = 2;
 static uint64_t setup_process(struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret =
-    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   return add_process_args.ret_addr;
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -15,7 +15,8 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -15,7 +15,8 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -19,7 +19,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -37,7 +37,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -54,7 +54,7 @@ static void setup_one_publisher_with_bridge(struct kunit * test, char * topic_na
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -184,7 +184,7 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -14,7 +14,8 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -20,7 +20,8 @@ static void setup_one_subscriber_impl(
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+    &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -48,7 +49,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -64,8 +65,8 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
   pid_t intra_pid = current->tgid;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(intra_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    intra_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -95,7 +96,8 @@ static void setup_current_publisher_in_domain(
 {
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    current->tgid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+    current->tgid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+    &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -14,7 +14,8 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -14,15 +14,16 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
 static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret =
-    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -14,15 +14,16 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
 static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret =
-    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -48,7 +48,8 @@ static topic_local_id_t setup_one_subscriber_in_domain_with_eventfd(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
   return add_subscriber_with_eventfd(
     test, subscriber_pid, eventfd, ignore_local_publications, sub_is_bridge);
@@ -75,7 +76,8 @@ static void setup_publisher_in_domain(
   union ioctl_add_process_args add_process_args;
   KUNIT_ASSERT_EQ(
     test,
-    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    agnocast_ioctl_add_process(
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
 
@@ -442,7 +444,7 @@ void test_case_publish_msg_does_not_signal_take_sub(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
     0);
 
   const int take_eventfd = 0;
@@ -483,7 +485,7 @@ void test_case_publish_msg_signals_large_fanout(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
     0);
   for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
     add_subscriber_with_eventfd(test, subscriber_pid, eventfd, false, is_bridge);
@@ -699,7 +701,7 @@ void test_case_publish_msg_no_process(struct kunit * test)
   KUNIT_ASSERT_EQ(test, global_pid, exiting_pid);
   KUNIT_ASSERT_EQ(test, get_exit_args.ret_pid, exiting_pid);
   bool daemon_should_exit = false;
-  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, -1, &daemon_should_exit);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -26,7 +26,8 @@ static void setup_subscriber_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -66,7 +67,8 @@ static void setup_publisher_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      publisher_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
 
@@ -700,7 +702,8 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -743,7 +746,7 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -781,7 +784,7 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -1007,7 +1010,8 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1050,7 +1054,8 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -23,7 +23,7 @@ static void setup_one_publisher(
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    PUBLISHER_PID, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    PUBLISHER_PID, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH,
@@ -103,7 +103,7 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -151,7 +151,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid1 = 1000;
   union ioctl_add_process_args add_process_args1;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid1, current->nsproxy->ipc_ns, false, 0, &add_process_args1);
+    subscriber_pid1, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -170,7 +170,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid2 = 1001;
   union ioctl_add_process_args add_process_args2;
   int ret5 = agnocast_ioctl_add_process(
-    subscriber_pid2, current->nsproxy->ipc_ns, false, 0, &add_process_args2);
+    subscriber_pid2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args2);
   KUNIT_ASSERT_EQ(test, ret5, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
@@ -227,7 +227,7 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -20,7 +20,8 @@ static const bool IS_BRIDGE = false;
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -21,7 +21,8 @@ static const bool IS_BRIDGE = false;
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -15,7 +15,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -18,7 +18,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -26,7 +26,8 @@ static void setup_subscriber_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -66,7 +67,8 @@ static void setup_publisher_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      publisher_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
 
@@ -793,7 +795,8 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   // Arrange
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -839,7 +842,7 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth1 = 10;
@@ -881,7 +884,7 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -1041,7 +1044,8 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1086,7 +1090,8 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -61,12 +61,19 @@ union ioctl_get_node_names_args {
 };
 #pragma GCC diagnostic pop
 
+// Mirrors enum process_role in the kernel module.
+enum process_role {
+  PROCESS_ROLE_APPLICATION = 0,
+  PROCESS_ROLE_BRIDGE_MANAGER = 1,
+  PROCESS_ROLE_UNLINK_DAEMON = 2,
+};
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 union ioctl_add_process_args {
   struct
   {
-    bool is_bridge_manager;
+    uint32_t role;       // enum process_role
     uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -61,6 +61,9 @@ union ioctl_get_node_names_args {
 };
 #pragma GCC diagnostic pop
 
+// Mirrors AGNOCAST_DOMAIN_ID_NONE in the kernel module.
+#define AGNOCAST_DOMAIN_ID_NONE UINT32_MAX
+
 // Mirrors enum process_role in the kernel module.
 enum process_role {
   PROCESS_ROLE_APPLICATION = 0,

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -175,7 +175,7 @@ void initialize_bridge_allocator(void * mempool_ptr, size_t mempool_size)
 initialize_agnocast_result acquire_agnocast_resources_for_bridge()
 {
   union ioctl_add_process_args add_process_args = {};
-  add_process_args.is_bridge_manager = true;
+  add_process_args.role = PROCESS_ROLE_BRIDGE_MANAGER;
   add_process_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     throw std::runtime_error(std::string("AGNOCAST_ADD_PROCESS_CMD failed: ") + strerror(errno));
@@ -201,6 +201,22 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge()
 
 void poll_for_unlink()
 {
+  // Register so the kernel module can tell a live daemon from a dead one. No domain_id: the
+  // kernel module records this daemon as belonging to none.
+  union ioctl_add_process_args add_process_args = {};
+  add_process_args.role = PROCESS_ROLE_UNLINK_DAEMON;
+  if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
+    RCLCPP_ERROR(logger, "AGNOCAST_ADD_PROCESS_CMD failed: %s", strerror(errno));
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+
+  // Another daemon won the race and registered first; this one has nothing to do.
+  if (add_process_args.ret_unlink_daemon_exist) {
+    close(agnocast_fd);
+    exit(EXIT_SUCCESS);
+  }
+
   while (true) {
     sleep(1);
 
@@ -540,6 +556,7 @@ struct initialize_agnocast_result initialize_agnocast(
   const uint32_t domain_id = get_ros_domain_id();
 
   union ioctl_add_process_args add_process_args = {};
+  add_process_args.role = PROCESS_ROLE_APPLICATION;
   add_process_args.domain_id = domain_id;
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_PROCESS_CMD failed: %s", strerror(errno));
@@ -551,6 +568,8 @@ struct initialize_agnocast_result initialize_agnocast(
   auto bridge_mode = get_bridge_mode();
 
   // Create a shm_unlink daemon process if it doesn't exist in its ipc namespace.
+  // ret_unlink_daemon_exist is only an early-out hint: poll_for_unlink() makes the singleton
+  // decision when it registers.
   if (!add_process_args.ret_unlink_daemon_exist) {
     spawn_daemon_process([]() { poll_for_unlink(); });
   }

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -554,6 +554,11 @@ struct initialize_agnocast_result initialize_agnocast(
 
   // add_process_args is a union, so ADD_PROCESS overwrites domain_id with its ret_* fields.
   const uint32_t domain_id = get_ros_domain_id();
+  if (domain_id == AGNOCAST_DOMAIN_ID_NONE) {
+    RCLCPP_ERROR(logger, "ROS_DOMAIN_ID=%u is reserved by Agnocast", domain_id);
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
 
   union ioctl_add_process_args add_process_args = {};
   add_process_args.role = PROCESS_ROLE_APPLICATION;


### PR DESCRIPTION
## Description

`ret_unlink_daemon_exist` was inferred from `get_process_num() > 0`, a count that includes exited processes still waiting to be drained. The unlink daemon is the only thing that drains them, so once it is gone the count never falls back to zero: no later process is told to spawn a replacement, and the entries and their shm segments are never cleaned up. The condition sustains itself.

Give the daemon an entry of its own. `process_info.is_bridge_manager` becomes `enum process_role` (`APPLICATION` / `BRIDGE_MANAGER` / `UNLINK_DAEMON`), the daemon registers through `AGNOCAST_ADD_PROCESS_CMD`, and `ret_unlink_daemon_exist` reports whether a live daemon is registered. A daemon that loses the race registers nothing and is told to stand down, decided under the write lock `add_process` already holds. The three counters that gate a daemon's shutdown skip it, since it is what they depend on.

Its entry is deleted rather than marked `exited`, in both directions. `agnocast_commit_exit_process()` deregisters it the moment it is told to exit, so a process starting before it actually dies is not told a daemon still exists — as `check_and_request_bridge_shutdown()` does for the bridge manager. `agnocast_process_exit_cleanup()` deletes it on death, since it is the one entry no daemon can drain.

`add_process()` also rejects a role outside the enum, and `AGNOCAST_DOMAIN_ID_NONE` from every role but the daemon, whose `domain_id` is assigned by role. `ROS_DOMAIN_ID=4294967295` therefore fails at startup rather than sharing that id.

Liveness is read only at `AGNOCAST_ADD_PROCESS_CMD`, so a daemon dying in an otherwise static namespace is not noticed until the next process starts.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

New KUnit cases cover registration and the refusal of a second daemon, respawn from a namespace of only exited entries (fails without this change), the daemon not counting as work, its entry and mempool slot released on both exit paths, and the rejected arguments.

## Notes for reviewers

The discovery agent stays in its own table: it is per (namespace, domain), and folding it in would mean reworking its three ioctls and its removal path.

The parent-side check in `initialize_agnocast()` is now an early-out hint rather than authoritative: processes starting at once can each fork a daemon, and all but the first exit as soon as `AGNOCAST_ADD_PROCESS_CMD` refuses them, before `assign_memory()`. Each loser stays a zombie of its parent until the parent exits, since `spawn_daemon_process()` single-forks and never reaps; the bridge manager and the discovery agent have had that shape all along. Whether to bring this back to a constant number of forks, and to double-fork so losers are reparented to init, will be decided by measurement in a follow-up.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-minor-update`


