### PR TITLE
chore(agnocast_cie_thread_configurator): name the IPC gtest target after its contents

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -76,10 +76,10 @@ ament_export_dependencies(agnocast_cie_config_msgs yaml-cpp rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(test_${PROJECT_NAME}
+  ament_add_gtest(test_non_ros_thread_ipc
     test/test_non_ros_thread_ipc.cpp
   )
-  target_link_libraries(test_${PROJECT_NAME} agnocast_thread_configurator)
+  target_link_libraries(test_non_ros_thread_ipc agnocast_thread_configurator)
 
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp


### PR DESCRIPTION
## Description

Part 1/7 of a series of small, behavior-preserving cleanups in `agnocast_cie_thread_configurator` that prepare for extracting unit-testable logic out of `ThreadConfiguratorNode` and `PrerunNode`.

The gtest target for `test/test_non_ros_thread_ipc.cpp` was named `test_${PROJECT_NAME}` (so the binary was `test_agnocast_cie_thread_configurator`), while the other two gtest targets, `test_thread_config` and `test_system_scan`, are named after what they test. Rename it to `test_non_ros_thread_ipc` for consistency. CMake only; no source change.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
