### PR TITLE
refactor(agnocast_cie_thread_configurator): format int64_t thread ids with PRId64

### DIFF
--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -9,6 +9,7 @@
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
 
 #include <algorithm>
+#include <cinttypes>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -118,7 +119,7 @@ void PrerunNode::topic_callback(
   }
 
   RCLCPP_INFO(
-    this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%ld | %s", domain_id,
+    this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%" PRId64 " | %s", domain_id,
     msg->thread_id, msg->callback_group_id.c_str());
 }
 
@@ -126,13 +127,14 @@ void PrerunNode::non_ros_thread_callback(agnocast_cie_thread_configurator::NonRo
 {
   if (non_ros_thread_names_.find(info.name) != non_ros_thread_names_.end()) {
     RCLCPP_ERROR(
-      this->get_logger(), "Duplicate thread_name received: tid=%ld | %s", info.tid,
+      this->get_logger(), "Duplicate thread_name received: tid=%" PRId64 " | %s", info.tid,
       info.name.c_str());
     return;
   }
 
   RCLCPP_INFO(
-    this->get_logger(), "Received NonRosThreadInfo: tid=%ld | %s", info.tid, info.name.c_str());
+    this->get_logger(), "Received NonRosThreadInfo: tid=%" PRId64 " | %s", info.tid,
+    info.name.c_str());
 
   non_ros_thread_names_.insert(std::move(info.name));
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cinttypes>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -421,7 +422,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
 
     if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
         config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
@@ -429,7 +430,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     // Specify nice value
     if (setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure nice value (thread=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
         config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
@@ -440,7 +441,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
 
     if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
         config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
@@ -464,13 +465,13 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
 
     if (sched_setattr(thread_id, &attr, 0) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
         config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
   } else {
     RCLCPP_ERROR(
-      this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%ld)",
+      this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%" PRId64 ")",
       config.policy.c_str(), config.thread_str.c_str(), thread_id);
     return false;
   }
@@ -486,7 +487,7 @@ bool ThreadConfiguratorNode::issue_affinity_syscalls(
     if (policy == "SCHED_DEADLINE") {
       if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
+          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%" PRId64 "): %s",
           thread_str.c_str(), thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
@@ -500,7 +501,7 @@ bool ThreadConfiguratorNode::issue_affinity_syscalls(
       }
       if (sched_setaffinity(thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
+          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%" PRId64 "): %s",
           thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
@@ -570,7 +571,8 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
           agnocast_cie_thread_configurator::parse_manageable_cpu_list(info->affinity))) {
         RCLCPP_ERROR(
           this->get_logger(),
-          "Failed to configure affinity (thread=%s, tid=%ld): per-CPU kernel thread "
+          "Failed to configure affinity (thread=%s, tid=%" PRId64
+          "): per-CPU kernel thread "
           "(PF_NO_SETAFFINITY); the kernel fixes its affinity. Set 'affinity' to %s for this "
           "entry.",
           config.comm.c_str(), info->tid,
@@ -598,8 +600,8 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
 
       if (ok) {
         RCLCPP_INFO(
-          this->get_logger(), "Configured kernel thread (comm=%s, tid=%ld)", config.comm.c_str(),
-          info->tid);
+          this->get_logger(), "Configured kernel thread (comm=%s, tid=%" PRId64 ")",
+          config.comm.c_str(), info->tid);
         outcome.applied.push_back(std::move(key));
       } else {
         outcome.failed.push_back(std::move(key));
@@ -782,7 +784,7 @@ void ThreadConfiguratorNode::callback_group_callback(
       RCLCPP_INFO(
         this->get_logger(),
         "Received CallbackGroupInfo: but the yaml file does not "
-        "contain configuration for domain=%zu, id=%s (tid=%ld)",
+        "contain configuration for domain=%zu, id=%s (tid=%" PRId64 ")",
         domain_id, msg->callback_group_id.c_str(), msg->thread_id);
       return;
     }
@@ -800,12 +802,12 @@ void ThreadConfiguratorNode::callback_group_callback(
     RCLCPP_INFO(
       this->get_logger(),
       "Re-applying configuration for already tracked callback group "
-      "(domain=%zu, id=%s, tid=%ld)",
+      "(domain=%zu, id=%s, tid=%" PRId64 ")",
       domain_id, msg->callback_group_id.c_str(), msg->thread_id);
   }
 
   RCLCPP_INFO(
-    this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%ld | %s", domain_id,
+    this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%" PRId64 " | %s", domain_id,
     msg->thread_id, msg->callback_group_id.c_str());
   // Record the tid before the syscall so a failed attempt can be retried via reapply.
   if (config->is_wildcard()) {
@@ -817,7 +819,8 @@ void ThreadConfiguratorNode::callback_group_callback(
   if (!issue_syscalls(*config, msg->thread_id)) {
     RCLCPP_WARN(
       this->get_logger(),
-      "Skipping configuration for callback group (domain=%zu, id=%s, tid=%ld) due to syscall "
+      "Skipping configuration for callback group (domain=%zu, id=%s, tid=%" PRId64
+      ") due to syscall "
       "failure.",
       domain_id, msg->callback_group_id.c_str(), msg->thread_id);
     return;
@@ -844,7 +847,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     RCLCPP_INFO(
       this->get_logger(),
       "Received NonRosThreadInfo: but the yaml file does not "
-      "contain configuration for name=%s (tid=%ld)",
+      "contain configuration for name=%s (tid=%" PRId64 ")",
       info.name.c_str(), info.tid);
     return;
   }
@@ -855,18 +858,20 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     // restarts, so we cannot use thread_id equality to skip reconfiguration.
     RCLCPP_INFO(
       this->get_logger(),
-      "Re-applying configuration for already configured non-ROS thread (name=%s, tid=%ld)",
+      "Re-applying configuration for already configured non-ROS thread (name=%s, tid=%" PRId64 ")",
       info.name.c_str(), info.tid);
   }
 
   RCLCPP_INFO(
-    this->get_logger(), "Received NonRosThreadInfo: tid=%ld | %s", info.tid, info.name.c_str());
+    this->get_logger(), "Received NonRosThreadInfo: tid=%" PRId64 " | %s", info.tid,
+    info.name.c_str());
   config->thread_id = info.tid;
 
   if (!issue_syscalls(*config, info.tid)) {
     RCLCPP_WARN(
       this->get_logger(),
-      "Skipping configuration for non-ROS thread (name=%s, tid=%ld) due to syscall "
+      "Skipping configuration for non-ROS thread (name=%s, tid=%" PRId64
+      ") due to syscall "
       "failure.",
       info.name.c_str(), info.tid);
     return;


### PR DESCRIPTION
## Description

Part 2/7 of the `agnocast_cie_thread_configurator` cleanup series.

Thread ids (`msg->thread_id`, `NonRosThreadInfo::tid`, `KernelThreadInfo::tid`, the `thread_id` parameters) are `int64_t`, but the log calls formatted them with `%ld`, which only matches `int64_t` on LP64 targets. Use `PRId64` from `<cinttypes>` instead: 17 occurrences in `thread_configurator_node.cpp` and 3 in `prerun_node.cpp`. The rendered log text is unchanged, so the E2E tests that match on these lines are unaffected.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1583 (base branch `chore/cie-tc-rename-ipc-gtest`); only the last commit belongs to this PR. Retarget to `main` once #1583 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
