### PR TITLE
refactor(agnocast_cie_thread_configurator): split daemon-internal logic into a static core library

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -11,14 +11,24 @@ find_package(rclcpp REQUIRED)
 find_package(agnocast_cie_config_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-add_library(agnocast_thread_configurator SHARED
-  src/util.cpp
-  src/non_ros_thread_ipc.cpp
+# Daemon-internal logic with no rclcpp dependency. Linked into the executables
+# and the unit tests; not installed.
+add_library(agnocast_thread_configurator_core STATIC
   src/thread_config.cpp
   src/system_scan.cpp
 )
+target_include_directories(agnocast_thread_configurator_core PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_link_libraries(agnocast_thread_configurator_core PUBLIC yaml-cpp)
+
+# Installed and exported: the client API (spawn_non_ros2_thread) and the ROS
+# glue shared by both executables.
+add_library(agnocast_thread_configurator SHARED
+  src/util.cpp
+  src/non_ros_thread_ipc.cpp
+)
 ament_target_dependencies(agnocast_thread_configurator rclcpp agnocast_cie_config_msgs)
-target_link_libraries(agnocast_thread_configurator yaml-cpp)
 
 add_executable(
   thread_configurator_node
@@ -27,7 +37,9 @@ add_executable(
   src/prerun_node.cpp
 )
 ament_target_dependencies(thread_configurator_node rclcpp agnocast_cie_config_msgs)
-target_link_libraries(thread_configurator_node yaml-cpp agnocast_thread_configurator)
+target_link_libraries(thread_configurator_node
+  yaml-cpp agnocast_thread_configurator agnocast_thread_configurator_core
+)
 
 target_include_directories(thread_configurator_node PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -39,7 +51,9 @@ add_executable(
   src/prerun_node.cpp
 )
 ament_target_dependencies(prerun_node rclcpp agnocast_cie_config_msgs)
-target_link_libraries(prerun_node yaml-cpp agnocast_thread_configurator)
+target_link_libraries(prerun_node
+  yaml-cpp agnocast_thread_configurator agnocast_thread_configurator_core
+)
 
 target_include_directories(prerun_node PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -84,7 +98,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp
   )
-  target_link_libraries(test_thread_config agnocast_thread_configurator yaml-cpp)
+  target_link_libraries(test_thread_config agnocast_thread_configurator_core yaml-cpp)
   target_include_directories(test_thread_config PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
@@ -92,7 +106,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_system_scan
     test/test_system_scan.cpp
   )
-  target_link_libraries(test_system_scan agnocast_thread_configurator)
+  target_link_libraries(test_system_scan agnocast_thread_configurator_core)
   target_include_directories(test_system_scan PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )


### PR DESCRIPTION
## Description

Part 4/7 of the `agnocast_cie_thread_configurator` cleanup series.

Split the package's build into two libraries:

- `agnocast_thread_configurator_core` (new, `STATIC`, not installed): `thread_config.cpp` and `system_scan.cpp`, i.e. the rclcpp-independent daemon logic. Both executables and the unit tests link it.
- `agnocast_thread_configurator` (`SHARED`, installed and exported, name unchanged): now only `util.cpp` and `non_ros_thread_ipc.cpp`, i.e. what external consumers actually use (`spawn_non_ros2_thread` and the ROS glue shared by both executables). It no longer links yaml-cpp, which it never needed.

Why: the core library is where logic extracted from `ThreadConfiguratorNode` / `PrerunNode` in later PRs (apply engine, config registry, template emitter, startup checks) will live, so that it can be unit-tested without installing daemon internals or growing the exported ABI beyond the client API.

Compatibility: no downstream package references `thread_config` / `system_scan` symbols. `agnocastlib`, `agnocast_components` and `agnocast_e2e_test` only use the header-only `spawn_non_ros2_thread` (checked by grep and by rebuilding those three packages against this change). The headers stay installed for now; moving daemon-only headers out of `include/` is a separate follow-up.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1585 (base branch `refactor/cie-tc-unique-fd`); only the last commit belongs to this PR. Retarget to `main` once #1585 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
