### PR TITLE
refactor(agnocast_cie_thread_configurator): replace policy strings with a SchedPolicy enum

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(agnocast_cie_thread_configurator)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror=switch)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(yaml-cpp REQUIRED)
 # Daemon-internal logic with no rclcpp dependency. Linked into the executables
 # and the unit tests; not installed.
 add_library(agnocast_thread_configurator_core STATIC
+  src/sched_policy.cpp
   src/thread_config.cpp
   src/system_scan.cpp
 )
@@ -94,6 +95,11 @@ if(BUILD_TESTING)
     test/test_non_ros_thread_ipc.cpp
   )
   target_link_libraries(test_non_ros_thread_ipc agnocast_thread_configurator)
+
+  ament_add_gtest(test_sched_policy
+    test/test_sched_policy.cpp
+  )
+  target_link_libraries(test_sched_policy agnocast_thread_configurator_core)
 
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_policy.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_policy.hpp
@@ -8,23 +8,26 @@ namespace agnocast_cie_thread_configurator
 {
 
 // Scheduling policies with a YAML representation. Enumerator order is the
-// order sched_policy_names() lists them in.
+// order sched_policy_names() lists them in; Deadline must stay last (the
+// name table is sized by it).
 enum class SchedPolicy { Other, Batch, Idle, Fifo, Rr, Deadline };
 
 // YAML policy name ("SCHED_FIFO") <-> policy. Exact, case-sensitive match;
 // nullopt for any other string.
-std::optional<SchedPolicy> parse_sched_policy(std::string_view name);
-std::string_view to_string(SchedPolicy policy);
+std::optional<SchedPolicy> parse_sched_policy(std::string_view name) noexcept;
+std::string_view to_string(SchedPolicy policy) noexcept;
 
 // Kernel SCHED_* value (sched_setscheduler(2), /proc/<pid>/stat field 41)
-// <-> policy. nullopt for values that have no YAML representation.
-int to_kernel_policy(SchedPolicy policy);
-std::optional<SchedPolicy> from_kernel_policy(int kernel_policy);
+// <-> policy. nullopt for values that have no YAML representation. The input
+// must be the bare policy: sched_getscheduler(2) may OR in
+// SCHED_RESET_ON_FORK, which is not masked here.
+int to_kernel_policy(SchedPolicy policy) noexcept;
+std::optional<SchedPolicy> from_kernel_policy(int kernel_policy) noexcept;
 
 // The CFS policies (OTHER/BATCH/IDLE) are tuned by nice, FIFO/RR by
 // rt_priority, DEADLINE by runtime/period/deadline. The template emitter and
 // the parser rely on this split.
-bool is_cfs(SchedPolicy policy);
+bool is_cfs(SchedPolicy policy) noexcept;
 
 // "SCHED_OTHER, SCHED_BATCH, ..." for error messages.
 std::string sched_policy_names();

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_policy.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_policy.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// Scheduling policies with a YAML representation. Enumerator order is the
+// order sched_policy_names() lists them in.
+enum class SchedPolicy { Other, Batch, Idle, Fifo, Rr, Deadline };
+
+// YAML policy name ("SCHED_FIFO") <-> policy. Exact, case-sensitive match;
+// nullopt for any other string.
+std::optional<SchedPolicy> parse_sched_policy(std::string_view name);
+std::string_view to_string(SchedPolicy policy);
+
+// Kernel SCHED_* value (sched_setscheduler(2), /proc/<pid>/stat field 41)
+// <-> policy. nullopt for values that have no YAML representation.
+int to_kernel_policy(SchedPolicy policy);
+std::optional<SchedPolicy> from_kernel_policy(int kernel_policy);
+
+// The CFS policies (OTHER/BATCH/IDLE) are tuned by nice, FIFO/RR by
+// rt_priority, DEADLINE by runtime/period/deadline. The template emitter and
+// the parser rely on this split.
+bool is_cfs(SchedPolicy policy);
+
+// "SCHED_OTHER, SCHED_BATCH, ..." for error messages.
+std::string sched_policy_names();
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -7,7 +7,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 namespace agnocast_cie_thread_configurator
@@ -95,15 +94,6 @@ struct IrqConfig
 // std::runtime_error on validation error.
 std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml);
 std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml);
-
-// Mapping from the policy string in the YAML to the kernel SCHED_* constant.
-// Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
-extern const std::unordered_map<std::string, int> policy_to_sched_const;
-
-// True for the CFS policies (SCHED_OTHER/BATCH/IDLE), whose tunable is nice;
-// the RT policies' tunable is priority. The template emitter and the parser
-// must agree on this split.
-bool is_cfs_policy(const std::string & policy);
 
 // Parse the given YAML document and populate the two output vectors.
 // Throws std::runtime_error on per-entry validation error. Output ThreadConfigs

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "agnocast_cie_thread_configurator/non_ros_thread_ipc.hpp"
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
@@ -12,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -20,6 +22,7 @@ class ThreadConfiguratorNode : public rclcpp::Node
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
   using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
   using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
+  using SchedPolicy = agnocast_cie_thread_configurator::SchedPolicy;
 
   // Concurrency:
   // - callback_group_configs_ / id_to_callback_group_config_ /
@@ -60,11 +63,12 @@ private:
   // thread_id is passed explicitly because a wildcard entry applies to many
   // threads (one per matched_tids element), not just config.thread_id.
   bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
-  // policy is compared only against "SCHED_DEADLINE" (cgroup-based affinity);
-  // any other value takes the plain sched_setaffinity path.
+  // Only Deadline takes the cgroup-based affinity path; any other value,
+  // including nullopt (an observed policy with no YAML name), uses
+  // sched_setaffinity.
   bool issue_affinity_syscalls(
-    const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
-    int64_t thread_id);
+    const std::string & thread_str, std::optional<SchedPolicy> policy,
+    const std::vector<int> & affinity, int64_t thread_id);
   SectionApplyOutcome apply_kernel_thread_configs();
   SectionApplyOutcome apply_irq_configs() const;
   // Sole logging point for the write path: emits errno-specific guidance on

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/prerun_node.hpp"
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -237,17 +238,16 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   for (const auto & info : kernel_threads) {
     // A policy with no YAML representation: UNKNOWN(<n>), or SCHED_DEADLINE,
     // whose runtime/period/deadline cannot be recovered from /proc.
+    const auto policy = agnocast_cie_thread_configurator::parse_sched_policy(info.policy);
     const bool policy_representable =
-      agnocast_cie_thread_configurator::policy_to_sched_const.count(info.policy) > 0 &&
-      info.policy != "SCHED_DEADLINE";
+      policy.has_value() && *policy != agnocast_cie_thread_configurator::SchedPolicy::Deadline;
     const auto cpus = agnocast_cie_thread_configurator::parse_manageable_cpu_list(info.affinity);
 
     out << YAML::BeginMap;
     out << YAML::Key << "comm" << YAML::Value << info.comm;
     if (policy_representable) {
-      const bool is_cfs = agnocast_cie_thread_configurator::is_cfs_policy(info.policy);
       out << YAML::Key << "policy" << YAML::Value << info.policy;
-      if (is_cfs) {
+      if (agnocast_cie_thread_configurator::is_cfs(*policy)) {
         out << YAML::Key << "nice" << YAML::Value << info.nice;
       } else {
         out << YAML::Key << "priority" << YAML::Value << info.rt_priority;

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -236,8 +236,8 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Value << YAML::BeginSeq;
 
   for (const auto & info : kernel_threads) {
-    // A policy with no YAML representation: UNKNOWN(<n>), or SCHED_DEADLINE,
-    // whose runtime/period/deadline cannot be recovered from /proc.
+    // A policy the template cannot round-trip: UNKNOWN(<n>) has no name, and
+    // SCHED_DEADLINE's runtime/period/deadline cannot be recovered from /proc.
     const auto policy = agnocast_cie_thread_configurator::parse_sched_policy(info.policy);
     const bool policy_representable =
       policy.has_value() && *policy != agnocast_cie_thread_configurator::SchedPolicy::Deadline;

--- a/src/agnocast_cie_thread_configurator/src/sched_policy.cpp
+++ b/src/agnocast_cie_thread_configurator/src/sched_policy.cpp
@@ -18,16 +18,21 @@ struct PolicyEntry
   SchedPolicy policy;
   std::string_view name;
   int kernel_policy;
+  bool cfs;
 };
 
-// Indexed by the enumerator's underlying value (checked below).
-constexpr std::array<PolicyEntry, 6> k_policies{{
-  {SchedPolicy::Other, "SCHED_OTHER", SCHED_OTHER},
-  {SchedPolicy::Batch, "SCHED_BATCH", SCHED_BATCH},
-  {SchedPolicy::Idle, "SCHED_IDLE", SCHED_IDLE},
-  {SchedPolicy::Fifo, "SCHED_FIFO", SCHED_FIFO},
-  {SchedPolicy::Rr, "SCHED_RR", SCHED_RR},
-  {SchedPolicy::Deadline, "SCHED_DEADLINE", SCHED_DEADLINE},
+constexpr size_t k_num_policies = static_cast<size_t>(SchedPolicy::Deadline) + 1;
+
+// Indexed by the enumerator's underlying value. A missing row leaves a
+// value-initialized trailing entry (policy == Other), which the check below
+// rejects.
+constexpr std::array<PolicyEntry, k_num_policies> k_policies{{
+  {SchedPolicy::Other, "SCHED_OTHER", SCHED_OTHER, true},
+  {SchedPolicy::Batch, "SCHED_BATCH", SCHED_BATCH, true},
+  {SchedPolicy::Idle, "SCHED_IDLE", SCHED_IDLE, true},
+  {SchedPolicy::Fifo, "SCHED_FIFO", SCHED_FIFO, false},
+  {SchedPolicy::Rr, "SCHED_RR", SCHED_RR, false},
+  {SchedPolicy::Deadline, "SCHED_DEADLINE", SCHED_DEADLINE, false},
 }};
 
 constexpr bool indexed_by_enumerator()
@@ -39,16 +44,16 @@ constexpr bool indexed_by_enumerator()
   }
   return true;
 }
-static_assert(indexed_by_enumerator(), "k_policies must be ordered by SchedPolicy value");
+static_assert(indexed_by_enumerator(), "k_policies must have one row per SchedPolicy, in order");
 
-const PolicyEntry & entry(SchedPolicy policy)
+const PolicyEntry & entry(SchedPolicy policy) noexcept
 {
   return k_policies[static_cast<size_t>(policy)];
 }
 
 }  // namespace
 
-std::optional<SchedPolicy> parse_sched_policy(std::string_view name)
+std::optional<SchedPolicy> parse_sched_policy(std::string_view name) noexcept
 {
   const auto * const it = std::find_if(
     k_policies.begin(), k_policies.end(), [name](const PolicyEntry & e) { return e.name == name; });
@@ -58,17 +63,17 @@ std::optional<SchedPolicy> parse_sched_policy(std::string_view name)
   return it->policy;
 }
 
-std::string_view to_string(SchedPolicy policy)
+std::string_view to_string(SchedPolicy policy) noexcept
 {
   return entry(policy).name;
 }
 
-int to_kernel_policy(SchedPolicy policy)
+int to_kernel_policy(SchedPolicy policy) noexcept
 {
   return entry(policy).kernel_policy;
 }
 
-std::optional<SchedPolicy> from_kernel_policy(int kernel_policy)
+std::optional<SchedPolicy> from_kernel_policy(int kernel_policy) noexcept
 {
   const auto * const it = std::find_if(
     k_policies.begin(), k_policies.end(),
@@ -79,10 +84,9 @@ std::optional<SchedPolicy> from_kernel_policy(int kernel_policy)
   return it->policy;
 }
 
-bool is_cfs(SchedPolicy policy)
+bool is_cfs(SchedPolicy policy) noexcept
 {
-  return policy == SchedPolicy::Other || policy == SchedPolicy::Batch ||
-         policy == SchedPolicy::Idle;
+  return entry(policy).cfs;
 }
 
 std::string sched_policy_names()

--- a/src/agnocast_cie_thread_configurator/src/sched_policy.cpp
+++ b/src/agnocast_cie_thread_configurator/src/sched_policy.cpp
@@ -1,0 +1,100 @@
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
+
+#include <linux/sched.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+
+struct PolicyEntry
+{
+  SchedPolicy policy;
+  std::string_view name;
+  int kernel_policy;
+};
+
+// Indexed by the enumerator's underlying value (checked below).
+constexpr std::array<PolicyEntry, 6> k_policies{{
+  {SchedPolicy::Other, "SCHED_OTHER", SCHED_OTHER},
+  {SchedPolicy::Batch, "SCHED_BATCH", SCHED_BATCH},
+  {SchedPolicy::Idle, "SCHED_IDLE", SCHED_IDLE},
+  {SchedPolicy::Fifo, "SCHED_FIFO", SCHED_FIFO},
+  {SchedPolicy::Rr, "SCHED_RR", SCHED_RR},
+  {SchedPolicy::Deadline, "SCHED_DEADLINE", SCHED_DEADLINE},
+}};
+
+constexpr bool indexed_by_enumerator()
+{
+  for (size_t i = 0; i < k_policies.size(); ++i) {
+    if (static_cast<size_t>(k_policies[i].policy) != i) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(indexed_by_enumerator(), "k_policies must be ordered by SchedPolicy value");
+
+const PolicyEntry & entry(SchedPolicy policy)
+{
+  return k_policies[static_cast<size_t>(policy)];
+}
+
+}  // namespace
+
+std::optional<SchedPolicy> parse_sched_policy(std::string_view name)
+{
+  const auto * const it = std::find_if(
+    k_policies.begin(), k_policies.end(), [name](const PolicyEntry & e) { return e.name == name; });
+  if (it == k_policies.end()) {
+    return std::nullopt;
+  }
+  return it->policy;
+}
+
+std::string_view to_string(SchedPolicy policy)
+{
+  return entry(policy).name;
+}
+
+int to_kernel_policy(SchedPolicy policy)
+{
+  return entry(policy).kernel_policy;
+}
+
+std::optional<SchedPolicy> from_kernel_policy(int kernel_policy)
+{
+  const auto * const it = std::find_if(
+    k_policies.begin(), k_policies.end(),
+    [kernel_policy](const PolicyEntry & e) { return e.kernel_policy == kernel_policy; });
+  if (it == k_policies.end()) {
+    return std::nullopt;
+  }
+  return it->policy;
+}
+
+bool is_cfs(SchedPolicy policy)
+{
+  return policy == SchedPolicy::Other || policy == SchedPolicy::Batch ||
+         policy == SchedPolicy::Idle;
+}
+
+std::string sched_policy_names()
+{
+  std::string names;
+  for (const auto & e : k_policies) {
+    if (!names.empty()) {
+      names += ", ";
+    }
+    names += e.name;
+  }
+  return names;
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -1,5 +1,6 @@
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
 #include <sched.h>
@@ -104,10 +105,8 @@ std::optional<std::string_view> stat_token(
 
 std::string policy_const_to_string(int policy)
 {
-  for (const auto & [name, value] : policy_to_sched_const) {
-    if (value == policy) {
-      return name;
-    }
+  if (const auto parsed = from_kernel_policy(policy)) {
+    return std::string(to_string(*parsed));
   }
   return "UNKNOWN(" + std::to_string(policy) + ")";
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
-#include <linux/sched.h>
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
+
 #include <sched.h>
 #include <unistd.h>
 
@@ -172,17 +173,18 @@ std::vector<int> parse_affinity(
   return cpus;
 }
 
-}  // namespace
-
-const std::unordered_map<std::string, int> policy_to_sched_const = {
-  {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
-  {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
-};
-
-bool is_cfs_policy(const std::string & policy)
+SchedPolicy parse_policy_or_throw(const std::string & policy, const std::string & entry_desc)
 {
-  return policy == "SCHED_OTHER" || policy == "SCHED_BATCH" || policy == "SCHED_IDLE";
+  const auto parsed = parse_sched_policy(policy);
+  if (!parsed) {
+    throw std::runtime_error(
+      "Unknown scheduling policy '" + policy + "' for " + entry_desc +
+      ". Valid policies: " + sched_policy_names());
+  }
+  return *parsed;
 }
+
+}  // namespace
 
 bool ThreadConfig::is_wildcard() const noexcept
 {
@@ -248,19 +250,13 @@ void parse_yaml(
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
     cfg.affinity = parse_affinity(cg, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     cfg.policy = cg["policy"].as<std::string>();
+    const SchedPolicy policy = parse_policy_or_throw(cfg.policy, "id=" + cfg.thread_str);
 
-    if (policy_to_sched_const.count(cfg.policy) == 0) {
-      throw std::runtime_error(
-        "Unknown scheduling policy '" + cfg.policy + "' for id=" + cfg.thread_str +
-        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
-        "SCHED_DEADLINE");
-    }
-
-    if (cfg.policy == "SCHED_DEADLINE") {
+    if (policy == SchedPolicy::Deadline) {
       cfg.runtime = cg["runtime"].as<unsigned int>();
       cfg.period = cg["period"].as<unsigned int>();
       cfg.deadline = cg["deadline"].as<unsigned int>();
-    } else if (is_cfs_policy(cfg.policy)) {
+    } else if (is_cfs(policy)) {
       cfg.nice = parse_nice(cg, cfg.policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
       cfg.priority =
@@ -275,19 +271,13 @@ void parse_yaml(
     cfg.thread_str = nrt["name"].as<std::string>();
     cfg.affinity = parse_affinity(nrt, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     cfg.policy = nrt["policy"].as<std::string>();
+    const SchedPolicy policy = parse_policy_or_throw(cfg.policy, "name=" + cfg.thread_str);
 
-    if (policy_to_sched_const.count(cfg.policy) == 0) {
-      throw std::runtime_error(
-        "Unknown scheduling policy '" + cfg.policy + "' for name=" + cfg.thread_str +
-        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
-        "SCHED_DEADLINE");
-    }
-
-    if (cfg.policy == "SCHED_DEADLINE") {
+    if (policy == SchedPolicy::Deadline) {
       cfg.runtime = nrt["runtime"].as<unsigned int>();
       cfg.period = nrt["period"].as<unsigned int>();
       cfg.deadline = nrt["deadline"].as<unsigned int>();
-    } else if (is_cfs_policy(cfg.policy)) {
+    } else if (is_cfs(policy)) {
       cfg.nice =
         parse_nice(nrt, cfg.policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
@@ -385,14 +375,9 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
     } catch (const YAML::Exception &) {
       throw std::runtime_error("'policy' must be a string for comm=" + cfg.comm);
     }
-    if (policy_to_sched_const.count(*cfg.policy) == 0) {
-      throw std::runtime_error(
-        "Unknown scheduling policy '" + *cfg.policy + "' for comm=" + cfg.comm +
-        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
-        "SCHED_DEADLINE");
-    }
+    const SchedPolicy policy = parse_policy_or_throw(*cfg.policy, "comm=" + cfg.comm);
 
-    if (*cfg.policy == "SCHED_DEADLINE") {
+    if (policy == SchedPolicy::Deadline) {
       // Explicit check for a clear message: these fields are always
       // hand-written (prerun never emits DEADLINE) and easy to forget.
       if (
@@ -405,7 +390,7 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
       cfg.runtime = parse_deadline_field(kt, "runtime", "comm=" + cfg.comm);
       cfg.period = parse_deadline_field(kt, "period", "comm=" + cfg.comm);
       cfg.deadline = parse_deadline_field(kt, "deadline", "comm=" + cfg.comm);
-    } else if (is_cfs_policy(*cfg.policy)) {
+    } else if (is_cfs(policy)) {
       cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
     } else {
       cfg.priority =

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -426,37 +426,27 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     return false;
   }
 
+  // No default: -Werror=switch must reject an unhandled SchedPolicy, since an
+  // unhandled case would fall through to the affinity syscalls.
   switch (*policy) {
     case SchedPolicy::Other:
     case SchedPolicy::Batch:
-    case SchedPolicy::Idle: {
-      struct sched_param param;
-      param.sched_priority = 0;
-
-      if (sched_setscheduler(thread_id, to_kernel_policy(*policy), &param) == -1) {
-        RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
-        return false;
-      }
-
-      // Specify nice value
-      if (setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
-        RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
-        return false;
-      }
-      break;
-    }
+    case SchedPolicy::Idle:
     case SchedPolicy::Fifo:
     case SchedPolicy::Rr: {
       struct sched_param param;
-      param.sched_priority = config.priority;
+      param.sched_priority = is_cfs(*policy) ? 0 : config.priority;
 
       if (sched_setscheduler(thread_id, to_kernel_policy(*policy), &param) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
+          config.thread_str.c_str(), thread_id, strerror(errno));
+        return false;
+      }
+
+      if (is_cfs(*policy) && setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
           config.thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
@@ -489,15 +479,15 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     }
   }
 
-  return issue_affinity_syscalls(config.thread_str, config.policy, config.affinity, thread_id);
+  return issue_affinity_syscalls(config.thread_str, policy, config.affinity, thread_id);
 }
 
 bool ThreadConfiguratorNode::issue_affinity_syscalls(
-  const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
-  int64_t thread_id)
+  const std::string & thread_str, std::optional<SchedPolicy> policy,
+  const std::vector<int> & affinity, int64_t thread_id)
 {
   if (affinity.size() > 0) {
-    if (parse_sched_policy(policy) == SchedPolicy::Deadline) {
+    if (policy == SchedPolicy::Deadline) {
       if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%" PRId64 "): %s",
@@ -608,7 +598,8 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
       } else {
         // Branch on the observed policy: an affinity-only entry matching a
         // thread currently under SCHED_DEADLINE needs the cgroup path.
-        ok = issue_affinity_syscalls(config.comm, info->policy, config.affinity, info->tid);
+        ok = issue_affinity_syscalls(
+          config.comm, parse_sched_policy(info->policy), config.affinity, info->tid);
       }
 
       if (ok) {

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -27,7 +28,10 @@
 #include <system_error>
 #include <utility>
 
-using agnocast_cie_thread_configurator::policy_to_sched_const;
+using agnocast_cie_thread_configurator::is_cfs;
+using agnocast_cie_thread_configurator::parse_sched_policy;
+using agnocast_cie_thread_configurator::SchedPolicy;
+using agnocast_cie_thread_configurator::to_kernel_policy;
 
 namespace
 {
@@ -53,7 +57,8 @@ bool kernel_thread_in_sync(
   const agnocast_cie_thread_configurator::KernelThreadInfo & info)
 {
   if (config.policy.has_value()) {
-    if (*config.policy == "SCHED_DEADLINE") {
+    const auto policy = parse_sched_policy(*config.policy);
+    if (!policy || *policy == SchedPolicy::Deadline) {
       return false;
     }
     if (*config.policy != info.policy) {
@@ -61,9 +66,8 @@ bool kernel_thread_in_sync(
     }
     // The policy classes tune different knobs: nice for CFS, rt_priority for
     // FIFO/RR (the emitter and parser agree on this split).
-    const bool tunable_in_sync = agnocast_cie_thread_configurator::is_cfs_policy(*config.policy)
-                                   ? config.nice == info.nice
-                                   : config.priority == info.rt_priority;
+    const bool tunable_in_sync =
+      is_cfs(*policy) ? config.nice == info.nice : config.priority == info.rt_priority;
     if (!tunable_in_sync) {
       return false;
     }
@@ -414,66 +418,75 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
 
 bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t thread_id)
 {
-  if (
-    config.policy == "SCHED_OTHER" || config.policy == "SCHED_BATCH" ||
-    config.policy == "SCHED_IDLE") {
-    struct sched_param param;
-    param.sched_priority = 0;
-
-    if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-        config.thread_str.c_str(), thread_id, strerror(errno));
-      return false;
-    }
-
-    // Specify nice value
-    if (setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
-        config.thread_str.c_str(), thread_id, strerror(errno));
-      return false;
-    }
-
-  } else if (config.policy == "SCHED_FIFO" || config.policy == "SCHED_RR") {
-    struct sched_param param;
-    param.sched_priority = config.priority;
-
-    if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-        config.thread_str.c_str(), thread_id, strerror(errno));
-      return false;
-    }
-
-  } else if (config.policy == "SCHED_DEADLINE") {
-    struct sched_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.size = sizeof(attr);
-    // SCHED_FLAG_RESET_ON_FORK lets the target thread still call fork(2)/clone(2)
-    // after being placed under SCHED_DEADLINE; without it, clone(2) returns EAGAIN.
-    // Children reset to SCHED_OTHER; each callback-group thread that needs its own
-    // SCHED_DEADLINE gets it via its own CallbackGroupInfo message.
-    attr.sched_flags = SCHED_FLAG_RESET_ON_FORK;
-    attr.sched_nice = 0;
-    attr.sched_priority = 0;
-
-    attr.sched_policy = SCHED_DEADLINE;
-    attr.sched_runtime = config.runtime;
-    attr.sched_period = config.period;
-    attr.sched_deadline = config.deadline;
-
-    if (sched_setattr(thread_id, &attr, 0) == -1) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-        config.thread_str.c_str(), thread_id, strerror(errno));
-      return false;
-    }
-  } else {
+  const auto policy = parse_sched_policy(config.policy);
+  if (!policy) {
     RCLCPP_ERROR(
       this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%" PRId64 ")",
       config.policy.c_str(), config.thread_str.c_str(), thread_id);
     return false;
+  }
+
+  switch (*policy) {
+    case SchedPolicy::Other:
+    case SchedPolicy::Batch:
+    case SchedPolicy::Idle: {
+      struct sched_param param;
+      param.sched_priority = 0;
+
+      if (sched_setscheduler(thread_id, to_kernel_policy(*policy), &param) == -1) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
+          config.thread_str.c_str(), thread_id, strerror(errno));
+        return false;
+      }
+
+      // Specify nice value
+      if (setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
+          config.thread_str.c_str(), thread_id, strerror(errno));
+        return false;
+      }
+      break;
+    }
+    case SchedPolicy::Fifo:
+    case SchedPolicy::Rr: {
+      struct sched_param param;
+      param.sched_priority = config.priority;
+
+      if (sched_setscheduler(thread_id, to_kernel_policy(*policy), &param) == -1) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
+          config.thread_str.c_str(), thread_id, strerror(errno));
+        return false;
+      }
+      break;
+    }
+    case SchedPolicy::Deadline: {
+      struct sched_attr attr;
+      memset(&attr, 0, sizeof(attr));
+      attr.size = sizeof(attr);
+      // SCHED_FLAG_RESET_ON_FORK lets the target thread still call fork(2)/clone(2)
+      // after being placed under SCHED_DEADLINE; without it, clone(2) returns EAGAIN.
+      // Children reset to SCHED_OTHER; each callback-group thread that needs its own
+      // SCHED_DEADLINE gets it via its own CallbackGroupInfo message.
+      attr.sched_flags = SCHED_FLAG_RESET_ON_FORK;
+      attr.sched_nice = 0;
+      attr.sched_priority = 0;
+
+      attr.sched_policy = SCHED_DEADLINE;
+      attr.sched_runtime = config.runtime;
+      attr.sched_period = config.period;
+      attr.sched_deadline = config.deadline;
+
+      if (sched_setattr(thread_id, &attr, 0) == -1) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
+          config.thread_str.c_str(), thread_id, strerror(errno));
+        return false;
+      }
+      break;
+    }
   }
 
   return issue_affinity_syscalls(config.thread_str, config.policy, config.affinity, thread_id);
@@ -484,7 +497,7 @@ bool ThreadConfiguratorNode::issue_affinity_syscalls(
   int64_t thread_id)
 {
   if (affinity.size() > 0) {
-    if (policy == "SCHED_DEADLINE") {
+    if (parse_sched_policy(policy) == SchedPolicy::Deadline) {
       if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%" PRId64 "): %s",

--- a/src/agnocast_cie_thread_configurator/test/test_sched_policy.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_sched_policy.cpp
@@ -1,0 +1,73 @@
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
+
+#include <gtest/gtest.h>
+#include <linux/sched.h>
+#include <sched.h>
+
+#include <optional>
+
+namespace acie = agnocast_cie_thread_configurator;
+
+namespace
+{
+constexpr acie::SchedPolicy kAllPolicies[] = {
+  acie::SchedPolicy::Other, acie::SchedPolicy::Batch, acie::SchedPolicy::Idle,
+  acie::SchedPolicy::Fifo,  acie::SchedPolicy::Rr,    acie::SchedPolicy::Deadline,
+};
+}  // namespace
+
+TEST(SchedPolicy, NameRoundTrip)
+{
+  for (const auto policy : kAllPolicies) {
+    EXPECT_EQ(acie::parse_sched_policy(acie::to_string(policy)), policy);
+  }
+  EXPECT_EQ(acie::to_string(acie::SchedPolicy::Other), "SCHED_OTHER");
+  EXPECT_EQ(acie::to_string(acie::SchedPolicy::Deadline), "SCHED_DEADLINE");
+}
+
+TEST(SchedPolicy, RejectsNamesThatAreNotExactMatches)
+{
+  EXPECT_EQ(acie::parse_sched_policy("sched_fifo"), std::nullopt);
+  EXPECT_EQ(acie::parse_sched_policy("FIFO"), std::nullopt);
+  EXPECT_EQ(acie::parse_sched_policy("SCHED_FIFO "), std::nullopt);
+  EXPECT_EQ(acie::parse_sched_policy("UNKNOWN(4)"), std::nullopt);
+  EXPECT_EQ(acie::parse_sched_policy(""), std::nullopt);
+}
+
+TEST(SchedPolicy, KernelConstantRoundTrip)
+{
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Other), SCHED_OTHER);
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Batch), SCHED_BATCH);
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Idle), SCHED_IDLE);
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Fifo), SCHED_FIFO);
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Rr), SCHED_RR);
+  EXPECT_EQ(acie::to_kernel_policy(acie::SchedPolicy::Deadline), SCHED_DEADLINE);
+  for (const auto policy : kAllPolicies) {
+    EXPECT_EQ(acie::from_kernel_policy(acie::to_kernel_policy(policy)), policy);
+  }
+}
+
+TEST(SchedPolicy, RejectsKernelValuesWithoutYamlName)
+{
+  // 4 is SCHED_ISO, reserved but never implemented; -1 and 100 never existed.
+  EXPECT_EQ(acie::from_kernel_policy(4), std::nullopt);
+  EXPECT_EQ(acie::from_kernel_policy(-1), std::nullopt);
+  EXPECT_EQ(acie::from_kernel_policy(100), std::nullopt);
+}
+
+TEST(SchedPolicy, IsCfsSplitsNiceFromRtPriorityPolicies)
+{
+  EXPECT_TRUE(acie::is_cfs(acie::SchedPolicy::Other));
+  EXPECT_TRUE(acie::is_cfs(acie::SchedPolicy::Batch));
+  EXPECT_TRUE(acie::is_cfs(acie::SchedPolicy::Idle));
+  EXPECT_FALSE(acie::is_cfs(acie::SchedPolicy::Fifo));
+  EXPECT_FALSE(acie::is_cfs(acie::SchedPolicy::Rr));
+  EXPECT_FALSE(acie::is_cfs(acie::SchedPolicy::Deadline));
+}
+
+TEST(SchedPolicy, NamesListsEveryPolicyInEnumeratorOrder)
+{
+  EXPECT_EQ(
+    acie::sched_policy_names(),
+    "SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, SCHED_DEADLINE");
+}

--- a/src/agnocast_cie_thread_configurator/test/test_sched_policy.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_sched_policy.cpp
@@ -4,6 +4,8 @@
 #include <linux/sched.h>
 #include <sched.h>
 
+#include <cstddef>
+#include <iterator>
 #include <optional>
 
 namespace acie = agnocast_cie_thread_configurator;
@@ -14,6 +16,9 @@ constexpr acie::SchedPolicy kAllPolicies[] = {
   acie::SchedPolicy::Other, acie::SchedPolicy::Batch, acie::SchedPolicy::Idle,
   acie::SchedPolicy::Fifo,  acie::SchedPolicy::Rr,    acie::SchedPolicy::Deadline,
 };
+static_assert(
+  std::size(kAllPolicies) == static_cast<size_t>(acie::SchedPolicy::Deadline) + 1,
+  "kAllPolicies must list every SchedPolicy enumerator");
 }  // namespace
 
 TEST(SchedPolicy, NameRoundTrip)


### PR DESCRIPTION
## Description

Part 5/7 of the `agnocast_cie_thread_configurator` cleanup series.

Scheduling policies were carried as strings and compared against literals in six places across the YAML parser, the `/proc` scanner, the template emitter and `issue_syscalls` (which re-did the CFS check by string comparison even though `is_cfs_policy` existed). The string-to-kernel-constant table was an `extern` global `std::unordered_map` (`policy_to_sched_const`), and `system_scan` did a linear reverse lookup over it.

This PR adds `sched_policy.hpp`: a `SchedPolicy` enum plus `parse_sched_policy` / `to_string` / `to_kernel_policy` / `from_kernel_policy` / `is_cfs` / `sched_policy_names`, backed by a single table in `sched_policy.cpp` (with a `static_assert` that the table is indexed by enumerator value). `policy_to_sched_const` and `is_cfs_policy` are removed.

- Parser: the three copies of the `Unknown scheduling policy ... Valid policies: ...` check collapse into one `parse_policy_or_throw` helper. The message text is byte-identical (the test suite matches on it).
- `issue_syscalls`: the policy string is parsed once and dispatched with a `switch` over the enum, so `-Wswitch` catches a future enumerator; the log lines are unchanged.
- `system_scan` and `prerun_node` use `from_kernel_policy` / `is_cfs` instead of iterating the map.

The config structs keep `std::string policy` for now; changing the config model itself is a later step. `test_sched_policy.cpp` covers the name and kernel-constant round trips, unknown names and values, the CFS split and the name list.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1586 (base branch `refactor/cie-tc-core-lib`); only the last commit belongs to this PR. Retarget to `main` once #1586 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
