### PR TITLE
refactor(agnocast_cie_thread_configurator): move is_kworker_comm to system_scan

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -30,6 +30,11 @@ struct IrqInfo
   std::string affinity;  // /proc/irq/<N>/smp_affinity_list, "" when unreadable
 };
 
+// kworker comms embed worker-pool/CPU state that mutates at runtime, so they
+// can never be matched reliably; both the scanner and the kernel_threads
+// parser exclude them.
+bool is_kworker_comm(const std::string & comm);
+
 // Sorted by (comm, tid); entries that vanish mid-scan are skipped silently.
 // kworker/* are excluded: their comms mutate at runtime, so they cannot be
 // managed per-thread.

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -46,11 +46,6 @@ struct ThreadConfig
 // first '@' (the whole string when no '@' is present).
 std::string extract_node_part(const std::string & callback_group_id);
 
-// kworker comms embed worker-pool/CPU state that mutates at runtime, so they
-// can never be matched reliably; both the system scanner and the
-// kernel_threads parser exclude them.
-bool is_kworker_comm(const std::string & comm);
-
 // Sentinel for kernel_threads/irqs attribute values: the kernel or this tool
 // cannot manage the attribute (fixed per-CPU affinity, a policy with no YAML
 // representation), whereas YAML null means the USER chose not to. Both parse

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -1,7 +1,6 @@
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
-#include "agnocast_cie_thread_configurator/thread_config.hpp"
 
 #include <sched.h>
 #include <unistd.h>
@@ -201,6 +200,12 @@ std::optional<KernelThreadInfo> read_kernel_thread(
 }
 
 }  // namespace
+
+bool is_kworker_comm(const std::string & comm)
+{
+  constexpr std::string_view kworker_prefix = "kworker/";
+  return comm.compare(0, kworker_prefix.size(), kworker_prefix) == 0;
+}
 
 std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root)
 {

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
 
 #include <sched.h>
 #include <unistd.h>
@@ -201,12 +202,6 @@ std::string ThreadConfig::wildcard_prefix() const
 std::string extract_node_part(const std::string & callback_group_id)
 {
   return callback_group_id.substr(0, callback_group_id.find('@'));
-}
-
-bool is_kworker_comm(const std::string & comm)
-{
-  constexpr std::string_view kworker_prefix = "kworker/";
-  return comm.compare(0, kworker_prefix.size(), kworker_prefix) == 0;
 }
 
 void parse_yaml(

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -336,6 +336,17 @@ TEST(ProcessWithCommExists, FindsByExactComm)
   EXPECT_FALSE(acie::process_with_comm_exists("nonexistent", tree.root.string()));
 }
 
+// ---------- is_kworker_comm ----------
+
+TEST(IsKworkerComm, MatchesTheKworkerPrefixOnly)
+{
+  EXPECT_TRUE(acie::is_kworker_comm("kworker/0:0H-events_highpri"));
+  EXPECT_TRUE(acie::is_kworker_comm("kworker/u16:3"));
+  EXPECT_FALSE(acie::is_kworker_comm("kworker"));
+  EXPECT_FALSE(acie::is_kworker_comm("ksoftirqd/0"));
+  EXPECT_FALSE(acie::is_kworker_comm(""));
+}
+
 // ---------- format_cpu_list / parse_cpu_list ----------
 
 TEST(FormatCpuList, JoinsWithCommas)


### PR DESCRIPTION
## Description

Part 6/7 of the `agnocast_cie_thread_configurator` cleanup series.

`is_kworker_comm` lived in `thread_config` (the YAML parser module) although its primary user is the `/proc` scanner, which made `system_scan.cpp` depend on the parser. Move it to `system_scan` (declaration, definition and a direct unit test); the parser now includes `system_scan.hpp` for it.

With the policy table already moved to `sched_policy` in the previous PR, this removes the last `#include "thread_config.hpp"` from `system_scan.cpp`, so the module dependency now runs one way only: parser -> scanner -> sched_policy.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1587 (base branch `refactor/cie-tc-sched-policy`); only the last commit belongs to this PR. Retarget to `main` once #1587 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
