### PR TITLE
refactor(agnocast_cie_thread_configurator): share the manageable CPU bound between parser and scanner

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -66,13 +66,15 @@ std::string format_cpu_list(const std::vector<int> & cpus);
 // nullopt on empty or malformed input.
 std::optional<std::vector<int>> parse_cpu_list(const std::string & s);
 
-// parse_cpu_list, additionally dropping CPUs above this machine's manageable
-// bound (min(CPU_SETSIZE, _SC_NPROCESSORS_CONF) - 1): the kernel prints
-// affinity over the possible-CPU mask, which can exceed the present CPUs.
-// Template emission and the apply-side compare-before-set must share this
-// bound with parse_affinity, or an untouched template entry stops comparing
-// equal to the value it was observed from. nullopt when nothing manageable
-// remains.
+// Highest CPU number this tool manages on this machine:
+// min(CPU_SETSIZE, _SC_NPROCESSORS_CONF) - 1. The YAML affinity parser and
+// parse_manageable_cpu_list both bound by it, so an untouched template entry
+// compares equal to the observed value it was emitted from.
+int manageable_cpu_bound();
+
+// parse_cpu_list, additionally dropping CPUs above manageable_cpu_bound():
+// the kernel prints affinity over the possible-CPU mask, which can exceed the
+// present CPUs. nullopt when nothing manageable remains.
 std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & s);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -360,14 +360,18 @@ std::optional<std::vector<int>> parse_cpu_list(const std::string & s)
   return result;
 }
 
+int manageable_cpu_bound()
+{
+  return static_cast<int>(std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF))) - 1;
+}
+
 std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & s)
 {
   auto cpus = parse_cpu_list(s);
   if (!cpus) {
     return std::nullopt;
   }
-  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
-  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
+  const int max_cpu = manageable_cpu_bound();
   cpus->erase(
     std::remove_if(cpus->begin(), cpus->end(), [max_cpu](int cpu) { return cpu > max_cpu; }),
     cpus->end());

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -3,7 +3,6 @@
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 
-#include <sched.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -151,8 +150,7 @@ std::vector<int> parse_affinity(
     throw std::runtime_error(
       "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + entry_desc);
   }
-  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
-  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
+  const int max_cpu = manageable_cpu_bound();
   for (const auto & cpu_node : affinity) {
     int cpu = 0;
     try {
@@ -165,7 +163,8 @@ std::vector<int> parse_affinity(
     if (cpu < 0 || cpu > max_cpu) {
       throw std::runtime_error(
         "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " + std::to_string(max_cpu) +
-        "] (this machine has " + std::to_string(num_cpus) + " CPUs) for " + entry_desc);
+        "] (this machine has " + std::to_string(sysconf(_SC_NPROCESSORS_CONF)) + " CPUs) for " +
+        entry_desc);
     }
     cpus.push_back(cpu);
   }

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -336,7 +336,7 @@ TEST(ProcessWithCommExists, FindsByExactComm)
   EXPECT_FALSE(acie::process_with_comm_exists("nonexistent", tree.root.string()));
 }
 
-// ---------- is_kworker_comm ----------
+// ---------- is_kworker_comm / manageable_cpu_bound ----------
 
 TEST(IsKworkerComm, MatchesTheKworkerPrefixOnly)
 {
@@ -345,6 +345,12 @@ TEST(IsKworkerComm, MatchesTheKworkerPrefixOnly)
   EXPECT_FALSE(acie::is_kworker_comm("kworker"));
   EXPECT_FALSE(acie::is_kworker_comm("ksoftirqd/0"));
   EXPECT_FALSE(acie::is_kworker_comm(""));
+}
+
+TEST(ManageableCpuBound, IsOneBelowTheSmallerOfCpuSetSizeAndProcessorCount)
+{
+  const long bound = std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF));
+  EXPECT_EQ(acie::manageable_cpu_bound(), static_cast<int>(bound) - 1);
 }
 
 // ---------- format_cpu_list / parse_cpu_list ----------


### PR DESCRIPTION
## Description

Part 7/7 of the `agnocast_cie_thread_configurator` cleanup series.

The manageable-CPU bound, `min(CPU_SETSIZE, _SC_NPROCESSORS_CONF) - 1`, was computed independently in `parse_affinity` (YAML side) and in `parse_manageable_cpu_list` (observed-value side), with a header comment warning that the two must never drift because compare-before-set relies on both sides producing the same canonical CPU list. Replace both with `manageable_cpu_bound()` in `system_scan` and drop the warning; the header now states the shared-bound invariant once, next to the function.

The `parse_affinity` error message is unchanged. A unit test pins `manageable_cpu_bound()` to the formula; the existing `ParseManageableCpuList.DropsCpusAboveTheManageableBound` and `ParseYaml.AcceptsHighestValidAffinityCpu` tests keep computing the bound independently, so they still check the value rather than the function.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1588 (base branch `refactor/cie-tc-kworker-to-system-scan`); only the last commit belongs to this PR. Retarget to `main` once #1588 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
