### PR TITLE
refactor(agnocast_kmod): derive ret_daemon_should_exit only on the idle poll

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1654,12 +1654,13 @@ void agnocast_commit_exit_process(
     }
   }
 
-  *ret_daemon_should_exit = (get_process_num_except_unlink_daemon(ipc_ns) == 0);
+  // Only the idle poll answers this: poll_for_unlink() drains until a call returns no pid and
+  // acts on that call's flag alone, so reporting it earlier would be reporting it to nobody.
+  *ret_daemon_should_exit = (global_pid < 0) && (get_process_num_except_unlink_daemon(ipc_ns) == 0);
 
   // Deregistering only on death would leave a window where a starting process is told a daemon
-  // exists and skips spawning its replacement. Restricted to the idle poll because that is the
-  // only call whose flag poll_for_unlink() acts on; the drain loop discards the rest.
-  if (*ret_daemon_should_exit && global_pid < 0 && caller_pid >= 0) {
+  // exists and skips spawning its replacement.
+  if (*ret_daemon_should_exit && caller_pid >= 0) {
     struct process_info * caller_info = agnocast_find_process_info(caller_pid);
     if (caller_info && caller_info->role == PROCESS_ROLE_UNLINK_DAEMON) {
       hash_del_rcu(&caller_info->node);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -267,7 +267,7 @@ void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct 
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, app_pid, daemon_pid, &daemon_should_exit);
 
   // Assert
-  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
   union ioctl_add_process_args next_args;
   KUNIT_EXPECT_EQ(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -8,10 +8,10 @@
 static const pid_t PID = 1000;
 
 // get_exit_process_cmd tolerates a failed ret_daemon_should_exit copy_to_user because the flag is
-// re-derived on the next poll. That fallback only works if agnocast_commit_exit_process() derives
-// the flag unconditionally, including on an idle poll where Phase 1 found nothing and passes
-// global_pid == -1. These cases pin that down so gating the derivation behind global_pid >= 0
-// cannot silently strand the daemon.
+// re-derived on the next poll. That fallback only works if the idle poll, where Phase 1 found
+// nothing and passes global_pid == -1, is the one that derives it. These cases pin that down so
+// neither gating the derivation behind global_pid >= 0 nor dropping the idle poll's own
+// derivation can silently strand the daemon.
 
 static void setup_one_process(struct kunit * test, const pid_t pid)
 {
@@ -80,9 +80,9 @@ void test_case_get_exit_process_commit_last_process(struct kunit * test)
   agnocast_commit_exit_process(
     current->nsproxy->ipc_ns, next_global_pid, -1, &next_daemon_should_exit);
 
-  // Assert: the flag is still derived on the idle poll that follows the commit.
+  // Assert: the commit that returned a pid says nothing; the idle poll that follows does.
   KUNIT_EXPECT_EQ(test, global_pid, PID);
-  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
   KUNIT_EXPECT_EQ(test, next_global_pid, -1);
   KUNIT_EXPECT_TRUE(test, next_daemon_should_exit);
 }


### PR DESCRIPTION
## Description

`ret_daemon_should_exit` was derived on every commit, but `poll_for_unlink()` drains until a call returns no pid and acts only on that call's flag, so the earlier ones were reported to nobody. Deriving it only on the idle poll makes the field mean "you may exit now", and any side effect keyed off it is then confined to the call user space actually honours -- which is why #1582 had to say `global_pid < 0` again at the deregistration site. That condition now lives once, in the derivation.

## Related links

Follows up on #1582.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Existing cases pin the change from both sides: `test_case_get_exit_process_commit_last_process` now expects the commit that returned a pid to say nothing and the idle poll that follows to say exit, and `test_case_add_process_unlink_daemon_stays_registered_while_draining` expects the same of the daemon's own deregistration.

## Notes for reviewers

No ioctl struct changes: `ret_daemon_should_exit` is still reported the same way, and `poll_for_unlink()` already read it only after its drain loop, so an unchanged agnocastlib behaves identically.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
