### PR TITLE
refactor(agnocast_cie_thread_configurator): extract startup checks into testable core functions

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(yaml-cpp REQUIRED)
 # and the unit tests; not installed.
 add_library(agnocast_thread_configurator_core STATIC
   src/sched_policy.cpp
+  src/startup_checks.cpp
   src/thread_config.cpp
   src/system_scan.cpp
 )
@@ -100,6 +101,11 @@ if(BUILD_TESTING)
     test/test_sched_policy.cpp
   )
   target_link_libraries(test_sched_policy agnocast_thread_configurator_core)
+
+  ament_add_gtest(test_startup_checks
+    test/test_startup_checks.cpp
+  )
+  target_link_libraries(test_startup_checks agnocast_thread_configurator_core yaml-cpp)
 
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -6,7 +6,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <thread>
@@ -15,9 +14,6 @@
 
 namespace agnocast_cie_thread_configurator
 {
-
-// Get hardware information from lscpu command
-std::map<std::string, std::string> get_hardware_info();
 
 // Get default domain ID from ROS_DOMAIN_ID environment variable
 size_t get_default_domain_id();

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "yaml-cpp/yaml.h"
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// The hardware_info entries the template records and startup validates,
+// keyed by the YAML key (model_name, cpu_family, ...). Values come from
+// running lscpu.
+std::map<std::string, std::string> get_hardware_info();
+
+// The parsing half of get_hardware_info, split out so it can be tested
+// without running lscpu. Keeps only the keys hardware_info records; values
+// are whitespace-trimmed.
+std::map<std::string, std::string> parse_lscpu_output(std::string_view output);
+
+// One hardware_info key whose configured value does not match this machine.
+struct HardwareMismatch
+{
+  std::string key;
+  std::string expected;  // value in the YAML
+  std::string actual;    // value on this machine
+};
+
+// Compare the YAML hardware_info section against `current` (typically
+// get_hardware_info()). Keys missing from either side are not compared: the
+// YAML records only what the user wants pinned, and `current` only what lscpu
+// reported on this machine. nullopt when the YAML has no hardware_info
+// section, so the caller can tell "validation skipped" from "no mismatch".
+std::optional<std::vector<HardwareMismatch>> check_hardware_info(
+  const YAML::Node & yaml, const std::map<std::string, std::string> & current);
+
+// One rt_throttling key present in the YAML, compared against the value
+// read_sysctl returned for the corresponding /proc/sys/kernel file.
+struct RtThrottlingCheck
+{
+  std::string key;  // "sched_rt_period_us" or "sched_rt_runtime_us"
+  int expected = 0;
+  std::optional<int> actual;  // nullopt: the sysctl could not be read
+};
+
+struct RtThrottlingReport
+{
+  std::vector<RtThrottlingCheck> checks;  // in YAML key order: period_us, runtime_us
+  bool mismatch = false;                  // some check has a readable actual != expected
+  // Non-empty iff mismatch: operator guidance listing every configured key as
+  // an /etc/sysctl.d entry.
+  std::string sysctl_guidance;
+};
+
+// Writing /proc/sys/kernel/sched_rt_{period,runtime}_us requires root
+// (uid 0); Linux capabilities (CAP_SYS_ADMIN etc.) cannot bypass the proc
+// sysctl DAC check. So the configured values are only compared against the
+// running kernel's, and the caller reports sysctl_guidance on a mismatch.
+// read_sysctl receives the /proc/sys/kernel path and returns nullopt when the
+// value cannot be read (such a key is recorded but never counts as a
+// mismatch); reporting that failure is the reader's job.
+RtThrottlingReport check_rt_throttling(
+  const YAML::Node & yaml,
+  const std::function<std::optional<int>(const std::string & path)> & read_sysctl);
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -1,0 +1,152 @@
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
+
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+// Functor deleter for popen() streams; avoids the -Wignored-attributes that
+// decltype(&pclose) triggers by carrying glibc's attributes into a type arg.
+struct PcloseDeleter
+{
+  void operator()(FILE * stream) const noexcept { pclose(stream); }
+};
+}  // namespace
+
+std::map<std::string, std::string> get_hardware_info()
+{
+  std::array<char, 128> buffer;
+  std::string output;
+  std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
+
+  if (!pipe) {
+    return {};
+  }
+
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    output += buffer.data();
+  }
+
+  return parse_lscpu_output(output);
+}
+
+std::map<std::string, std::string> parse_lscpu_output(std::string_view output)
+{
+  std::map<std::string, std::string> hw_info;
+
+  std::istringstream iss{std::string(output)};
+  std::string line;
+
+  while (std::getline(iss, line)) {
+    size_t colon_pos = line.find(':');
+    if (colon_pos == std::string::npos) {
+      continue;
+    }
+
+    std::string key = line.substr(0, colon_pos);
+    std::string value = line.substr(colon_pos + 1);
+
+    // Trim leading/trailing whitespace from value
+    size_t start = value.find_first_not_of(" \t");
+    size_t end = value.find_last_not_of(" \t\r\n");
+    if (start != std::string::npos && end != std::string::npos) {
+      value = value.substr(start, end - start + 1);
+    }
+
+    // Store relevant hardware information
+    if (key == "Model name") {
+      hw_info["model_name"] = value;
+    } else if (key == "CPU family") {
+      hw_info["cpu_family"] = value;
+    } else if (key == "Model") {
+      hw_info["model"] = value;
+    } else if (key == "Thread(s) per core") {
+      hw_info["threads_per_core"] = value;
+    } else if (key == "Frequency boost") {
+      hw_info["frequency_boost"] = value;
+    } else if (key == "CPU max MHz") {
+      hw_info["cpu_max_mhz"] = value;
+    } else if (key == "CPU min MHz") {
+      hw_info["cpu_min_mhz"] = value;
+    }
+  }
+
+  return hw_info;
+}
+
+std::optional<std::vector<HardwareMismatch>> check_hardware_info(
+  const YAML::Node & yaml, const std::map<std::string, std::string> & current)
+{
+  if (!yaml["hardware_info"]) {
+    return std::nullopt;
+  }
+
+  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
+  std::vector<HardwareMismatch> mismatches;
+
+  for (const auto & [key, current_value] : current) {
+    if (!yaml_hw_info[key]) {
+      continue;
+    }
+
+    std::string yaml_value = yaml_hw_info[key].as<std::string>();
+    if (yaml_value != current_value) {
+      mismatches.push_back({key, yaml_value, current_value});
+    }
+  }
+
+  return mismatches;
+}
+
+RtThrottlingReport check_rt_throttling(
+  const YAML::Node & yaml,
+  const std::function<std::optional<int>(const std::string & path)> & read_sysctl)
+{
+  RtThrottlingReport report;
+  if (!yaml["rt_throttling"]) {
+    return report;
+  }
+
+  const auto & rt_bw = yaml["rt_throttling"];
+
+  for (const char * yaml_key : {"period_us", "runtime_us"}) {
+    if (!rt_bw[yaml_key]) {
+      continue;
+    }
+    RtThrottlingCheck check;
+    check.key = std::string("sched_rt_") + yaml_key;
+    check.expected = rt_bw[yaml_key].as<int>();
+    check.actual = read_sysctl("/proc/sys/kernel/" + check.key);
+    if (check.actual.has_value() && *check.actual != check.expected) {
+      report.mismatch = true;
+    }
+    report.checks.push_back(std::move(check));
+  }
+
+  if (report.mismatch) {
+    std::string message =
+      "rt_throttling values do not match the configuration. "
+      "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+      "(or run 'sudo sysctl --system'):\n";
+
+    if (rt_bw["period_us"]) {
+      message +=
+        "  kernel.sched_rt_period_us = " + std::to_string(rt_bw["period_us"].as<int>()) + "\n";
+    }
+    if (rt_bw["runtime_us"]) {
+      message += "  kernel.sched_rt_runtime_us = " + std::to_string(rt_bw["runtime_us"].as<int>());
+    }
+
+    report.sysctl_guidance = std::move(message);
+  }
+
+  return report;
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -3,6 +3,7 @@
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -211,17 +212,8 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
 void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
 {
-  if (!yaml["rt_throttling"]) {
-    return;
-  }
-
-  const auto & rt_bw = yaml["rt_throttling"];
-
-  // Writing to /proc/sys/kernel/sched_rt_{period,runtime}_us requires root (uid 0).
-  // Linux capabilities (CAP_SYS_ADMIN etc.) cannot bypass the proc sysctl DAC check.
-  // Instead, we validate that the current kernel values match the config and guide the
-  // user to apply them via /etc/sysctl.d/ if they differ.
-
+  // The reader reports its own failures; check_rt_throttling records such a
+  // key with an unset actual, which is skipped below.
   auto read_sysctl = [this](const std::string & path) -> std::optional<int> {
     std::ifstream file(path);
     if (!file) {
@@ -236,91 +228,48 @@ void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
     return value;
   };
 
-  bool mismatch = false;
+  const auto report = agnocast_cie_thread_configurator::check_rt_throttling(yaml, read_sysctl);
 
-  if (rt_bw["period_us"]) {
-    int expected = rt_bw["period_us"].as<int>();
-    auto actual = read_sysctl("/proc/sys/kernel/sched_rt_period_us");
-    if (actual.has_value()) {
-      if (actual.value() != expected) {
-        RCLCPP_ERROR(
-          this->get_logger(), "sched_rt_period_us mismatch: expected %d, actual %d", expected,
-          actual.value());
-        mismatch = true;
-      } else {
-        RCLCPP_INFO(this->get_logger(), "sched_rt_period_us is already set to %d", expected);
-      }
+  for (const auto & check : report.checks) {
+    if (!check.actual.has_value()) {
+      continue;
+    }
+    if (*check.actual != check.expected) {
+      RCLCPP_ERROR(
+        this->get_logger(), "%s mismatch: expected %d, actual %d", check.key.c_str(),
+        check.expected, *check.actual);
+    } else {
+      RCLCPP_INFO(this->get_logger(), "%s is already set to %d", check.key.c_str(), check.expected);
     }
   }
 
-  if (rt_bw["runtime_us"]) {
-    int expected = rt_bw["runtime_us"].as<int>();
-    auto actual = read_sysctl("/proc/sys/kernel/sched_rt_runtime_us");
-    if (actual.has_value()) {
-      if (actual.value() != expected) {
-        RCLCPP_ERROR(
-          this->get_logger(), "sched_rt_runtime_us mismatch: expected %d, actual %d", expected,
-          actual.value());
-        mismatch = true;
-      } else {
-        RCLCPP_INFO(this->get_logger(), "sched_rt_runtime_us is already set to %d", expected);
-      }
-    }
-  }
-
-  if (mismatch) {
-    std::string message =
-      "rt_throttling values do not match the configuration. "
-      "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
-      "(or run 'sudo sysctl --system'):\n";
-
-    if (rt_bw["period_us"]) {
-      message +=
-        "  kernel.sched_rt_period_us = " + std::to_string(rt_bw["period_us"].as<int>()) + "\n";
-    }
-    if (rt_bw["runtime_us"]) {
-      message += "  kernel.sched_rt_runtime_us = " + std::to_string(rt_bw["runtime_us"].as<int>());
-    }
-
-    RCLCPP_ERROR(this->get_logger(), "%s", message.c_str());
+  if (report.mismatch) {
+    RCLCPP_ERROR(this->get_logger(), "%s", report.sysctl_guidance.c_str());
   }
 }
 
 void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
 {
-  if (!yaml["hardware_info"]) {
+  const auto mismatches = agnocast_cie_thread_configurator::check_hardware_info(
+    yaml, agnocast_cie_thread_configurator::get_hardware_info());
+  if (!mismatches.has_value()) {
     RCLCPP_WARN(
       this->get_logger(),
       "No hardware_info section found in configuration file. Skipping hardware validation.");
     return;
   }
 
-  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
-  const auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
-
-  std::vector<std::string> mismatches;
-
-  for (const auto & [key, current_value] : current_hw_info) {
-    if (!yaml_hw_info[key]) {
-      continue;
-    }
-
-    std::string yaml_value = yaml_hw_info[key].as<std::string>();
-    if (yaml_value != current_value) {
-      mismatches.push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
-    }
-  }
-
-  if (!mismatches.empty()) {
+  if (!mismatches->empty()) {
     std::string error_msg = "Hardware validation failed with the following mismatches:\n";
-    for (const auto & mismatch : mismatches) {
-      error_msg += "  - " + mismatch + "\n";
+    for (const auto & mismatch : *mismatches) {
+      error_msg += "  - " + mismatch.key + ": expected '" + mismatch.expected + "', got '" +
+                   mismatch.actual + "'\n";
     }
     throw std::runtime_error(error_msg);
-  } else {
-    RCLCPP_INFO(
-      this->get_logger(), "Hardware validation successful. Configuration matches this system.");
   }
+
+  RCLCPP_INFO(
+    this->get_logger(), "Hardware validation successful. Configuration matches this system.");
 }
 
 ThreadConfiguratorNode::~ThreadConfiguratorNode()

--- a/src/agnocast_cie_thread_configurator/src/util.cpp
+++ b/src/agnocast_cie_thread_configurator/src/util.cpp
@@ -1,85 +1,12 @@
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <array>
-#include <chrono>
-#include <cstdio>
 #include <cstdlib>
-#include <functional>
 #include <memory>
-#include <sstream>
 #include <string>
 
 namespace agnocast_cie_thread_configurator
 {
-
-namespace
-{
-// Functor deleter for popen() streams; avoids the -Wignored-attributes that
-// decltype(&pclose) triggers by carrying glibc's attributes into a type arg.
-struct PcloseDeleter
-{
-  void operator()(FILE * stream) const noexcept { pclose(stream); }
-};
-}  // namespace
-
-std::map<std::string, std::string> get_hardware_info()
-{
-  std::map<std::string, std::string> hw_info;
-
-  // Execute lscpu command and capture output
-  std::array<char, 128> buffer;
-  std::string result;
-  std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
-
-  if (!pipe) {
-    return hw_info;
-  }
-
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    result += buffer.data();
-  }
-
-  // Parse lscpu output
-  std::istringstream iss(result);
-  std::string line;
-
-  while (std::getline(iss, line)) {
-    size_t colon_pos = line.find(':');
-    if (colon_pos == std::string::npos) {
-      continue;
-    }
-
-    std::string key = line.substr(0, colon_pos);
-    std::string value = line.substr(colon_pos + 1);
-
-    // Trim leading/trailing whitespace from value
-    size_t start = value.find_first_not_of(" \t");
-    size_t end = value.find_last_not_of(" \t\r\n");
-    if (start != std::string::npos && end != std::string::npos) {
-      value = value.substr(start, end - start + 1);
-    }
-
-    // Store relevant hardware information
-    if (key == "Model name") {
-      hw_info["model_name"] = value;
-    } else if (key == "CPU family") {
-      hw_info["cpu_family"] = value;
-    } else if (key == "Model") {
-      hw_info["model"] = value;
-    } else if (key == "Thread(s) per core") {
-      hw_info["threads_per_core"] = value;
-    } else if (key == "Frequency boost") {
-      hw_info["frequency_boost"] = value;
-    } else if (key == "CPU max MHz") {
-      hw_info["cpu_max_mhz"] = value;
-    } else if (key == "CPU min MHz") {
-      hw_info["cpu_min_mhz"] = value;
-    }
-  }
-
-  return hw_info;
-}
 
 size_t get_default_domain_id()
 {

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -1,0 +1,201 @@
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
+
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace acie = agnocast_cie_thread_configurator;
+
+// ---------- parse_lscpu_output ----------
+
+TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
+{
+  const char * output =
+    "Architecture:                    x86_64\n"
+    "CPU(s):                          16\n"
+    "Model name:                      AMD Ryzen 7 5800X 8-Core Processor\n"
+    "CPU family:                      25\n"
+    "Model:                           33\n"
+    "Thread(s) per core:              2\n"
+    "Frequency boost:                 enabled\n"
+    "CPU max MHz:                     4850.1948\n"
+    "CPU min MHz:                     2200.0000\n"
+    "Vendor ID:                       AuthenticAMD\n";
+  const auto info = acie::parse_lscpu_output(output);
+  EXPECT_EQ(info.size(), 7u);
+  EXPECT_EQ(info.at("model_name"), "AMD Ryzen 7 5800X 8-Core Processor");
+  EXPECT_EQ(info.at("cpu_family"), "25");
+  EXPECT_EQ(info.at("model"), "33");
+  EXPECT_EQ(info.at("threads_per_core"), "2");
+  EXPECT_EQ(info.at("frequency_boost"), "enabled");
+  EXPECT_EQ(info.at("cpu_max_mhz"), "4850.1948");
+  EXPECT_EQ(info.at("cpu_min_mhz"), "2200.0000");
+}
+
+TEST(ParseLscpuOutput, TrimsWhitespaceAroundValues)
+{
+  const auto info = acie::parse_lscpu_output("Model name:\t  Cortex-A76  \r\n");
+  ASSERT_EQ(info.size(), 1u);
+  EXPECT_EQ(info.at("model_name"), "Cortex-A76");
+}
+
+TEST(ParseLscpuOutput, IgnoresMalformedAndUnknownLines)
+{
+  EXPECT_TRUE(acie::parse_lscpu_output("").empty());
+  EXPECT_TRUE(acie::parse_lscpu_output("no colon here\n").empty());
+  EXPECT_TRUE(acie::parse_lscpu_output("Vendor ID: GenuineIntel\n").empty());
+  // "BIOS Model name" must not be picked up as "Model name".
+  EXPECT_TRUE(acie::parse_lscpu_output("BIOS Model name: To Be Filled By O.E.M.\n").empty());
+}
+
+// ---------- check_hardware_info ----------
+
+TEST(CheckHardwareInfo, MissingSectionMeansSkippedNotPassed)
+{
+  const auto result =
+    acie::check_hardware_info(YAML::Load("callback_groups: []"), {{"model", "33"}});
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckHardwareInfo, MatchingValuesYieldNoMismatch)
+{
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_family: '25'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_family", "25"}});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->empty());
+}
+
+TEST(CheckHardwareInfo, ReportsEachMismatchWithExpectedAndActual)
+{
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  threads_per_core: '2'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "44"}, {"threads_per_core", "1"}});
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->size(), 2u);
+  // `current` is a std::map, so mismatches come back in key order.
+  EXPECT_EQ((*result)[0].key, "model");
+  EXPECT_EQ((*result)[0].expected, "33");
+  EXPECT_EQ((*result)[0].actual, "44");
+  EXPECT_EQ((*result)[1].key, "threads_per_core");
+  EXPECT_EQ((*result)[1].expected, "2");
+  EXPECT_EQ((*result)[1].actual, "1");
+}
+
+TEST(CheckHardwareInfo, ComparesOnlyKeysPresentOnBothSides)
+{
+  // The YAML pins keys this machine did not report, and the machine reports
+  // keys the YAML does not pin; neither may produce a mismatch.
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_max_mhz: '9999'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_min_mhz", "2200"}});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->empty());
+}
+
+// ---------- check_rt_throttling ----------
+
+namespace
+{
+
+// read_sysctl double: records the requested paths and serves fixed values.
+struct FakeSysctl
+{
+  std::map<std::string, std::optional<int>> values;
+  mutable std::vector<std::string> requested;
+
+  std::function<std::optional<int>(const std::string &)> reader() const
+  {
+    return [this](const std::string & path) {
+      requested.push_back(path);
+      const auto it = values.find(path);
+      return it == values.end() ? std::nullopt : it->second;
+    };
+  }
+};
+
+constexpr const char * k_period_path = "/proc/sys/kernel/sched_rt_period_us";
+constexpr const char * k_runtime_path = "/proc/sys/kernel/sched_rt_runtime_us";
+
+}  // namespace
+
+TEST(CheckRtThrottling, MissingSectionYieldsEmptyReport)
+{
+  FakeSysctl sysctl;
+  const auto report = acie::check_rt_throttling(YAML::Load("callback_groups: []"), sysctl.reader());
+  EXPECT_TRUE(report.checks.empty());
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
+  EXPECT_TRUE(sysctl.requested.empty());
+}
+
+TEST(CheckRtThrottling, ReadsTheKernelSysctlPathsInYamlKeyOrder)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_period_path] = 1000000;
+  sysctl.values[k_runtime_path] = 950000;
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_EQ(sysctl.requested, (std::vector<std::string>{k_period_path, k_runtime_path}));
+  ASSERT_EQ(report.checks.size(), 2u);
+  EXPECT_EQ(report.checks[0].key, "sched_rt_period_us");
+  EXPECT_EQ(report.checks[0].expected, 1000000);
+  EXPECT_EQ(report.checks[0].actual, 1000000);
+  EXPECT_EQ(report.checks[1].key, "sched_rt_runtime_us");
+  EXPECT_EQ(report.checks[1].expected, 950000);
+  EXPECT_EQ(report.checks[1].actual, 950000);
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
+}
+
+TEST(CheckRtThrottling, MismatchGuidanceListsEveryConfiguredKey)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_period_path] = 1000000;  // matches
+  sysctl.values[k_runtime_path] = -1;      // differs
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_TRUE(report.mismatch);
+  EXPECT_EQ(
+    report.sysctl_guidance,
+    "rt_throttling values do not match the configuration. "
+    "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+    "(or run 'sudo sysctl --system'):\n"
+    "  kernel.sched_rt_period_us = 1000000\n"
+    "  kernel.sched_rt_runtime_us = 950000");
+}
+
+TEST(CheckRtThrottling, ChecksOnlyTheConfiguredKeys)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_runtime_path] = -1;
+  const auto yaml = YAML::Load("rt_throttling:\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_EQ(sysctl.requested, (std::vector<std::string>{k_runtime_path}));
+  ASSERT_EQ(report.checks.size(), 1u);
+  EXPECT_EQ(report.checks[0].key, "sched_rt_runtime_us");
+  EXPECT_TRUE(report.mismatch);
+  EXPECT_EQ(
+    report.sysctl_guidance,
+    "rt_throttling values do not match the configuration. "
+    "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+    "(or run 'sudo sysctl --system'):\n"
+    "  kernel.sched_rt_runtime_us = 950000");
+}
+
+TEST(CheckRtThrottling, UnreadableSysctlIsRecordedButNeverAMismatch)
+{
+  FakeSysctl sysctl;  // serves nothing: every read returns nullopt
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  ASSERT_EQ(report.checks.size(), 2u);
+  EXPECT_FALSE(report.checks[0].actual.has_value());
+  EXPECT_FALSE(report.checks[1].actual.has_value());
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
+}


### PR DESCRIPTION
## Description

Extracts the startup validation logic out of `ThreadConfiguratorNode` and `util.cpp` into a new core-library module, `startup_checks.{hpp,cpp}`, so it can be unit-tested without a node, a real `/proc`, or `lscpu`:

- `parse_lscpu_output`: the parsing half of `get_hardware_info`, split from the `popen` call.
- `check_hardware_info`: compares the YAML `hardware_info` section against this machine's values and returns structured mismatches (`HardwareMismatch{key, expected, actual}`); `nullopt` distinguishes "section absent, validation skipped" from "no mismatch".
- `check_rt_throttling`: compares the `rt_throttling` section against the running kernel through an injected `read_sysctl` function and builds the `/etc/sysctl.d` guidance text. Writing these sysctls requires uid 0 (capabilities cannot bypass the proc sysctl DAC check), which is why the daemon checks and guides instead of writing; that rationale now lives on the function's declaration.
- `get_hardware_info` itself (now `popen` + `parse_lscpu_output`) moves from the installed shared library into the core static library: its only callers are the two daemon executables, and the shared library should not depend on the core. Its declaration leaves the public umbrella header `cie_thread_configurator.hpp`; nothing outside this package uses it (checked repo-wide), and after the move the symbol would no longer be in the installed `.so` anyway.

The node's `validate_hardware_info` / `validate_rt_throttling` become thin wrappers that only log and throw; every log line and the thrown message text are unchanged. Two side effects of the restructuring, both cosmetic:

- `lscpu` now runs once at startup even when the YAML has no `hardware_info` section (the section check happens inside `check_hardware_info`, after the current values are gathered).
- When a sysctl cannot be read, its error line (logged by the injected reader) now appears before the per-key match/mismatch lines instead of interleaved with them, because the checks are computed before they are reported.

`test_startup_checks.cpp` covers the lscpu parsing (recorded keys only, whitespace trimming, malformed and near-miss lines), the hardware comparison (skipped vs passed vs structured mismatches, keys compared only when present on both sides), and the rt_throttling report (sysctl paths and key order, byte-exact guidance text, unreadable sysctls never counting as a mismatch).

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
