### PR TITLE
refactor(agnocast_cie_thread_configurator): move the lscpu hardware-info reader into the core library

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(yaml-cpp REQUIRED)
 # and the unit tests; not installed.
 add_library(agnocast_thread_configurator_core STATIC
   src/sched_policy.cpp
+  src/startup_checks.cpp
   src/thread_config.cpp
   src/system_scan.cpp
 )
@@ -100,6 +101,11 @@ if(BUILD_TESTING)
     test/test_sched_policy.cpp
   )
   target_link_libraries(test_sched_policy agnocast_thread_configurator_core)
+
+  ament_add_gtest(test_startup_checks
+    test/test_startup_checks.cpp
+  )
+  target_link_libraries(test_startup_checks agnocast_thread_configurator_core yaml-cpp)
 
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp

--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -105,7 +105,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_startup_checks
     test/test_startup_checks.cpp
   )
-  target_link_libraries(test_startup_checks agnocast_thread_configurator_core yaml-cpp)
+  target_link_libraries(test_startup_checks agnocast_thread_configurator_core)
 
   ament_add_gtest(test_thread_config
     test/test_thread_config.cpp

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -6,7 +6,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <thread>
@@ -15,9 +14,6 @@
 
 namespace agnocast_cie_thread_configurator
 {
-
-// Get hardware information from lscpu command
-std::map<std::string, std::string> get_hardware_info();
 
 // Get default domain ID from ROS_DOMAIN_ID environment variable
 size_t get_default_domain_id();

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -9,8 +10,9 @@ namespace agnocast_cie_thread_configurator
 
 // The hardware_info entries the template records and startup validates,
 // keyed by the YAML key (model_name, cpu_family, ...). Values come from
-// running lscpu.
-std::map<std::string, std::string> get_hardware_info();
+// running lscpu; nullopt when lscpu cannot be started, exits nonzero, or
+// its output cannot be read, so callers can tell failure from "no data".
+std::optional<std::map<std::string, std::string>> get_hardware_info();
 
 // The parsing half of get_hardware_info, split out so it can be tested
 // without running lscpu. Keeps only the keys hardware_info records; values

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// The hardware_info entries the template records and startup validates,
+// keyed by the YAML key (model_name, cpu_family, ...). Values come from
+// running lscpu.
+std::map<std::string, std::string> get_hardware_info();
+
+// The parsing half of get_hardware_info, split out so it can be tested
+// without running lscpu. Keeps only the keys hardware_info records; values
+// are whitespace-trimmed.
+std::map<std::string, std::string> parse_lscpu_output(std::string_view output);
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -1,22 +1,19 @@
 #pragma once
 
 #include <map>
-#include <optional>
 #include <string>
-#include <string_view>
 
 namespace agnocast_cie_thread_configurator
 {
 
-// The hardware_info entries the template records and startup validates,
-// keyed by the YAML key (model_name, cpu_family, ...). Values come from
-// running lscpu; nullopt when lscpu cannot be started, exits nonzero, or
-// its output cannot be read, so callers can tell failure from "no data".
-std::optional<std::map<std::string, std::string>> get_hardware_info();
+// The hardware_info entries the template records and startup validates, keyed
+// by the YAML key (model_name, cpu_family, ...). Empty when lscpu cannot be
+// run or reports none of them: callers have nothing to record or compare.
+std::map<std::string, std::string> get_hardware_info();
 
 // The parsing half of get_hardware_info, split out so it can be tested
 // without running lscpu. Keeps only the keys hardware_info records; values
 // are whitespace-trimmed.
-std::map<std::string, std::string> parse_lscpu_output(std::string_view output);
+std::map<std::string, std::string> parse_lscpu_output(const std::string & output);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/package.xml
+++ b/src/agnocast_cie_thread_configurator/package.xml
@@ -25,6 +25,9 @@
 
   <depend>agnocast_cie_config_msgs</depend>
 
+  <!-- get_hardware_info shells out to /usr/bin/lscpu -->
+  <exec_depend>util-linux</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/agnocast_cie_thread_configurator/package.xml
+++ b/src/agnocast_cie_thread_configurator/package.xml
@@ -25,9 +25,6 @@
 
   <depend>agnocast_cie_config_msgs</depend>
 
-  <!-- get_hardware_info shells out to /usr/bin/lscpu -->
-  <exec_depend>util-linux</exec_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -156,10 +156,15 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Key << "hardware_info";
   out << YAML::Value << YAML::BeginMap;
 
-  auto hw_info = agnocast_cie_thread_configurator::get_hardware_info();
+  const auto hw_info = agnocast_cie_thread_configurator::get_hardware_info();
 
-  for (const auto & [key, value] : hw_info) {
-    out << YAML::Key << key << YAML::Value << value;
+  if (!hw_info) {
+    RCLCPP_WARN(
+      this->get_logger(), "Failed to read hardware info from lscpu; hardware_info will be empty.");
+  } else {
+    for (const auto & [key, value] : *hw_info) {
+      out << YAML::Key << key << YAML::Value << value;
+    }
   }
 
   out << YAML::EndMap;

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -157,14 +157,12 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Value << YAML::BeginMap;
 
   const auto hw_info = agnocast_cie_thread_configurator::get_hardware_info();
+  if (hw_info.empty()) {
+    RCLCPP_WARN(this->get_logger(), "No hardware info from lscpu; hardware_info will be empty.");
+  }
 
-  if (!hw_info) {
-    RCLCPP_WARN(
-      this->get_logger(), "Failed to read hardware info from lscpu; hardware_info will be empty.");
-  } else {
-    for (const auto & [key, value] : *hw_info) {
-      out << YAML::Key << key << YAML::Value << value;
-    }
+  for (const auto & [key, value] : hw_info) {
+    out << YAML::Key << key << YAML::Value << value;
   }
 
   out << YAML::EndMap;

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -1,0 +1,82 @@
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
+
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <sstream>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+// Functor deleter for popen() streams; avoids the -Wignored-attributes that
+// decltype(&pclose) triggers by carrying glibc's attributes into a type arg.
+struct PcloseDeleter
+{
+  void operator()(FILE * stream) const noexcept { pclose(stream); }
+};
+}  // namespace
+
+std::map<std::string, std::string> get_hardware_info()
+{
+  std::array<char, 128> buffer;
+  std::string output;
+  std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
+
+  if (!pipe) {
+    return {};
+  }
+
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    output += buffer.data();
+  }
+
+  return parse_lscpu_output(output);
+}
+
+std::map<std::string, std::string> parse_lscpu_output(std::string_view output)
+{
+  std::map<std::string, std::string> hw_info;
+
+  std::istringstream iss{std::string(output)};
+  std::string line;
+
+  while (std::getline(iss, line)) {
+    size_t colon_pos = line.find(':');
+    if (colon_pos == std::string::npos) {
+      continue;
+    }
+
+    std::string key = line.substr(0, colon_pos);
+    std::string value = line.substr(colon_pos + 1);
+
+    // Trim leading/trailing whitespace from value
+    size_t start = value.find_first_not_of(" \t");
+    size_t end = value.find_last_not_of(" \t\r\n");
+    if (start != std::string::npos && end != std::string::npos) {
+      value = value.substr(start, end - start + 1);
+    }
+
+    // Store relevant hardware information
+    if (key == "Model name") {
+      hw_info["model_name"] = value;
+    } else if (key == "CPU family") {
+      hw_info["cpu_family"] = value;
+    } else if (key == "Model") {
+      hw_info["model"] = value;
+    } else if (key == "Thread(s) per core") {
+      hw_info["threads_per_core"] = value;
+    } else if (key == "Frequency boost") {
+      hw_info["frequency_boost"] = value;
+    } else if (key == "CPU max MHz") {
+      hw_info["cpu_max_mhz"] = value;
+    } else if (key == "CPU min MHz") {
+      hw_info["cpu_min_mhz"] = value;
+    }
+  }
+
+  return hw_info;
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -2,8 +2,12 @@
 
 #include <array>
 #include <cstdio>
+#include <map>
 #include <memory>
+#include <optional>
 #include <sstream>
+#include <string>
+#include <string_view>
 
 namespace agnocast_cie_thread_configurator
 {
@@ -18,18 +22,26 @@ struct PcloseDeleter
 };
 }  // namespace
 
-std::map<std::string, std::string> get_hardware_info()
+std::optional<std::map<std::string, std::string>> get_hardware_info()
 {
   std::array<char, 128> buffer;
   std::string output;
   std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
 
   if (!pipe) {
-    return {};
+    return std::nullopt;
   }
 
   while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
     output += buffer.data();
+  }
+
+  // A missing lscpu binary is not a popen failure: the shell still runs and
+  // exits 127, so failures only surface through ferror and the exit status.
+  const bool read_error = ferror(pipe.get()) != 0;
+  const int exit_status = pclose(pipe.release());
+  if (read_error || exit_status != 0) {
+    return std::nullopt;
   }
 
   return parse_lscpu_output(output);
@@ -49,13 +61,19 @@ std::map<std::string, std::string> parse_lscpu_output(std::string_view output)
     }
 
     std::string key = line.substr(0, colon_pos);
+    // lscpu >= 2.38 indents keys in its hierarchic summary output.
+    const size_t key_start = key.find_first_not_of(" \t");
+    key.erase(0, key_start == std::string::npos ? key.size() : key_start);
+
     std::string value = line.substr(colon_pos + 1);
 
     // Trim leading/trailing whitespace from value
-    size_t start = value.find_first_not_of(" \t");
-    size_t end = value.find_last_not_of(" \t\r\n");
-    if (start != std::string::npos && end != std::string::npos) {
-      value = value.substr(start, end - start + 1);
+    constexpr const char * whitespace = " \t\r\n";
+    const size_t start = value.find_first_not_of(whitespace);
+    if (start == std::string::npos) {
+      value.clear();
+    } else {
+      value = value.substr(start, value.find_last_not_of(whitespace) - start + 1);
     }
 
     // Store relevant hardware information

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <map>
 #include <memory>
-#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -14,83 +13,65 @@ namespace agnocast_cie_thread_configurator
 
 namespace
 {
-// Functor deleter for popen() streams; avoids the -Wignored-attributes that
-// decltype(&pclose) triggers by carrying glibc's attributes into a type arg.
-struct PcloseDeleter
+
+std::string_view trim(std::string_view s)
 {
-  void operator()(FILE * stream) const noexcept { pclose(stream); }
-};
+  const size_t begin = s.find_first_not_of(" \t\r\n");
+  if (begin == std::string_view::npos) {
+    return {};
+  }
+  return s.substr(begin, s.find_last_not_of(" \t\r\n") - begin + 1);
+}
+
+// lscpu label -> the hardware_info key it is recorded under. Labels are
+// matched after trimming, so the indented hierarchic summary layout of
+// util-linux >= 2.38 matches too; the match stays exact, so "BIOS Model name"
+// is still not "Model name".
+const std::map<std::string_view, std::string> kRecordedKeys{
+  {"Model name", "model_name"},
+  {"CPU family", "cpu_family"},
+  {"Model", "model"},
+  {"Thread(s) per core", "threads_per_core"},
+  {"Frequency boost", "frequency_boost"},
+  {"CPU max MHz", "cpu_max_mhz"},
+  {"CPU min MHz", "cpu_min_mhz"}};
+
 }  // namespace
 
-std::optional<std::map<std::string, std::string>> get_hardware_info()
+std::map<std::string, std::string> get_hardware_info()
 {
   std::array<char, 128> buffer;
   std::string output;
-  std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
+  std::unique_ptr<FILE, int (*)(FILE *)> pipe(popen("/usr/bin/lscpu", "r"), pclose);
 
   if (!pipe) {
-    return std::nullopt;
+    return {};
   }
 
   while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
     output += buffer.data();
   }
 
-  // A missing lscpu binary is not a popen failure: the shell still runs and
-  // exits 127, so failures only surface through ferror and the exit status.
-  const bool read_error = ferror(pipe.get()) != 0;
-  const int exit_status = pclose(pipe.release());
-  if (read_error || exit_status != 0) {
-    return std::nullopt;
-  }
-
   return parse_lscpu_output(output);
 }
 
-std::map<std::string, std::string> parse_lscpu_output(std::string_view output)
+std::map<std::string, std::string> parse_lscpu_output(const std::string & output)
 {
   std::map<std::string, std::string> hw_info;
 
-  std::istringstream iss{std::string(output)};
+  std::istringstream iss(output);
   std::string line;
 
   while (std::getline(iss, line)) {
-    size_t colon_pos = line.find(':');
+    const size_t colon_pos = line.find(':');
     if (colon_pos == std::string::npos) {
       continue;
     }
 
-    std::string key = line.substr(0, colon_pos);
-    // lscpu >= 2.38 indents keys in its hierarchic summary output.
-    const size_t key_start = key.find_first_not_of(" \t");
-    key.erase(0, key_start == std::string::npos ? key.size() : key_start);
-
-    std::string value = line.substr(colon_pos + 1);
-
-    // Trim leading/trailing whitespace from value
-    constexpr const char * whitespace = " \t\r\n";
-    const size_t start = value.find_first_not_of(whitespace);
-    if (start == std::string::npos) {
-      value.clear();
-    } else {
-      value = value.substr(start, value.find_last_not_of(whitespace) - start + 1);
-    }
-
-    // Store relevant hardware information
-    if (key == "Model name") {
-      hw_info["model_name"] = value;
-    } else if (key == "CPU family") {
-      hw_info["cpu_family"] = value;
-    } else if (key == "Model") {
-      hw_info["model"] = value;
-    } else if (key == "Thread(s) per core") {
-      hw_info["threads_per_core"] = value;
-    } else if (key == "Frequency boost") {
-      hw_info["frequency_boost"] = value;
-    } else if (key == "CPU max MHz") {
-      hw_info["cpu_max_mhz"] = value;
-    } else if (key == "CPU min MHz") {
-      hw_info["cpu_min_mhz"] = value;
+    const std::string_view sv{line};
+    const auto it = kRecordedKeys.find(trim(sv.substr(0, colon_pos)));
+    if (it != kRecordedKeys.end()) {
+      hw_info[it->second] = trim(sv.substr(colon_pos + 1));
     }
   }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -299,15 +299,14 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   const YAML::Node & yaml_hw_info = yaml["hardware_info"];
   const auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
 
-  if (!current_hw_info) {
-    RCLCPP_WARN(
-      this->get_logger(), "Failed to read hardware info from lscpu. Skipping hardware validation.");
+  if (current_hw_info.empty()) {
+    RCLCPP_WARN(this->get_logger(), "No hardware info from lscpu. Skipping hardware validation.");
     return;
   }
 
   std::vector<std::string> mismatches;
 
-  for (const auto & [key, current_value] : *current_hw_info) {
+  for (const auto & [key, current_value] : current_hw_info) {
     if (!yaml_hw_info[key]) {
       continue;
     }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -299,9 +299,15 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   const YAML::Node & yaml_hw_info = yaml["hardware_info"];
   const auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
 
+  if (!current_hw_info) {
+    RCLCPP_WARN(
+      this->get_logger(), "Failed to read hardware info from lscpu. Skipping hardware validation.");
+    return;
+  }
+
   std::vector<std::string> mismatches;
 
-  for (const auto & [key, current_value] : current_hw_info) {
+  for (const auto & [key, current_value] : *current_hw_info) {
     if (!yaml_hw_info[key]) {
       continue;
     }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -3,6 +3,7 @@
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
 #include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -305,12 +305,14 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   }
 
   std::vector<std::string> mismatches;
+  size_t compared_count = 0;
 
   for (const auto & [key, current_value] : current_hw_info) {
     if (!yaml_hw_info[key]) {
       continue;
     }
 
+    compared_count++;
     std::string yaml_value = yaml_hw_info[key].as<std::string>();
     if (yaml_value != current_value) {
       mismatches.push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
@@ -323,10 +325,17 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
       error_msg += "  - " + mismatch + "\n";
     }
     throw std::runtime_error(error_msg);
-  } else {
-    RCLCPP_INFO(
-      this->get_logger(), "Hardware validation successful. Configuration matches this system.");
   }
+
+  if (compared_count == 0) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "hardware_info has none of the keys reported by lscpu. Skipping hardware validation.");
+    return;
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(), "Hardware validation successful. Configuration matches this system.");
 }
 
 ThreadConfiguratorNode::~ThreadConfiguratorNode()

--- a/src/agnocast_cie_thread_configurator/src/util.cpp
+++ b/src/agnocast_cie_thread_configurator/src/util.cpp
@@ -1,85 +1,12 @@
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <array>
-#include <chrono>
-#include <cstdio>
 #include <cstdlib>
-#include <functional>
 #include <memory>
-#include <sstream>
 #include <string>
 
 namespace agnocast_cie_thread_configurator
 {
-
-namespace
-{
-// Functor deleter for popen() streams; avoids the -Wignored-attributes that
-// decltype(&pclose) triggers by carrying glibc's attributes into a type arg.
-struct PcloseDeleter
-{
-  void operator()(FILE * stream) const noexcept { pclose(stream); }
-};
-}  // namespace
-
-std::map<std::string, std::string> get_hardware_info()
-{
-  std::map<std::string, std::string> hw_info;
-
-  // Execute lscpu command and capture output
-  std::array<char, 128> buffer;
-  std::string result;
-  std::unique_ptr<FILE, PcloseDeleter> pipe(popen("/usr/bin/lscpu", "r"));
-
-  if (!pipe) {
-    return hw_info;
-  }
-
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    result += buffer.data();
-  }
-
-  // Parse lscpu output
-  std::istringstream iss(result);
-  std::string line;
-
-  while (std::getline(iss, line)) {
-    size_t colon_pos = line.find(':');
-    if (colon_pos == std::string::npos) {
-      continue;
-    }
-
-    std::string key = line.substr(0, colon_pos);
-    std::string value = line.substr(colon_pos + 1);
-
-    // Trim leading/trailing whitespace from value
-    size_t start = value.find_first_not_of(" \t");
-    size_t end = value.find_last_not_of(" \t\r\n");
-    if (start != std::string::npos && end != std::string::npos) {
-      value = value.substr(start, end - start + 1);
-    }
-
-    // Store relevant hardware information
-    if (key == "Model name") {
-      hw_info["model_name"] = value;
-    } else if (key == "CPU family") {
-      hw_info["cpu_family"] = value;
-    } else if (key == "Model") {
-      hw_info["model"] = value;
-    } else if (key == "Thread(s) per core") {
-      hw_info["threads_per_core"] = value;
-    } else if (key == "Frequency boost") {
-      hw_info["frequency_boost"] = value;
-    } else if (key == "CPU max MHz") {
-      hw_info["cpu_max_mhz"] = value;
-    } else if (key == "CPU min MHz") {
-      hw_info["cpu_min_mhz"] = value;
-    }
-  }
-
-  return hw_info;
-}
 
 size_t get_default_domain_id()
 {

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -4,8 +4,6 @@
 
 namespace acie = agnocast_cie_thread_configurator;
 
-// ---------- parse_lscpu_output ----------
-
 TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
 {
   const char * output =
@@ -30,19 +28,14 @@ TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
   EXPECT_EQ(info.at("cpu_min_mhz"), "2200.0000");
 }
 
-TEST(ParseLscpuOutput, TrimsWhitespaceAroundValues)
+TEST(ParseLscpuOutput, TrimsValuesAndEmptiesWhitespaceOnlyOnes)
 {
-  const auto info = acie::parse_lscpu_output("Model name:\t  Cortex-A76  \r\n");
-  ASSERT_EQ(info.size(), 1u);
+  const auto info =
+    acie::parse_lscpu_output("Model name:\t  Cortex-A76  \r\nFrequency boost:   \r\nModel:\n");
+  ASSERT_EQ(info.size(), 3u);
   EXPECT_EQ(info.at("model_name"), "Cortex-A76");
-}
-
-TEST(ParseLscpuOutput, TrimsWhitespaceOnlyValuesToEmpty)
-{
-  const auto info = acie::parse_lscpu_output("Frequency boost:   \r\nModel name:\n");
-  ASSERT_EQ(info.size(), 2u);
   EXPECT_EQ(info.at("frequency_boost"), "");
-  EXPECT_EQ(info.at("model_name"), "");
+  EXPECT_EQ(info.at("model"), "");
 }
 
 TEST(ParseLscpuOutput, MatchesIndentedHierarchicKeys)

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -1,0 +1,47 @@
+#include "agnocast_cie_thread_configurator/startup_checks.hpp"
+
+#include <gtest/gtest.h>
+
+namespace acie = agnocast_cie_thread_configurator;
+
+// ---------- parse_lscpu_output ----------
+
+TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
+{
+  const char * output =
+    "Architecture:                    x86_64\n"
+    "CPU(s):                          16\n"
+    "Model name:                      AMD Ryzen 7 5800X 8-Core Processor\n"
+    "CPU family:                      25\n"
+    "Model:                           33\n"
+    "Thread(s) per core:              2\n"
+    "Frequency boost:                 enabled\n"
+    "CPU max MHz:                     4850.1948\n"
+    "CPU min MHz:                     2200.0000\n"
+    "Vendor ID:                       AuthenticAMD\n";
+  const auto info = acie::parse_lscpu_output(output);
+  EXPECT_EQ(info.size(), 7u);
+  EXPECT_EQ(info.at("model_name"), "AMD Ryzen 7 5800X 8-Core Processor");
+  EXPECT_EQ(info.at("cpu_family"), "25");
+  EXPECT_EQ(info.at("model"), "33");
+  EXPECT_EQ(info.at("threads_per_core"), "2");
+  EXPECT_EQ(info.at("frequency_boost"), "enabled");
+  EXPECT_EQ(info.at("cpu_max_mhz"), "4850.1948");
+  EXPECT_EQ(info.at("cpu_min_mhz"), "2200.0000");
+}
+
+TEST(ParseLscpuOutput, TrimsWhitespaceAroundValues)
+{
+  const auto info = acie::parse_lscpu_output("Model name:\t  Cortex-A76  \r\n");
+  ASSERT_EQ(info.size(), 1u);
+  EXPECT_EQ(info.at("model_name"), "Cortex-A76");
+}
+
+TEST(ParseLscpuOutput, IgnoresMalformedAndUnknownLines)
+{
+  EXPECT_TRUE(acie::parse_lscpu_output("").empty());
+  EXPECT_TRUE(acie::parse_lscpu_output("no colon here\n").empty());
+  EXPECT_TRUE(acie::parse_lscpu_output("Vendor ID: GenuineIntel\n").empty());
+  // "BIOS Model name" must not be picked up as "Model name".
+  EXPECT_TRUE(acie::parse_lscpu_output("BIOS Model name: To Be Filled By O.E.M.\n").empty());
+}

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -20,7 +20,7 @@ TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
     "CPU min MHz:                     2200.0000\n"
     "Vendor ID:                       AuthenticAMD\n";
   const auto info = acie::parse_lscpu_output(output);
-  EXPECT_EQ(info.size(), 7u);
+  ASSERT_EQ(info.size(), 7u);
   EXPECT_EQ(info.at("model_name"), "AMD Ryzen 7 5800X 8-Core Processor");
   EXPECT_EQ(info.at("cpu_family"), "25");
   EXPECT_EQ(info.at("model"), "33");
@@ -35,6 +35,29 @@ TEST(ParseLscpuOutput, TrimsWhitespaceAroundValues)
   const auto info = acie::parse_lscpu_output("Model name:\t  Cortex-A76  \r\n");
   ASSERT_EQ(info.size(), 1u);
   EXPECT_EQ(info.at("model_name"), "Cortex-A76");
+}
+
+TEST(ParseLscpuOutput, TrimsWhitespaceOnlyValuesToEmpty)
+{
+  const auto info = acie::parse_lscpu_output("Frequency boost:   \r\nModel name:\n");
+  ASSERT_EQ(info.size(), 2u);
+  EXPECT_EQ(info.at("frequency_boost"), "");
+  EXPECT_EQ(info.at("model_name"), "");
+}
+
+TEST(ParseLscpuOutput, MatchesIndentedHierarchicKeys)
+{
+  // The indented layout util-linux >= 2.38 emits for hybrid-CPU machines.
+  const char * output =
+    "CPU(s):                 20\n"
+    "  Model name:           12th Gen Intel(R) Core(TM) i7-12700H\n"
+    "    CPU family:         6\n"
+    "    Thread(s) per core: 2\n";
+  const auto info = acie::parse_lscpu_output(output);
+  ASSERT_EQ(info.size(), 3u);
+  EXPECT_EQ(info.at("model_name"), "12th Gen Intel(R) Core(TM) i7-12700H");
+  EXPECT_EQ(info.at("cpu_family"), "6");
+  EXPECT_EQ(info.at("threads_per_core"), "2");
 }
 
 TEST(ParseLscpuOutput, IgnoresMalformedAndUnknownLines)


### PR DESCRIPTION
## Description

Part 1/3 of extracting the startup validation logic into unit-testable core functions; together with the two follow-up PRs this supersedes #1597.

Moves the lscpu hardware-info reader out of the installed shared library into the core static library, as a new `startup_checks.{hpp,cpp}` module, and splits `get_hardware_info` into its `popen` half and a pure `parse_lscpu_output` half so the parsing is testable without running lscpu.

- `get_hardware_info` is only called by the two daemon executables, and the installed shared library should not depend on the core static library, so the function moves to the core rather than delegating from `util.cpp`.
- Its declaration leaves the public umbrella header `cie_thread_configurator.hpp`: nothing outside this package uses it (checked repo-wide), and after the move the symbol is no longer in the installed `.so` anyway.

The move also hardens the reader:

- An empty result is reported instead of passing silently. Both daemons log a warning when lscpu yields none of the recorded keys, where an empty map previously made `validate_hardware_info` pass without comparing anything. Every failure mode funnels into that one case: a missing `/usr/bin/lscpu` is not a `popen` failure (the shell exits 127 with empty output), and empty output parses to an empty map.
- Keys are whitespace-trimmed so the hierarchic (indented) summary layout of util-linux >= 2.38 also matches; the comparison stays exact after the trim, so `BIOS Model name` still does not match `Model name`.
- Whitespace-only values are trimmed to empty strings instead of being stored verbatim.

The recorded lscpu labels are a single `kRecordedKeys` table rather than a seven-arm `if`/`else` chain, and one `trim` covers both the label and the value.

`test_startup_checks.cpp` pins the parser: only the recorded keys are kept, values are whitespace-trimmed (whitespace-only values become empty), indented keys match, and malformed or unknown lines are ignored.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
