### PR TITLE
refactor(agnocast_cie_thread_configurator): extract hardware_info validation into a testable check

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -20,22 +20,14 @@ std::map<std::string, std::string> get_hardware_info();
 // are whitespace-trimmed.
 std::map<std::string, std::string> parse_lscpu_output(const std::string & output);
 
-// One hardware_info key whose configured value does not match this machine.
-struct HardwareMismatch
-{
-  std::string key;
-  std::string expected;  // value in the YAML
-  std::string actual;    // value on this machine
-};
-
 // Compare the YAML hardware_info section against `current` (typically
 // get_hardware_info()). Keys missing from either side are not compared, since
 // the YAML records only what the user wants pinned and `current` only what
-// lscpu reported on this machine. nullopt when no key was compared at all,
-// either because the YAML has no hardware_info section or because it pins none
-// of the keys in `current`, so the caller can tell "validation skipped" from
+// lscpu reported on this machine. Each mismatch is a formatted
+// "key: expected 'x', got 'y'" line. nullopt when the section pins none of the
+// keys in `current`, so the caller can tell "validation skipped" from
 // "no mismatch".
-std::optional<std::vector<HardwareMismatch>> check_hardware_info(
-  const YAML::Node & yaml, const std::map<std::string, std::string> & current);
+std::optional<std::vector<std::string>> check_hardware_info(
+  const YAML::Node & hw_info, const std::map<std::string, std::string> & current);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "yaml-cpp/yaml.h"
+
 #include <map>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace agnocast_cie_thread_configurator
 {
@@ -15,5 +19,23 @@ std::map<std::string, std::string> get_hardware_info();
 // without running lscpu. Keeps only the keys hardware_info records; values
 // are whitespace-trimmed.
 std::map<std::string, std::string> parse_lscpu_output(const std::string & output);
+
+// One hardware_info key whose configured value does not match this machine.
+struct HardwareMismatch
+{
+  std::string key;
+  std::string expected;  // value in the YAML
+  std::string actual;    // value on this machine
+};
+
+// Compare the YAML hardware_info section against `current` (typically
+// get_hardware_info()). Keys missing from either side are not compared, since
+// the YAML records only what the user wants pinned and `current` only what
+// lscpu reported on this machine. nullopt when no key was compared at all,
+// either because the YAML has no hardware_info section or because it pins none
+// of the keys in `current`, so the caller can tell "validation skipped" from
+// "no mismatch".
+std::optional<std::vector<HardwareMismatch>> check_hardware_info(
+  const YAML::Node & yaml, const std::map<std::string, std::string> & current);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -78,31 +78,23 @@ std::map<std::string, std::string> parse_lscpu_output(const std::string & output
   return hw_info;
 }
 
-std::optional<std::vector<HardwareMismatch>> check_hardware_info(
-  const YAML::Node & yaml, const std::map<std::string, std::string> & current)
+std::optional<std::vector<std::string>> check_hardware_info(
+  const YAML::Node & hw_info, const std::map<std::string, std::string> & current)
 {
-  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
-  if (!yaml_hw_info) {
-    return std::nullopt;
-  }
-
-  std::vector<HardwareMismatch> mismatches;
-  size_t compared_count = 0;
+  std::optional<std::vector<std::string>> mismatches;
 
   for (const auto & [key, current_value] : current) {
-    if (!yaml_hw_info[key]) {
+    if (!hw_info[key]) {
       continue;
     }
 
-    compared_count++;
-    std::string yaml_value = yaml_hw_info[key].as<std::string>();
-    if (yaml_value != current_value) {
-      mismatches.push_back({key, yaml_value, current_value});
+    if (!mismatches) {
+      mismatches.emplace();
     }
-  }
-
-  if (compared_count == 0) {
-    return std::nullopt;
+    std::string yaml_value = hw_info[key].as<std::string>();
+    if (yaml_value != current_value) {
+      mismatches->push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
+    }
   }
 
   return mismatches;

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -78,4 +78,34 @@ std::map<std::string, std::string> parse_lscpu_output(const std::string & output
   return hw_info;
 }
 
+std::optional<std::vector<HardwareMismatch>> check_hardware_info(
+  const YAML::Node & yaml, const std::map<std::string, std::string> & current)
+{
+  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
+  if (!yaml_hw_info) {
+    return std::nullopt;
+  }
+
+  std::vector<HardwareMismatch> mismatches;
+  size_t compared_count = 0;
+
+  for (const auto & [key, current_value] : current) {
+    if (!yaml_hw_info[key]) {
+      continue;
+    }
+
+    compared_count++;
+    std::string yaml_value = yaml_hw_info[key].as<std::string>();
+    if (yaml_value != current_value) {
+      mismatches.push_back({key, yaml_value, current_value});
+    }
+  }
+
+  if (compared_count == 0) {
+    return std::nullopt;
+  }
+
+  return mismatches;
+}
+
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -296,42 +296,28 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
     return;
   }
 
-  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
   const auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
-
   if (current_hw_info.empty()) {
     RCLCPP_WARN(this->get_logger(), "No hardware info from lscpu. Skipping hardware validation.");
     return;
   }
 
-  std::vector<std::string> mismatches;
-  size_t compared_count = 0;
-
-  for (const auto & [key, current_value] : current_hw_info) {
-    if (!yaml_hw_info[key]) {
-      continue;
-    }
-
-    compared_count++;
-    std::string yaml_value = yaml_hw_info[key].as<std::string>();
-    if (yaml_value != current_value) {
-      mismatches.push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
-    }
-  }
-
-  if (!mismatches.empty()) {
-    std::string error_msg = "Hardware validation failed with the following mismatches:\n";
-    for (const auto & mismatch : mismatches) {
-      error_msg += "  - " + mismatch + "\n";
-    }
-    throw std::runtime_error(error_msg);
-  }
-
-  if (compared_count == 0) {
+  const auto mismatches =
+    agnocast_cie_thread_configurator::check_hardware_info(yaml, current_hw_info);
+  if (!mismatches.has_value()) {
     RCLCPP_WARN(
       this->get_logger(),
       "hardware_info has none of the keys reported by lscpu. Skipping hardware validation.");
     return;
+  }
+
+  if (!mismatches->empty()) {
+    std::string error_msg = "Hardware validation failed with the following mismatches:\n";
+    for (const auto & mismatch : *mismatches) {
+      error_msg += "  - " + mismatch.key + ": expected '" + mismatch.expected + "', got '" +
+                   mismatch.actual + "'\n";
+    }
+    throw std::runtime_error(error_msg);
   }
 
   RCLCPP_INFO(

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -303,7 +303,7 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   }
 
   const auto mismatches =
-    agnocast_cie_thread_configurator::check_hardware_info(yaml, current_hw_info);
+    agnocast_cie_thread_configurator::check_hardware_info(yaml["hardware_info"], current_hw_info);
   if (!mismatches.has_value()) {
     RCLCPP_WARN(
       this->get_logger(),
@@ -314,8 +314,7 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   if (!mismatches->empty()) {
     std::string error_msg = "Hardware validation failed with the following mismatches:\n";
     for (const auto & mismatch : *mismatches) {
-      error_msg += "  - " + mismatch.key + ": expected '" + mismatch.expected + "', got '" +
-                   mismatch.actual + "'\n";
+      error_msg += "  - " + mismatch + "\n";
     }
     throw std::runtime_error(error_msg);
   }

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/startup_checks.hpp"
 
 #include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
 
 namespace acie = agnocast_cie_thread_configurator;
 
@@ -60,4 +61,54 @@ TEST(ParseLscpuOutput, IgnoresMalformedAndUnknownLines)
   EXPECT_TRUE(acie::parse_lscpu_output("Vendor ID: GenuineIntel\n").empty());
   // "BIOS Model name" must not be picked up as "Model name".
   EXPECT_TRUE(acie::parse_lscpu_output("BIOS Model name: To Be Filled By O.E.M.\n").empty());
+}
+
+// ---------- check_hardware_info ----------
+
+TEST(CheckHardwareInfo, MissingSectionMeansSkippedNotPassed)
+{
+  const auto result =
+    acie::check_hardware_info(YAML::Load("callback_groups: []"), {{"model", "33"}});
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckHardwareInfo, NothingComparedMeansSkippedNotPassed)
+{
+  EXPECT_FALSE(
+    acie::check_hardware_info(YAML::Load("hardware_info: {}"), {{"model", "33"}}).has_value());
+  const auto unreported = YAML::Load("hardware_info:\n  cpu_max_mhz: '9999'\n");
+  EXPECT_FALSE(acie::check_hardware_info(unreported, {{"model", "33"}}).has_value());
+}
+
+TEST(CheckHardwareInfo, MatchingValuesYieldNoMismatch)
+{
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_family: '25'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_family", "25"}});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->empty());
+}
+
+TEST(CheckHardwareInfo, ReportsEachMismatchWithExpectedAndActual)
+{
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  threads_per_core: '2'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "44"}, {"threads_per_core", "1"}});
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->size(), 2u);
+  // `current` is a std::map, so mismatches come back in key order.
+  EXPECT_EQ((*result)[0].key, "model");
+  EXPECT_EQ((*result)[0].expected, "33");
+  EXPECT_EQ((*result)[0].actual, "44");
+  EXPECT_EQ((*result)[1].key, "threads_per_core");
+  EXPECT_EQ((*result)[1].expected, "2");
+  EXPECT_EQ((*result)[1].actual, "1");
+}
+
+TEST(CheckHardwareInfo, ComparesOnlyKeysPresentOnBothSides)
+{
+  // The YAML pins keys this machine did not report, and the machine reports
+  // keys the YAML does not pin; neither may produce a mismatch.
+  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_max_mhz: '9999'\n");
+  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_min_mhz", "2200"}});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->empty());
 }

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -1,7 +1,6 @@
 #include "agnocast_cie_thread_configurator/startup_checks.hpp"
 
 #include <gtest/gtest.h>
-#include <yaml-cpp/yaml.h>
 
 namespace acie = agnocast_cie_thread_configurator;
 
@@ -65,50 +64,30 @@ TEST(ParseLscpuOutput, IgnoresMalformedAndUnknownLines)
 
 // ---------- check_hardware_info ----------
 
-TEST(CheckHardwareInfo, MissingSectionMeansSkippedNotPassed)
-{
-  const auto result =
-    acie::check_hardware_info(YAML::Load("callback_groups: []"), {{"model", "33"}});
-  EXPECT_FALSE(result.has_value());
-}
-
 TEST(CheckHardwareInfo, NothingComparedMeansSkippedNotPassed)
 {
-  EXPECT_FALSE(
-    acie::check_hardware_info(YAML::Load("hardware_info: {}"), {{"model", "33"}}).has_value());
-  const auto unreported = YAML::Load("hardware_info:\n  cpu_max_mhz: '9999'\n");
+  EXPECT_FALSE(acie::check_hardware_info(YAML::Load("{}"), {{"model", "33"}}).has_value());
+  const auto unreported = YAML::Load("cpu_max_mhz: '9999'");
   EXPECT_FALSE(acie::check_hardware_info(unreported, {{"model", "33"}}).has_value());
 }
 
 TEST(CheckHardwareInfo, MatchingValuesYieldNoMismatch)
 {
-  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_family: '25'\n");
-  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_family", "25"}});
+  // Keys present on only one side (cpu_max_mhz, cpu_min_mhz) are not compared.
+  const auto yaml = YAML::Load("model: '33'\ncpu_family: '25'\ncpu_max_mhz: '9999'");
+  const auto result = acie::check_hardware_info(
+    yaml, {{"model", "33"}, {"cpu_family", "25"}, {"cpu_min_mhz", "2200"}});
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result->empty());
 }
 
 TEST(CheckHardwareInfo, ReportsEachMismatchWithExpectedAndActual)
 {
-  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  threads_per_core: '2'\n");
+  const auto yaml = YAML::Load("model: '33'\nthreads_per_core: '2'");
   const auto result = acie::check_hardware_info(yaml, {{"model", "44"}, {"threads_per_core", "1"}});
   ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result->size(), 2u);
   // `current` is a std::map, so mismatches come back in key order.
-  EXPECT_EQ((*result)[0].key, "model");
-  EXPECT_EQ((*result)[0].expected, "33");
-  EXPECT_EQ((*result)[0].actual, "44");
-  EXPECT_EQ((*result)[1].key, "threads_per_core");
-  EXPECT_EQ((*result)[1].expected, "2");
-  EXPECT_EQ((*result)[1].actual, "1");
-}
-
-TEST(CheckHardwareInfo, ComparesOnlyKeysPresentOnBothSides)
-{
-  // The YAML pins keys this machine did not report, and the machine reports
-  // keys the YAML does not pin; neither may produce a mismatch.
-  const auto yaml = YAML::Load("hardware_info:\n  model: '33'\n  cpu_max_mhz: '9999'\n");
-  const auto result = acie::check_hardware_info(yaml, {{"model", "33"}, {"cpu_min_mhz", "2200"}});
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result->empty());
+  const std::vector<std::string> expected = {
+    "model: expected '33', got '44'", "threads_per_core: expected '2', got '1'"};
+  EXPECT_EQ(*result, expected);
 }


### PR DESCRIPTION
## Description

Part 2/3 of extracting the startup validation logic into unit-testable core functions (supersedes #1597 together with its neighbors).

Extracts the comparison half of `ThreadConfiguratorNode::validate_hardware_info` into a pure core function so it can be tested without running lscpu or a node.

- `check_hardware_info(hw_info, current)` takes the YAML `hardware_info` section and this machine's values and returns the mismatch lines already formatted as `key: expected 'x', got 'y'`. Keys are compared only when present on both sides, as before.
- The return type is `std::optional<std::vector<std::string>>`. `nullopt` means no key was compared at all, which lets the node keep its "none of the keys reported by lscpu" warning instead of reporting a validation success that compared nothing.
- The node keeps only the section-exists check, the lscpu call, and the logging. All log and exception texts are unchanged.

The function takes the section rather than the YAML root and returns formatted strings rather than a struct, since the node is the only consumer and it checks the section and formats the message itself. That keeps the header to one function and the tests to three cases (skipped, matched, mismatched).

## Related links

- #1598 (part 1, merged)
- #1600 (part 3, stacked on this PR)

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.