### PR TITLE
refactor(agnocast_cie_thread_configurator): extract rt_throttling validation into a testable check

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -2,6 +2,7 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -29,5 +30,34 @@ std::map<std::string, std::string> parse_lscpu_output(const std::string & output
 // "no mismatch".
 std::optional<std::vector<std::string>> check_hardware_info(
   const YAML::Node & hw_info, const std::map<std::string, std::string> & current);
+
+// One rt_throttling key present in the YAML, compared against the value
+// read_sysctl returned for the corresponding /proc/sys/kernel file.
+struct RtThrottlingCheck
+{
+  std::string key;  // "sched_rt_period_us" or "sched_rt_runtime_us"
+  int expected = 0;
+  std::optional<int> actual;  // nullopt: the sysctl could not be read
+};
+
+struct RtThrottlingReport
+{
+  std::vector<RtThrottlingCheck> checks;  // in YAML key order: period_us, runtime_us
+  bool mismatch = false;                  // some check has a readable actual != expected
+  // Non-empty iff mismatch: operator guidance listing every configured key as
+  // an /etc/sysctl.d entry.
+  std::string sysctl_guidance;
+};
+
+// Writing /proc/sys/kernel/sched_rt_{period,runtime}_us requires root
+// (uid 0); Linux capabilities (CAP_SYS_ADMIN etc.) cannot bypass the proc
+// sysctl DAC check. So the configured values are only compared against the
+// running kernel's, and the caller reports sysctl_guidance on a mismatch.
+// read_sysctl receives the /proc/sys/kernel path and returns nullopt when the
+// value cannot be read (such a key is recorded but never counts as a
+// mismatch); reporting that failure is the reader's job.
+RtThrottlingReport check_rt_throttling(
+  const YAML::Node & yaml,
+  const std::function<std::optional<int>(const std::string & path)> & read_sysctl);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/startup_checks.hpp
@@ -42,10 +42,9 @@ struct RtThrottlingCheck
 
 struct RtThrottlingReport
 {
-  std::vector<RtThrottlingCheck> checks;  // in YAML key order: period_us, runtime_us
-  bool mismatch = false;                  // some check has a readable actual != expected
-  // Non-empty iff mismatch: operator guidance listing every configured key as
-  // an /etc/sysctl.d entry.
+  std::vector<RtThrottlingCheck> checks;  // in fixed order: period_us, runtime_us
+  // Non-empty iff some check has a readable actual != expected: operator
+  // guidance listing every configured key as an /etc/sysctl.d entry.
   std::string sysctl_guidance;
 };
 

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace agnocast_cie_thread_configurator
 {
@@ -98,6 +99,51 @@ std::optional<std::vector<std::string>> check_hardware_info(
   }
 
   return mismatches;
+}
+
+RtThrottlingReport check_rt_throttling(
+  const YAML::Node & yaml,
+  const std::function<std::optional<int>(const std::string & path)> & read_sysctl)
+{
+  RtThrottlingReport report;
+  if (!yaml["rt_throttling"]) {
+    return report;
+  }
+
+  const auto & rt_bw = yaml["rt_throttling"];
+
+  for (const char * yaml_key : {"period_us", "runtime_us"}) {
+    if (!rt_bw[yaml_key]) {
+      continue;
+    }
+    RtThrottlingCheck check;
+    check.key = std::string("sched_rt_") + yaml_key;
+    check.expected = rt_bw[yaml_key].as<int>();
+    check.actual = read_sysctl("/proc/sys/kernel/" + check.key);
+    if (check.actual.has_value() && *check.actual != check.expected) {
+      report.mismatch = true;
+    }
+    report.checks.push_back(std::move(check));
+  }
+
+  if (report.mismatch) {
+    std::string message =
+      "rt_throttling values do not match the configuration. "
+      "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+      "(or run 'sudo sysctl --system'):\n";
+
+    if (rt_bw["period_us"]) {
+      message +=
+        "  kernel.sched_rt_period_us = " + std::to_string(rt_bw["period_us"].as<int>()) + "\n";
+    }
+    if (rt_bw["runtime_us"]) {
+      message += "  kernel.sched_rt_runtime_us = " + std::to_string(rt_bw["runtime_us"].as<int>());
+    }
+
+    report.sysctl_guidance = std::move(message);
+  }
+
+  return report;
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/src/startup_checks.cpp
@@ -111,6 +111,7 @@ RtThrottlingReport check_rt_throttling(
   }
 
   const auto & rt_bw = yaml["rt_throttling"];
+  bool mismatch = false;
 
   for (const char * yaml_key : {"period_us", "runtime_us"}) {
     if (!rt_bw[yaml_key]) {
@@ -121,26 +122,19 @@ RtThrottlingReport check_rt_throttling(
     check.expected = rt_bw[yaml_key].as<int>();
     check.actual = read_sysctl("/proc/sys/kernel/" + check.key);
     if (check.actual.has_value() && *check.actual != check.expected) {
-      report.mismatch = true;
+      mismatch = true;
     }
     report.checks.push_back(std::move(check));
   }
 
-  if (report.mismatch) {
-    std::string message =
+  if (mismatch) {
+    report.sysctl_guidance =
       "rt_throttling values do not match the configuration. "
       "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
-      "(or run 'sudo sysctl --system'):\n";
-
-    if (rt_bw["period_us"]) {
-      message +=
-        "  kernel.sched_rt_period_us = " + std::to_string(rt_bw["period_us"].as<int>()) + "\n";
+      "(or run 'sudo sysctl --system'):";
+    for (const auto & check : report.checks) {
+      report.sysctl_guidance += "\n  kernel." + check.key + " = " + std::to_string(check.expected);
     }
-    if (rt_bw["runtime_us"]) {
-      message += "  kernel.sched_rt_runtime_us = " + std::to_string(rt_bw["runtime_us"].as<int>());
-    }
-
-    report.sysctl_guidance = std::move(message);
   }
 
   return report;

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -212,17 +212,8 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
 void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
 {
-  if (!yaml["rt_throttling"]) {
-    return;
-  }
-
-  const auto & rt_bw = yaml["rt_throttling"];
-
-  // Writing to /proc/sys/kernel/sched_rt_{period,runtime}_us requires root (uid 0).
-  // Linux capabilities (CAP_SYS_ADMIN etc.) cannot bypass the proc sysctl DAC check.
-  // Instead, we validate that the current kernel values match the config and guide the
-  // user to apply them via /etc/sysctl.d/ if they differ.
-
+  // The reader reports its own failures; check_rt_throttling records such a
+  // key with an unset actual, which is skipped below.
   auto read_sysctl = [this](const std::string & path) -> std::optional<int> {
     std::ifstream file(path);
     if (!file) {
@@ -237,53 +228,23 @@ void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
     return value;
   };
 
-  bool mismatch = false;
+  const auto report = agnocast_cie_thread_configurator::check_rt_throttling(yaml, read_sysctl);
 
-  if (rt_bw["period_us"]) {
-    int expected = rt_bw["period_us"].as<int>();
-    auto actual = read_sysctl("/proc/sys/kernel/sched_rt_period_us");
-    if (actual.has_value()) {
-      if (actual.value() != expected) {
-        RCLCPP_ERROR(
-          this->get_logger(), "sched_rt_period_us mismatch: expected %d, actual %d", expected,
-          actual.value());
-        mismatch = true;
-      } else {
-        RCLCPP_INFO(this->get_logger(), "sched_rt_period_us is already set to %d", expected);
-      }
+  for (const auto & check : report.checks) {
+    if (!check.actual.has_value()) {
+      continue;
+    }
+    if (*check.actual != check.expected) {
+      RCLCPP_ERROR(
+        this->get_logger(), "%s mismatch: expected %d, actual %d", check.key.c_str(),
+        check.expected, *check.actual);
+    } else {
+      RCLCPP_INFO(this->get_logger(), "%s is already set to %d", check.key.c_str(), check.expected);
     }
   }
 
-  if (rt_bw["runtime_us"]) {
-    int expected = rt_bw["runtime_us"].as<int>();
-    auto actual = read_sysctl("/proc/sys/kernel/sched_rt_runtime_us");
-    if (actual.has_value()) {
-      if (actual.value() != expected) {
-        RCLCPP_ERROR(
-          this->get_logger(), "sched_rt_runtime_us mismatch: expected %d, actual %d", expected,
-          actual.value());
-        mismatch = true;
-      } else {
-        RCLCPP_INFO(this->get_logger(), "sched_rt_runtime_us is already set to %d", expected);
-      }
-    }
-  }
-
-  if (mismatch) {
-    std::string message =
-      "rt_throttling values do not match the configuration. "
-      "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
-      "(or run 'sudo sysctl --system'):\n";
-
-    if (rt_bw["period_us"]) {
-      message +=
-        "  kernel.sched_rt_period_us = " + std::to_string(rt_bw["period_us"].as<int>()) + "\n";
-    }
-    if (rt_bw["runtime_us"]) {
-      message += "  kernel.sched_rt_runtime_us = " + std::to_string(rt_bw["runtime_us"].as<int>());
-    }
-
-    RCLCPP_ERROR(this->get_logger(), "%s", message.c_str());
+  if (report.mismatch) {
+    RCLCPP_ERROR(this->get_logger(), "%s", report.sysctl_guidance.c_str());
   }
 }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -243,7 +243,7 @@ void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
     }
   }
 
-  if (report.mismatch) {
+  if (!report.sysctl_guidance.empty()) {
     RCLCPP_ERROR(this->get_logger(), "%s", report.sysctl_guidance.c_str());
   }
 }

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -2,6 +2,11 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
 namespace acie = agnocast_cie_thread_configurator;
 
 TEST(ParseLscpuOutput, ExtractsExactlyTheRecordedKeys)
@@ -90,4 +95,110 @@ TEST(CheckHardwareInfo, ReportsEachMismatchWithExpectedAndActual)
   const std::vector<std::string> expected = {
     "model: expected '33', got '44'", "threads_per_core: expected '2', got '1'"};
   EXPECT_EQ(*result, expected);
+}
+
+// ---------- check_rt_throttling ----------
+
+namespace
+{
+
+// read_sysctl double: records the requested paths and serves fixed values.
+struct FakeSysctl
+{
+  std::map<std::string, std::optional<int>> values;
+  mutable std::vector<std::string> requested;
+
+  std::function<std::optional<int>(const std::string &)> reader() const
+  {
+    return [this](const std::string & path) {
+      requested.push_back(path);
+      const auto it = values.find(path);
+      return it == values.end() ? std::nullopt : it->second;
+    };
+  }
+};
+
+constexpr const char * k_period_path = "/proc/sys/kernel/sched_rt_period_us";
+constexpr const char * k_runtime_path = "/proc/sys/kernel/sched_rt_runtime_us";
+
+}  // namespace
+
+TEST(CheckRtThrottling, MissingSectionYieldsEmptyReport)
+{
+  FakeSysctl sysctl;
+  const auto report = acie::check_rt_throttling(YAML::Load("callback_groups: []"), sysctl.reader());
+  EXPECT_TRUE(report.checks.empty());
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
+  EXPECT_TRUE(sysctl.requested.empty());
+}
+
+TEST(CheckRtThrottling, ReadsTheKernelSysctlPathsInYamlKeyOrder)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_period_path] = 1000000;
+  sysctl.values[k_runtime_path] = 950000;
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_EQ(sysctl.requested, (std::vector<std::string>{k_period_path, k_runtime_path}));
+  ASSERT_EQ(report.checks.size(), 2u);
+  EXPECT_EQ(report.checks[0].key, "sched_rt_period_us");
+  EXPECT_EQ(report.checks[0].expected, 1000000);
+  EXPECT_EQ(report.checks[0].actual, 1000000);
+  EXPECT_EQ(report.checks[1].key, "sched_rt_runtime_us");
+  EXPECT_EQ(report.checks[1].expected, 950000);
+  EXPECT_EQ(report.checks[1].actual, 950000);
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
+}
+
+TEST(CheckRtThrottling, MismatchGuidanceListsEveryConfiguredKey)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_period_path] = 1000000;  // matches
+  sysctl.values[k_runtime_path] = -1;      // differs
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_TRUE(report.mismatch);
+  EXPECT_EQ(
+    report.sysctl_guidance,
+    "rt_throttling values do not match the configuration. "
+    "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+    "(or run 'sudo sysctl --system'):\n"
+    "  kernel.sched_rt_period_us = 1000000\n"
+    "  kernel.sched_rt_runtime_us = 950000");
+}
+
+TEST(CheckRtThrottling, ChecksOnlyTheConfiguredKeys)
+{
+  FakeSysctl sysctl;
+  sysctl.values[k_runtime_path] = -1;
+  const auto yaml = YAML::Load("rt_throttling:\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  EXPECT_EQ(sysctl.requested, (std::vector<std::string>{k_runtime_path}));
+  ASSERT_EQ(report.checks.size(), 1u);
+  EXPECT_EQ(report.checks[0].key, "sched_rt_runtime_us");
+  EXPECT_TRUE(report.mismatch);
+  EXPECT_EQ(
+    report.sysctl_guidance,
+    "rt_throttling values do not match the configuration. "
+    "Please create /etc/sysctl.d/99-rt-throttling.conf with the following content and reboot "
+    "(or run 'sudo sysctl --system'):\n"
+    "  kernel.sched_rt_runtime_us = 950000");
+}
+
+TEST(CheckRtThrottling, UnreadableSysctlIsRecordedButNeverAMismatch)
+{
+  FakeSysctl sysctl;  // serves nothing: every read returns nullopt
+  const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
+  const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
+
+  ASSERT_EQ(report.checks.size(), 2u);
+  EXPECT_FALSE(report.checks[0].actual.has_value());
+  EXPECT_FALSE(report.checks[1].actual.has_value());
+  EXPECT_FALSE(report.mismatch);
+  EXPECT_TRUE(report.sysctl_guidance.empty());
 }

--- a/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_startup_checks.cpp
@@ -128,12 +128,11 @@ TEST(CheckRtThrottling, MissingSectionYieldsEmptyReport)
   FakeSysctl sysctl;
   const auto report = acie::check_rt_throttling(YAML::Load("callback_groups: []"), sysctl.reader());
   EXPECT_TRUE(report.checks.empty());
-  EXPECT_FALSE(report.mismatch);
   EXPECT_TRUE(report.sysctl_guidance.empty());
   EXPECT_TRUE(sysctl.requested.empty());
 }
 
-TEST(CheckRtThrottling, ReadsTheKernelSysctlPathsInYamlKeyOrder)
+TEST(CheckRtThrottling, ReadsTheKernelSysctlPathsInFixedKeyOrder)
 {
   FakeSysctl sysctl;
   sysctl.values[k_period_path] = 1000000;
@@ -149,7 +148,6 @@ TEST(CheckRtThrottling, ReadsTheKernelSysctlPathsInYamlKeyOrder)
   EXPECT_EQ(report.checks[1].key, "sched_rt_runtime_us");
   EXPECT_EQ(report.checks[1].expected, 950000);
   EXPECT_EQ(report.checks[1].actual, 950000);
-  EXPECT_FALSE(report.mismatch);
   EXPECT_TRUE(report.sysctl_guidance.empty());
 }
 
@@ -161,7 +159,6 @@ TEST(CheckRtThrottling, MismatchGuidanceListsEveryConfiguredKey)
   const auto yaml = YAML::Load("rt_throttling:\n  period_us: 1000000\n  runtime_us: 950000\n");
   const auto report = acie::check_rt_throttling(yaml, sysctl.reader());
 
-  EXPECT_TRUE(report.mismatch);
   EXPECT_EQ(
     report.sysctl_guidance,
     "rt_throttling values do not match the configuration. "
@@ -181,7 +178,6 @@ TEST(CheckRtThrottling, ChecksOnlyTheConfiguredKeys)
   EXPECT_EQ(sysctl.requested, (std::vector<std::string>{k_runtime_path}));
   ASSERT_EQ(report.checks.size(), 1u);
   EXPECT_EQ(report.checks[0].key, "sched_rt_runtime_us");
-  EXPECT_TRUE(report.mismatch);
   EXPECT_EQ(
     report.sysctl_guidance,
     "rt_throttling values do not match the configuration. "
@@ -199,6 +195,5 @@ TEST(CheckRtThrottling, UnreadableSysctlIsRecordedButNeverAMismatch)
   ASSERT_EQ(report.checks.size(), 2u);
   EXPECT_FALSE(report.checks[0].actual.has_value());
   EXPECT_FALSE(report.checks[1].actual.has_value());
-  EXPECT_FALSE(report.mismatch);
   EXPECT_TRUE(report.sysctl_guidance.empty());
 }


### PR DESCRIPTION
## Description

Part 3/3 of extracting the startup validation logic into unit-testable core functions (supersedes #1597 together with its neighbors).

Extracts the comparison half of `ThreadConfiguratorNode::validate_rt_throttling` into a pure core function:

- `check_rt_throttling(yaml, read_sysctl)` compares the `rt_throttling` section against the running kernel through an injected reader and returns per-key checks plus the `/etc/sysctl.d` guidance text (listing every configured key, matching or not, exactly as before). Writing these sysctls requires uid 0 (capabilities cannot bypass the proc sysctl DAC check), which is why the daemon checks and guides instead of writing; that rationale now lives on the declaration.
- The node keeps the reader (which logs its own read failures) and the per-key match/mismatch logging; all log lines are unchanged.
- One cosmetic difference: a failed sysctl read is now logged before the per-key result lines instead of interleaved with them, because the checks are computed before they are reported.

Tests cover the sysctl paths and their YAML key order, the byte-exact guidance text, and that unreadable sysctls are recorded but never count as a mismatch.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1599 (base branch `refactor/cie-tc-check-hardware-info`); only the last commit belongs to this PR. Retarget to `main` once #1599 is merged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
