### PR TITLE
fix(agnocast_kmod): count qos_depth in messages the subscriber can be handed

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1157,6 +1157,25 @@ static struct rb_node * find_first_entry_ge(struct rb_root * root, const int64_t
   return candidate;
 }
 
+// Whether `sub_info` may be handed an entry published by `pub_info`.
+static bool is_entry_deliverable(
+  const struct topic_wrapper * wrapper, const struct subscriber_info * sub_info,
+  const struct publisher_info * pub_info)
+{
+  const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
+  if (!proc_info || proc_info->exited) {
+    return false;
+  }
+
+  if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+    return false;
+  }
+
+  return domain_delivery_allowed(
+    wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
+    sub_info->is_bridge);
+}
+
 static int receive_msg_core(
   struct topic_wrapper * wrapper, struct subscriber_info * sub_info,
   const topic_local_id_t subscriber_id, union ioctl_receive_msg_args * ioctl_ret)
@@ -1169,14 +1188,25 @@ static int receive_msg_core(
     return 0;
   }
 
-  const struct entry_node * newest_en = container_of(newest_node, struct entry_node, node);
-  const int64_t newest_entry_id = newest_en->entry_id;
-
-  // Calculate start_entry_id = max(newest - qos_depth + 1, latest_received_entry_id + 1)
-  const int64_t latest_received_entry_id = sub_info->latest_received_entry_id;
-  const int64_t qos_start = newest_entry_id - (int64_t)sub_info->qos_depth + 1;
-  const int64_t start_entry_id =
-    (qos_start > latest_received_entry_id) ? qos_start : (latest_received_entry_id + 1);
+  // start_entry_id is the qos_depth-th newest entry the subscriber can be handed, or its oldest
+  // unreceived entry when fewer than qos_depth of them are deliverable.
+  const int64_t oldest_wanted_entry_id = sub_info->latest_received_entry_id + 1;
+  int64_t start_entry_id = oldest_wanted_entry_id;
+  uint32_t deliverable_num = 0;
+  for (struct rb_node * back = newest_node; back; back = rb_prev(back)) {
+    const struct entry_node * en = container_of(back, struct entry_node, node);
+    if (en->entry_id < oldest_wanted_entry_id) {
+      break;
+    }
+    const struct publisher_info * pub_info = find_publisher_info(wrapper, en->publisher_id);
+    if (!pub_info || !is_entry_deliverable(wrapper, sub_info, pub_info)) {
+      continue;
+    }
+    start_entry_id = en->entry_id;
+    if (++deliverable_num >= sub_info->qos_depth) {
+      break;
+    }
+  }
 
   struct rb_node * node = find_first_entry_ge(&wrapper->topic->entries, start_entry_id);
 
@@ -1198,18 +1228,7 @@ static int receive_msg_core(
       return -ENODATA;
     }
 
-    const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
-    if (!proc_info || proc_info->exited) {
-      continue;
-    }
-
-    if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
-      continue;
-    }
-
-    if (!domain_delivery_allowed(
-          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
-          sub_info->is_bridge)) {
+    if (!is_entry_deliverable(wrapper, sub_info, pub_info)) {
       continue;
     }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1197,7 +1197,7 @@ static int receive_msg_core(
     struct entry_node * en = container_of(node, struct entry_node, node);
 
     if (ioctl_ret->ret_entry_num == MAX_RECEIVE_NUM) {
-      ioctl_ret->ret_call_again = true;
+      ioctl_ret->ret_call_again = ioctl_ret->ret_entry_num < deliverable_num;
       break;
     }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1138,25 +1138,6 @@ unlock_only_global:
   return ret;
 }
 
-// Find the first entry with entry_id >= target_entry_id
-static struct rb_node * find_first_entry_ge(struct rb_root * root, const int64_t target_entry_id)
-{
-  struct rb_node ** curr = &(root->rb_node);
-  struct rb_node * candidate = NULL;
-
-  while (*curr) {
-    const struct entry_node * en = container_of(*curr, struct entry_node, node);
-    if (en->entry_id >= target_entry_id) {
-      candidate = *curr;
-      curr = &((*curr)->rb_left);
-    } else {
-      curr = &((*curr)->rb_right);
-    }
-  }
-
-  return candidate;
-}
-
 // Whether `sub_info` may be handed an entry published by `pub_info`.
 static bool is_entry_deliverable(
   const struct topic_wrapper * wrapper, const struct subscriber_info * sub_info,
@@ -1192,10 +1173,10 @@ static int receive_msg_core(
     return 0;
   }
 
-  // start_entry_id is the qos_depth-th newest entry the subscriber can be handed, or its oldest
-  // unreceived entry when fewer than qos_depth of them are deliverable.
+  // node ends up on the qos_depth-th newest entry the subscriber can be handed, on its oldest
+  // unreceived deliverable entry when fewer than qos_depth of them are, and NULL when none are.
   const int64_t oldest_wanted_entry_id = sub_info->latest_received_entry_id + 1;
-  int64_t start_entry_id = oldest_wanted_entry_id;
+  struct rb_node * node = NULL;
   uint32_t deliverable_num = 0;
   for (struct rb_node * back = newest_node; back; back = rb_prev(back)) {
     const struct entry_node * en = container_of(back, struct entry_node, node);
@@ -1206,13 +1187,11 @@ static int receive_msg_core(
     if (!pub_info || !is_entry_deliverable(wrapper, sub_info, pub_info)) {
       continue;
     }
-    start_entry_id = en->entry_id;
+    node = back;
     if (++deliverable_num >= sub_info->qos_depth) {
       break;
     }
   }
-
-  struct rb_node * node = find_first_entry_ge(&wrapper->topic->entries, start_entry_id);
 
   for (; node; node = rb_next(node)) {
     struct entry_node * en = container_of(node, struct entry_node, node);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1138,18 +1138,29 @@ unlock_only_global:
   return ret;
 }
 
-// Whether `sub_info` may be handed an entry published by `pub_info`.
-static bool is_entry_deliverable(
+// Whether `sub_info` may be handed `en`: 1 when it may, 0 when the entry has to be skipped,
+// -ENODATA when the entry's publisher is no longer in the topic.
+static int is_entry_deliverable(
   const struct topic_wrapper * wrapper, const struct subscriber_info * sub_info,
-  const struct publisher_info * pub_info)
+  const struct entry_node * en)
 {
+  const struct publisher_info * pub_info = find_publisher_info(wrapper, en->publisher_id);
+  if (!pub_info) {
+    dev_warn(
+      agnocast_device,
+      "Unreachable: corresponding publisher(id=%d) not found for entry(id=%lld) in "
+      "topic(topic_name=%s). (%s)\n",
+      en->publisher_id, en->entry_id, wrapper->key, __func__);
+    return -ENODATA;
+  }
+
   const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
   if (!proc_info || proc_info->exited) {
-    return false;
+    return 0;
   }
 
   if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
-    return false;
+    return 0;
   }
 
   return domain_delivery_allowed(
@@ -1183,10 +1194,14 @@ static int receive_msg_core(
     if (en->entry_id < oldest_wanted_entry_id) {
       break;
     }
-    const struct publisher_info * pub_info = find_publisher_info(wrapper, en->publisher_id);
-    if (!pub_info || !is_entry_deliverable(wrapper, sub_info, pub_info)) {
+    int ret = is_entry_deliverable(wrapper, sub_info, en);
+    if (ret < 0) {
+      return ret;
+    }
+    if (ret == 0) {
       continue;
     }
+
     node = back;
     if (++deliverable_num >= sub_info->qos_depth) {
       break;
@@ -1201,21 +1216,15 @@ static int receive_msg_core(
       break;
     }
 
-    const struct publisher_info * pub_info = find_publisher_info(wrapper, en->publisher_id);
-    if (!pub_info) {
-      dev_warn(
-        agnocast_device,
-        "Unreachable: corresponding publisher(id=%d) not found for entry(id=%lld) in "
-        "topic(topic_name=%s). (%s)\n",
-        en->publisher_id, en->entry_id, wrapper->key, __func__);
-      return -ENODATA;
+    int ret = is_entry_deliverable(wrapper, sub_info, en);
+    if (ret < 0) {
+      return ret;
     }
-
-    if (!is_entry_deliverable(wrapper, sub_info, pub_info)) {
+    if (ret == 0) {
       continue;
     }
 
-    int ret = add_subscriber_reference(en, subscriber_id, false);
+    ret = add_subscriber_reference(en, subscriber_id, false);
     if (ret < 0) {
       return ret;
     }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1188,6 +1188,10 @@ static int receive_msg_core(
     return 0;
   }
 
+  if (sub_info->qos_depth == 0) {
+    return 0;
+  }
+
   // start_entry_id is the qos_depth-th newest entry the subscriber can be handed, or its oldest
   // unreceived entry when fewer than qos_depth of them are deliverable.
   const int64_t oldest_wanted_entry_id = sub_info->latest_received_entry_id + 1;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1140,6 +1140,8 @@ unlock_only_global:
 
 // Whether `sub_info` may be handed `en`: 1 when it may, 0 when the entry has to be skipped,
 // -ENODATA when the entry's publisher is no longer in the topic.
+// Caller holds global_htables_rwsem (read), which keeps pub_info and proc_info alive, and
+// wrapper->topic->rwsem (read), which keeps `en` alive.
 static int is_entry_deliverable(
   const struct topic_wrapper * wrapper, const struct subscriber_info * sub_info,
   const struct entry_node * en)

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1377,29 +1377,12 @@ int agnocast_ioctl_take_msg(
       break;  // Never take any messages that are older than the most recently received
     }
 
-    const struct publisher_info * pub_info = find_publisher_info(wrapper, en->publisher_id);
-    if (!pub_info) {
-      dev_warn(
-        agnocast_device,
-        "Unreachable: corresponding publisher(id=%d) not found for entry(id=%lld) in "
-        "topic(topic_name=%s). (%s)\n",
-        en->publisher_id, en->entry_id, topic_name, __func__);
-      ret = -ENODATA;
+    const int deliverable = is_entry_deliverable(wrapper, sub_info, en);
+    if (deliverable < 0) {
+      ret = deliverable;
       goto unlock_all;
     }
-
-    const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
-    if (!proc_info || proc_info->exited) {
-      continue;
-    }
-
-    if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
-      continue;
-    }
-
-    if (!domain_delivery_allowed(
-          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
-          sub_info->is_bridge)) {
+    if (deliverable == 0) {
       continue;
     }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -766,6 +766,70 @@ void test_case_receive_msg_zero_qos_depth_receives_nothing(struct kunit * test)
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
+void test_case_receive_msg_no_call_again_when_only_undeliverable_entries_remain(struct kunit * test)
+{
+  // Arrange
+  const bool is_transient_local = true;
+  const uint32_t qos_depth = MAX_RECEIVE_NUM;
+  const pid_t subscriber_pid = 2000;
+
+  topic_local_id_t remote_publisher_id;
+  uint64_t remote_ret_addr;
+  setup_one_publisher(
+    test, 1000, qos_depth, is_transient_local, &remote_publisher_id, &remote_ret_addr);
+  union ioctl_publish_msg_args publish_msg_ret;
+  int64_t remote_newest_entry_id = -1;
+  for (uint32_t i = 0; i < qos_depth; i++) {
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_publish_msg(
+        TOPIC_NAME, current->nsproxy->ipc_ns, remote_publisher_id, remote_ret_addr + i,
+        &publish_msg_ret),
+      0);
+    remote_newest_entry_id = publish_msg_ret.ret_entry_id;
+  }
+
+  // The newest entry belongs to the subscriber's own process, so the walk that delivers the
+  // MAX_RECEIVE_NUM entries below it ends on one it has to skip.
+  topic_local_id_t local_publisher_id;
+  uint64_t local_ret_addr;
+  setup_one_publisher(
+    test, subscriber_pid, 1, is_transient_local, &local_publisher_id, &local_ret_addr);
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, local_publisher_id, local_ret_addr, &publish_msg_ret),
+    0);
+
+  const bool ignore_local_publications = true;
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1,
+      &add_subscriber_args),
+    0);
+
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id, pub_shm_infos,
+    KUNIT_PUB_SHM_BUF_SIZE, &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, MAX_RECEIVE_NUM);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_call_again, false);
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_get_latest_received_entry_id(
+      TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id),
+    remote_newest_entry_id);
+}
+
 // ================================================
 // Tests for set_publisher_shm_info
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -659,6 +659,71 @@ void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_th
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
+// qos_depth counts the messages the topic holds, not a span of entry_ids. entry_id is topic-wide
+// while release_msgs_to_meet_depth() drops one publisher's oldest entries and leaves the others
+// alone, so the ids a topic holds have gaps in them, and a depth of 3 still reaches 3 messages
+// across those gaps.
+void test_case_receive_msg_qos_depth_counts_entries_not_entry_ids(struct kunit * test)
+{
+  // Arrange
+  const bool is_transient_local = true;
+
+  topic_local_id_t publisher_id1;
+  uint64_t ret_addr1;
+  const uint32_t publisher1_qos_depth = 1;
+  setup_one_publisher(
+    test, 1000, publisher1_qos_depth, is_transient_local, &publisher_id1, &ret_addr1);
+  union ioctl_publish_msg_args publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1, ret_addr1, &publish_msg_ret),
+    0);
+  const int64_t publisher1_entry_id = publish_msg_ret.ret_entry_id;
+
+  // Publishes once more than its depth, so its oldest entry is released and that id is left as a
+  // hole above the entry the other publisher holds.
+  topic_local_id_t publisher_id2;
+  uint64_t ret_addr2;
+  const uint32_t publisher2_qos_depth = 2;
+  setup_one_publisher(
+    test, 1001, publisher2_qos_depth, is_transient_local, &publisher_id2, &ret_addr2);
+  int64_t publisher2_older_entry_id = -1;
+  int64_t publisher2_newer_entry_id = -1;
+  for (uint32_t i = 0; i < publisher2_qos_depth + 1; i++) {
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_publish_msg(
+        TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2, ret_addr2 + i, &publish_msg_ret),
+      0);
+    publisher2_older_entry_id = publisher2_newer_entry_id;
+    publisher2_newer_entry_id = publish_msg_ret.ret_entry_id;
+  }
+
+  topic_local_id_t subscriber_id;
+  const uint32_t subscriber_qos_depth = 3;
+  setup_one_subscriber(test, 2000, subscriber_qos_depth, is_transient_local, &subscriber_id);
+
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+    &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 3);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], publisher1_entry_id);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[1], publisher2_older_entry_id);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[2], publisher2_newer_entry_id);
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
+    publisher2_newer_entry_id);
+}
+
 // ================================================
 // Tests for set_publisher_shm_info
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -662,6 +662,63 @@ void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_th
 // ================================================
 // Tests for set_publisher_shm_info
 
+// qos_depth counts messages the subscriber can be handed: an entry it has to discard (here its
+// own, under ignore_local_publications) does not use up a slot, even as the newest on the topic.
+void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test)
+{
+  // Arrange
+  const bool is_transient_local = true;
+  const uint32_t qos_depth = 1;
+  const pid_t subscriber_pid = 2000;
+
+  topic_local_id_t remote_publisher_id;
+  uint64_t remote_ret_addr;
+  setup_one_publisher(
+    test, 1000, qos_depth, is_transient_local, &remote_publisher_id, &remote_ret_addr);
+  union ioctl_publish_msg_args remote_publish_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, remote_publisher_id, remote_ret_addr,
+      &remote_publish_ret),
+    0);
+
+  // Published after the remote one, from the subscriber's own process, so it is the newest entry
+  // and the one the subscriber has to skip.
+  topic_local_id_t local_publisher_id;
+  uint64_t local_ret_addr;
+  setup_one_publisher(
+    test, subscriber_pid, qos_depth, is_transient_local, &local_publisher_id, &local_ret_addr);
+  union ioctl_publish_msg_args local_publish_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, local_publisher_id, local_ret_addr, &local_publish_ret),
+    0);
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, true /* ignore_local_publications */, IS_BRIDGE,
+      -1, &add_subscriber_args),
+    0);
+
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id, pub_shm_infos,
+    KUNIT_PUB_SHM_BUF_SIZE, &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], remote_publish_ret.ret_entry_id);
+}
+
 void test_case_receive_msg_one_new_pub(struct kunit * test)
 {
   // Arrange

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -724,6 +724,48 @@ void test_case_receive_msg_qos_depth_counts_entries_not_entry_ids(struct kunit *
     publisher2_newer_entry_id);
 }
 
+void test_case_receive_msg_zero_qos_depth_receives_nothing(struct kunit * test)
+{
+  // Arrange
+  const bool is_transient_local = true;
+
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  const pid_t publisher_pid = 1000;
+  const uint32_t publisher_qos_depth = 1;
+  setup_one_publisher(
+    test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
+  union ioctl_publish_msg_args publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &publish_msg_ret),
+    0);
+
+  topic_local_id_t subscriber_id;
+  const uint32_t subscriber_qos_depth = 0;
+  setup_one_subscriber(test, 2000, subscriber_qos_depth, is_transient_local, &subscriber_id);
+
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+    &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_call_again, false);
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id), -1);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_num, 1);
+  KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, publisher_pid);
+  KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
+}
+
 // ================================================
 // Tests for set_publisher_shm_info
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -830,9 +830,6 @@ void test_case_receive_msg_no_call_again_when_only_undeliverable_entries_remain(
     remote_newest_entry_id);
 }
 
-// ================================================
-// Tests for set_publisher_shm_info
-
 // qos_depth counts messages the subscriber can be handed: an entry it has to discard (here its
 // own, under ignore_local_publications) does not use up a slot, even as the newest on the topic.
 void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test)
@@ -867,13 +864,14 @@ void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct k
       TOPIC_NAME, current->nsproxy->ipc_ns, local_publisher_id, local_ret_addr, &local_publish_ret),
     0);
 
+  const bool ignore_local_publications = true;
   union ioctl_add_subscriber_args add_subscriber_args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_subscriber(
       TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
-      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, true /* ignore_local_publications */, IS_BRIDGE,
-      -1, &add_subscriber_args),
+      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1,
+      &add_subscriber_args),
     0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -888,7 +886,15 @@ void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct k
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], remote_publish_ret.ret_entry_id);
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_get_latest_received_entry_id(
+      TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id),
+    remote_publish_ret.ret_entry_id);
 }
+
+// ================================================
+// Tests for set_publisher_shm_info
 
 void test_case_receive_msg_one_new_pub(struct kunit * test)
 {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -19,6 +19,7 @@
       test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_than_pub_qos),      \
     KUNIT_CASE(                                                                                    \
       test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),      \
+    KUNIT_CASE(test_case_receive_msg_qos_depth_counts_entries_not_entry_ids),                      \
     KUNIT_CASE(test_case_receive_msg_discarded_message_does_not_consume_qos_depth),                \
     KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                 \
     KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                      \
@@ -53,6 +54,7 @@ void test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_th
   struct kunit * test);
 void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test);
+void test_case_receive_msg_qos_depth_counts_entries_not_entry_ids(struct kunit * test);
 void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test);
 void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -19,6 +19,7 @@
       test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_than_pub_qos),      \
     KUNIT_CASE(                                                                                    \
       test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),      \
+    KUNIT_CASE(test_case_receive_msg_discarded_message_does_not_consume_qos_depth),                \
     KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                 \
     KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                      \
     KUNIT_CASE(test_case_receive_msg_2pub_in_same_process),                                        \
@@ -52,6 +53,7 @@ void test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_th
   struct kunit * test);
 void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test);
+void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test);
 void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);
 void test_case_receive_msg_2pub_in_same_process(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -21,6 +21,7 @@
       test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),      \
     KUNIT_CASE(test_case_receive_msg_qos_depth_counts_entries_not_entry_ids),                      \
     KUNIT_CASE(test_case_receive_msg_zero_qos_depth_receives_nothing),                             \
+    KUNIT_CASE(test_case_receive_msg_no_call_again_when_only_undeliverable_entries_remain),        \
     KUNIT_CASE(test_case_receive_msg_discarded_message_does_not_consume_qos_depth),                \
     KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                 \
     KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                      \
@@ -57,6 +58,8 @@ void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_th
   struct kunit * test);
 void test_case_receive_msg_qos_depth_counts_entries_not_entry_ids(struct kunit * test);
 void test_case_receive_msg_zero_qos_depth_receives_nothing(struct kunit * test);
+void test_case_receive_msg_no_call_again_when_only_undeliverable_entries_remain(
+  struct kunit * test);
 void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test);
 void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -20,6 +20,7 @@
     KUNIT_CASE(                                                                                    \
       test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),      \
     KUNIT_CASE(test_case_receive_msg_qos_depth_counts_entries_not_entry_ids),                      \
+    KUNIT_CASE(test_case_receive_msg_zero_qos_depth_receives_nothing),                             \
     KUNIT_CASE(test_case_receive_msg_discarded_message_does_not_consume_qos_depth),                \
     KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                 \
     KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                      \
@@ -55,6 +56,7 @@ void test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_th
 void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test);
 void test_case_receive_msg_qos_depth_counts_entries_not_entry_ids(struct kunit * test);
+void test_case_receive_msg_zero_qos_depth_receives_nothing(struct kunit * test);
 void test_case_receive_msg_discarded_message_does_not_consume_qos_depth(struct kunit * test);
 void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);


### PR DESCRIPTION
## Description

`receive_msg_core()` derived the range to scan from `entry_id` before looking at what was in it:

```c
qos_start = newest_entry_id - sub_info->qos_depth + 1;
```

The loop that follows skips entries the subscriber may not be handed -- an exited publisher, `ignore_local_publications`, a domain that may not deliver -- but the range is already fixed and is never widened to make up for it, so every skipped entry still costs a slot. A subscriber can come away with nothing while a deliverable message sits one id below the range.

This counts `qos_depth` in messages the subscriber can be handed instead of in entry_ids. A topic's ids have holes in them, so this also changes what a subscriber gets with nothing skipped: with publisher A holding entry 0 and publisher B holding 4 and 5, a transient_local subscriber at depth 3 now receives {0, 4, 5} where it received {4, 5}.

## Related links

#1603

## How was this PR tested?

- [x] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

A single backward walk keeping the last `MAX_RECEIVE_NUM` entries it accepts in a ring would do this in one pass, with one `find_publisher_info()` per entry instead of two. It rewrites the delivery loop, and with a release close this seemed like the wrong moment for that diff, so it is left to #1603.

The two walks are bounded by the entries in the tree. `release_msgs_to_meet_depth()` holds each publisher to its own `qos_depth`, so the tree rests at the sum of the publishers' depths -- tens, not thousands -- and it already warns at `qos_depth + 100` for one publisher as a leak. A tree large enough for the second walk to cost anything means entry_nodes are leaking.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`


