### PR TITLE
fix(agnocast_kmod): make the exit tracepoint path atomic-safe on PREEMPT_RT

### DIFF
--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -81,7 +81,7 @@ void agnocast_exit_free_data(void)
 
 void agnocast_exit_kthread(void)
 {
-  wake_up_interruptible(&worker_wait);
+  swake_up_one(&worker_wait);
   kthread_stop(worker_task);
 }
 

--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -24,9 +24,9 @@ static const struct file_operations fops = {
 static int exit_worker_thread(void * data)
 {
   while (!kthread_should_stop()) {
+    // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
+    // queue writes from the enqueuer are visible before we read the queue.
     swait_event_interruptible_exclusive(
-      // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
-      // queue writes from the enqueuer are visible before we read the queue.
       worker_wait, smp_load_acquire(&has_new_pid) || kthread_should_stop());
 
     if (kthread_should_stop()) break;

--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -24,9 +24,10 @@ static const struct file_operations fops = {
 static int exit_worker_thread(void * data)
 {
   while (!kthread_should_stop()) {
-    // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
-    // queue writes from the enqueuer are visible before we read the queue.
-    wait_event_interruptible(worker_wait, smp_load_acquire(&has_new_pid) || kthread_should_stop());
+    swait_event_interruptible_exclusive(
+      // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
+      // queue writes from the enqueuer are visible before we read the queue.
+      worker_wait, smp_load_acquire(&has_new_pid) || kthread_should_stop());
 
     if (kthread_should_stop()) break;
 
@@ -36,7 +37,7 @@ static int exit_worker_thread(void * data)
       unsigned long flags;
       bool got_pid = false;
 
-      spin_lock_irqsave(&pid_queue_lock, flags);
+      raw_spin_lock_irqsave(&pid_queue_lock, flags);
 
       if (queue_head != queue_tail) {
         pid = exit_pid_queue[queue_head];
@@ -48,7 +49,7 @@ static int exit_worker_thread(void * data)
       // preventing the enqueuer from seeing a stale 0 after re-checking the queue.
       if (queue_head == queue_tail) smp_store_release(&has_new_pid, 0);
 
-      spin_unlock_irqrestore(&pid_queue_lock, flags);
+      raw_spin_unlock_irqrestore(&pid_queue_lock, flags);
 
       if (!got_pid) break;
 

--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -24,10 +24,11 @@ static const struct file_operations fops = {
 static int exit_worker_thread(void * data)
 {
   while (!kthread_should_stop()) {
-    // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
-    // queue writes from the enqueuer are visible before we read the queue.
     swait_event_interruptible_exclusive(
-      worker_wait, smp_load_acquire(&has_new_pid) || kthread_should_stop());
+      worker_wait,
+      // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
+      // queue writes from the enqueuer are visible before we read the queue.
+      smp_load_acquire(&has_new_pid) || kthread_should_stop());
 
     if (kthread_should_stop()) break;
 

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -333,7 +333,7 @@ void agnocast_process_exit_cleanup(const pid_t pid)
   // here before the proc_info lookup (which would otherwise return early for the agent's pid).
   agnocast_remove_discovery_agent_by_pid(pid);
 
-  // The PID was already filtered by is_agnocast_pid() in the tracepoint probe, but the state may
+  // The PID was already filtered by is_agnocast_pid() in the kprobe handler, but the state may
   // have changed between then and now (e.g., the process was already cleaned up by a prior call).
   struct process_info * proc_info = NULL;
   uint32_t hash_val = hash_min(pid, PROC_INFO_HASH_BITS);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -333,7 +333,7 @@ void agnocast_process_exit_cleanup(const pid_t pid)
   // here before the proc_info lookup (which would otherwise return early for the agent's pid).
   agnocast_remove_discovery_agent_by_pid(pid);
 
-  // The PID was already filtered by is_agnocast_pid() in the kprobe handler, but the state may
+  // The PID was already filtered by is_agnocast_pid() in the tracepoint probe, but the state may
   // have changed between then and now (e.g., the process was already cleaned up by a prior call).
   struct process_info * proc_info = NULL;
   uint32_t hash_val = hash_min(pid, PROC_INFO_HASH_BITS);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -13,13 +13,13 @@ DEFINE_HASHTABLE(topic_hashtable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
 
-DEFINE_SPINLOCK(pid_queue_lock);
+DEFINE_RAW_SPINLOCK(pid_queue_lock);
 pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 uint32_t queue_head;
 uint32_t queue_tail;
 
 struct task_struct * worker_task;
-DECLARE_WAIT_QUEUE_HEAD(worker_wait);
+DECLARE_SWAIT_QUEUE_HEAD(worker_wait);
 int has_new_pid;
 
 struct tracepoint * tp_sched_process_exit;
@@ -255,7 +255,7 @@ void agnocast_enqueue_exit_pid(const pid_t pid)
 
   bool need_wakeup = false;
 
-  spin_lock_irqsave(&pid_queue_lock, flags);
+  raw_spin_lock_irqsave(&pid_queue_lock, flags);
 
   next = (queue_tail + 1) & EXIT_QUEUE_MASK;
 
@@ -268,10 +268,10 @@ void agnocast_enqueue_exit_pid(const pid_t pid)
     need_wakeup = true;
   }
 
-  spin_unlock_irqrestore(&pid_queue_lock, flags);
+  raw_spin_unlock_irqrestore(&pid_queue_lock, flags);
 
   if (need_wakeup) {
-    wake_up_interruptible(&worker_wait);
+    swake_up_one(&worker_wait);
   } else {
     dev_warn(
       agnocast_device,

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -14,6 +14,7 @@
 #include <linux/module.h>
 #include <linux/rwsem.h>
 #include <linux/slab.h>  // kmalloc, kfree
+#include <linux/swait.h>
 #include <linux/tracepoint.h>
 #include <linux/version.h>
 
@@ -306,14 +307,17 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 // Ring buffer to hold exited pids.
 // EXIT_QUEUE_SIZE (65536) far exceeds mempool_num (default 4096), and only Agnocast PIDs are
 // enqueued (via is_agnocast_pid()), each exiting at most once, so the ring buffer cannot overflow.
-extern spinlock_t pid_queue_lock;
+// pid_queue_lock is a raw_spinlock_t and worker_wait an swait queue because
+// agnocast_enqueue_exit_pid() runs in tracepoint context, where sleeping locks are forbidden on
+// PREEMPT_RT (spinlock_t and wait_queue_head locks become sleeping rt_mutexes there).
+extern raw_spinlock_t pid_queue_lock;
 extern pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 extern uint32_t queue_head;
 extern uint32_t queue_tail;
 
 // For controlling the kernel thread
 extern struct task_struct * worker_task;
-extern struct wait_queue_head worker_wait;
+extern struct swait_queue_head worker_wait;
 extern int has_new_pid;
 
 extern struct tracepoint * tp_sched_process_exit;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -309,13 +309,16 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 // enqueued (via is_agnocast_pid()), each exiting at most once, so the ring buffer cannot overflow.
 // pid_queue_lock is a raw_spinlock_t and worker_wait an swait queue because
 // agnocast_enqueue_exit_pid() runs in tracepoint context, where sleeping locks are forbidden on
-// PREEMPT_RT (spinlock_t and wait_queue_head locks become sleeping rt_mutexes there).
+// PREEMPT_RT (spinlock_t, including the one embedded in wait_queue_head, becomes a sleeping
+// rt_mutex there).
 extern raw_spinlock_t pid_queue_lock;
 extern pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 extern uint32_t queue_head;
 extern uint32_t queue_tail;
 
-// For controlling the kernel thread
+// For controlling the kernel thread.
+// worker_wait is an swait queue (see the pid_queue_lock comment above); swake_up_one() wakes
+// exactly one waiter, so the exit worker must remain the only waiter on worker_wait.
 extern struct task_struct * worker_task;
 extern struct swait_queue_head worker_wait;
 extern int has_new_pid;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -316,9 +316,6 @@ extern pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 extern uint32_t queue_head;
 extern uint32_t queue_tail;
 
-// For controlling the kernel thread.
-// worker_wait is an swait queue (see the pid_queue_lock comment above); swake_up_one() wakes
-// exactly one waiter, so the exit worker must remain the only waiter on worker_wait.
 extern struct task_struct * worker_task;
 extern struct swait_queue_head worker_wait;
 extern int has_new_pid;


### PR DESCRIPTION
## Description

The `sched_process_exit` tracepoint probe (`agnocast_process_exit`) runs with preemption disabled, but `agnocast_enqueue_exit_pid()` acquires `pid_queue_lock` (a `spinlock_t`) and calls `wake_up_interruptible()`, which internally takes the wait queue's `spinlock_t`. On PREEMPT_RT kernels, `spinlock_t` becomes a sleeping rt_mutex-based lock, so both calls sleep in atomic context. With `CONFIG_DEBUG_ATOMIC_SLEEP` this triggers `BUG: sleeping function called from invalid context` on every Agnocast process exit; on production RT kernels it can escalate to scheduling-while-atomic or a hang once the lock is contended.

This PR makes the exit path safe on PREEMPT_RT:

- `pid_queue_lock`: `spinlock_t` → `raw_spinlock_t`. The raw variant remains a true spinning lock on RT. The critical sections (ring buffer enqueue/dequeue) are only a few instructions, so a raw spinlock is appropriate.
- `worker_wait`: wait queue → simple wait queue (`swait`). `swake_up_one()` uses a raw spinlock internally and is explicitly allowed from atomic context, unlike `wake_up_interruptible()`.

Behavior on non-RT kernels is unchanged: `raw_spinlock_t` and `spinlock_t` are identical there, and since the exit worker is the only waiter, `swake_up_one()` is equivalent to `wake_up_interruptible()`.

## Related links

- [`include/linux/swait.h`](https://elixir.bootlin.com/linux/v6.8/source/include/linux/swait.h)
- [Kernel documentation: Lock types and their rules](https://www.kernel.org/doc/html/latest/locking/locktypes.html)

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

FYI: Claude says

> The rest of the module was audited for the same class of problem: the only atomic-context entry point is this tracepoint probe (no IRQ handlers, timers, or explicit preemption-disabled sections). `mempool_lock` is reached only from task context and contains no sleeping calls. The RCU read section in `is_agnocast_pid()` IS reached from the tracepoint probe, but `rcu_read_lock()` never sleeps (including on PREEMPT_RT), so both remain correct as-is.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.

