### PR TITLE
fix(agnocast_kmod): tighten exit path shutdown order and locking

### DIFF
--- a/.github/kunit/kunitconfig
+++ b/.github/kunit/kunitconfig
@@ -13,3 +13,9 @@ CONFIG_IPC_NS=y
 # the suite fails to start (-ENOENT). FTRACE gates ENABLE_DEFAULT_TRACERS.
 CONFIG_FTRACE=y
 CONFIG_ENABLE_DEFAULT_TRACERS=y
+
+# Catch sleeping-in-atomic regressions in the exit tracepoint path. Partial guard only:
+# RT-specific classes (spinlock_t becoming a sleeping rt_mutex) stay invisible on this
+# non-PREEMPT_RT UML kernel.
+CONFIG_DEBUG_KERNEL=y
+CONFIG_DEBUG_ATOMIC_SLEEP=y

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -81,7 +81,7 @@ void agnocast_exit_free_data(void)
 
 void agnocast_exit_kthread(void)
 {
-  swake_up_one(&worker_wait);
+  // kthread_stop() wakes the worker itself; the wait condition includes kthread_should_stop().
   kthread_stop(worker_task);
 }
 

--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -35,10 +35,9 @@ static int exit_worker_thread(void * data)
     // Drain all queued PIDs in a single wake-up cycle
     while (true) {
       pid_t pid;
-      unsigned long flags;
       bool got_pid = false;
 
-      raw_spin_lock_irqsave(&pid_queue_lock, flags);
+      raw_spin_lock(&pid_queue_lock);
 
       if (queue_head != queue_tail) {
         pid = exit_pid_queue[queue_head];
@@ -50,7 +49,7 @@ static int exit_worker_thread(void * data)
       // preventing the enqueuer from seeing a stale 0 after re-checking the queue.
       if (queue_head == queue_tail) smp_store_release(&has_new_pid, 0);
 
-      raw_spin_unlock_irqrestore(&pid_queue_lock, flags);
+      raw_spin_unlock(&pid_queue_lock);
 
       if (!got_pid) break;
 

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -250,12 +250,11 @@ void agnocast_process_exit(void * data, struct task_struct * task)
 
 void agnocast_enqueue_exit_pid(const pid_t pid)
 {
-  unsigned long flags;
   uint32_t next;
 
   bool need_wakeup = false;
 
-  raw_spin_lock_irqsave(&pid_queue_lock, flags);
+  raw_spin_lock(&pid_queue_lock);
 
   next = (queue_tail + 1) & EXIT_QUEUE_MASK;
 
@@ -268,7 +267,7 @@ void agnocast_enqueue_exit_pid(const pid_t pid)
     need_wakeup = true;
   }
 
-  raw_spin_unlock_irqrestore(&pid_queue_lock, flags);
+  raw_spin_unlock(&pid_queue_lock);
 
   if (need_wakeup) {
     swake_up_one(&worker_wait);

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -310,7 +310,8 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 // pid_queue_lock is a raw_spinlock_t and worker_wait an swait queue because
 // agnocast_enqueue_exit_pid() runs in tracepoint context, where sleeping locks are forbidden on
 // PREEMPT_RT (spinlock_t, including the one embedded in wait_queue_head, becomes a sleeping
-// rt_mutex there).
+// rt_mutex there). No taker runs in IRQ context, so the plain lock variants (without _irqsave)
+// suffice.
 extern raw_spinlock_t pid_queue_lock;
 extern pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 extern uint32_t queue_head;

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -43,8 +43,10 @@ static int agnocast_init(void)
 
 static void agnocast_exit(void)
 {
-  agnocast_exit_kthread();
+  // Unregister (and synchronize) the tracepoint first so no probe can enqueue into the pid queue
+  // after the worker is gone; agnocast_exit_free_data() then covers any pids left undrained.
   agnocast_exit_exit_hook();
+  agnocast_exit_kthread();
 
   agnocast_exit_free_data();
   cleanup_memory_allocator();


### PR DESCRIPTION
## Description

Follow-up to #1605, addressing the remaining review findings on the exit tracepoint path:

- **Module exit ordering**: `agnocast_exit()` used to stop the exit worker before unregistering the `sched_process_exit` tracepoint, leaving a window where an exiting Agnocast process could still run `agnocast_enqueue_exit_pid()` (and `swake_up_one()`) after `worker_task` was already reaped. This was benign only because the enqueue path never dereferences `worker_task`, an undocumented and fragile property. Unregistering the tracepoint first (including `tracepoint_synchronize_unregister()`) closes the window entirely; any pids enqueued just before unregistration are covered by `agnocast_exit_free_data()`. This also makes the exit order symmetric with the `agnocast_init()` error paths, which already tear down hook before kthread.
- **Redundant wakeup removed**: the `swake_up_one()` before `kthread_stop()` in `agnocast_exit_kthread()` did no work in either ordering: at that point neither `has_new_pid` nor the stop flag is set, and `kthread_stop()` performs its own `wake_up_process()`, which the wait condition (`kthread_should_stop()`) observes. Dropping it removes the false impression that the wakeup is load-bearing for shutdown.
- **Plain raw spinlock**: `pid_queue_lock` has exactly two takers, the tracepoint probe (task context, preemption disabled, IRQs enabled) and the worker kthread; no IRQ-context taker exists. The `_irqsave` variants therefore disabled interrupts for no protective benefit, and on PREEMPT_RT every raw IRQ-off section contributes directly to IRQ latency. Switched to plain `raw_spin_lock()`/`raw_spin_unlock()` and documented the constraint in the header.
- **CI guard**: enabled `CONFIG_DEBUG_ATOMIC_SLEEP` (with its `CONFIG_DEBUG_KERNEL` dependency) in the kunit config as a partial regression guard for sleeping-in-atomic bugs in this path. Note the limitation: the UML kunit kernel cannot enable PREEMPT_RT, so RT-only classes (a `spinlock_t` becoming a sleeping rt_mutex) remain invisible to CI and still require verification on an RT target.

## Related links

- #1605

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Depends on #1605 (based on its branch; will retarget to `main` once #1605 merges).

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.