### PR TITLE
fix(agnocast_kmod)[needs minor version update]: make the right to fork a daemon exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Refer to the [Linux kernel documentation](https://www.kernel.org/doc/Documentati
 
 ### Shared memory cleanup
 
-Agnocast spawns a background daemon process that automatically cleans up shared memory when processes exit. It is forked by any Agnocast process that finds no daemon running, so the first process in an IPC namespace starts one, and so does the next process to start after the daemon is gone. The daemon inherits the parent's process name, so broad kill commands like `killall` or `kill -9 $(pgrep -f ...)` may accidentally kill it along with application processes; cleanup then stops until an Agnocast process starts again, which spawns a replacement and unlinks what was left behind in the meantime.
+Agnocast spawns a background daemon process that automatically cleans up shared memory when processes exit. The kernel module hands the right to fork it to one process at a time, so the first process in an IPC namespace starts one, and so does the next process to start after the daemon is gone, however many processes start at once. The daemon inherits the parent's process name, so broad kill commands like `killall` or `kill -9 $(pgrep -f ...)` may accidentally kill it along with application processes; cleanup then stops until an Agnocast process starts again, which spawns a replacement and unlinks what was left behind in the meantime.
 
 If shared memory is left behind, you can remove it manually:
 

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -55,19 +55,45 @@ enum process_role {
   PROCESS_ROLE_UNLINK_DAEMON = 2,
 };
 
+// The daemons a process may be granted the exclusive right to fork.
+enum agnocast_spawn_kind {
+  AGNOCAST_SPAWN_UNLINK_DAEMON = 0,
+  AGNOCAST_SPAWN_BRIDGE_MANAGER = 1,
+  AGNOCAST_SPAWN_DISCOVERY_AGENT = 2,
+  AGNOCAST_SPAWN_KIND_NUM,
+};
+
+#define AGNOCAST_SPAWN_MASK(kind) (1u << (kind))
+#define AGNOCAST_SPAWN_MASK_ALL (AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_KIND_NUM) - 1u)
+
+// Defined in agnocast_internal.h; opaque to everyone else.
+struct spawn_grant;
+
+struct agnocast_spawn_grants
+{
+  uint32_t requested_mask;                                // in
+  struct spawn_grant * granted[AGNOCAST_SPAWN_KIND_NUM];  // out, NULL == not granted
+};
+
 union ioctl_add_process_args {
   struct
   {
     uint32_t role;       // enum process_role
     uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
+    // The daemons this caller is willing to fork, so a granted right is never one it will not use.
+    uint32_t spawn_request_mask;
   };
   struct
   {
     uint64_t ret_addr;
     uint64_t ret_shm_size;
-    bool ret_unlink_daemon_exist;
-    bool ret_bridge_daemon_exist;
-    bool ret_discovery_agent_exist;
+    // The exclusive right to fork this daemon, or -1. The forked child inherits the fd, and the
+    // right comes back when its last holder closes it or dies.
+    int32_t ret_unlink_daemon_spawn_fd;
+    int32_t ret_bridge_daemon_spawn_fd;
+    int32_t ret_discovery_agent_spawn_fd;
+    // Daemon roles only: one is already registered, so stand down.
+    bool ret_role_already_taken;
   };
 };
 
@@ -463,9 +489,15 @@ int agnocast_ioctl_take_msg(
   struct publisher_shm_info * pub_shm_infos, uint32_t pub_shm_infos_size,
   union ioctl_take_msg_args * ioctl_ret);
 
+// Hands the right back and frees the grant. A no-op on a right the daemon already settled.
+void agnocast_spawn_grant_release(struct spawn_grant * grant);
+
+// The caller owns every right returned in spawn->granted until it wraps it in a file or releases
+// it. spawn may be NULL to request none.
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const enum process_role role,
-  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret);
+  const uint32_t domain_id, struct agnocast_spawn_grants * spawn,
+  union ioctl_add_process_args * ioctl_ret);
 
 int agnocast_ioctl_get_subscriber_num(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const pid_t pid,
@@ -574,6 +606,12 @@ int agnocast_increment_message_entry_rc(
   const int64_t entry_id);
 int agnocast_get_alive_proc_num(void);
 int agnocast_get_discovery_agent_num(void);
+bool agnocast_daemon_alive(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id);
+bool agnocast_spawn_grant_outstanding(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id);
 bool agnocast_is_proc_exited(const pid_t pid);
 int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns);
 int64_t agnocast_get_latest_received_entry_id(

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -67,6 +67,19 @@ static void remove_all_domain_rules(void)
   }
 }
 
+// Only reachable in the KUnit build, which creates grants without files: a real outstanding grant
+// holds a file that pins the module. It is also what isolates one test case from the next.
+static void remove_all_spawn_grants(void)
+{
+  struct spawn_grant * grant;
+  struct spawn_grant * tmp;
+  list_for_each_entry_safe(grant, tmp, &spawn_grant_list, node)
+  {
+    list_del_init(&grant->node);
+    kfree(grant);
+  }
+}
+
 // Called during module unload. Not an ioctl function, so we manage locks here directly.
 void agnocast_exit_free_data(void)
 {
@@ -76,6 +89,7 @@ void agnocast_exit_free_data(void)
   remove_all_discovery_agents();
   remove_all_bridge_info();
   remove_all_domain_rules();
+  remove_all_spawn_grants();
   up_write(&global_htables_rwsem);
 }
 

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -13,6 +13,8 @@ DEFINE_HASHTABLE(topic_hashtable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
 
+LIST_HEAD(spawn_grant_list);
+
 DEFINE_SPINLOCK(pid_queue_lock);
 pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 uint32_t queue_head;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -4,8 +4,10 @@
 #include "agnocast.h"
 #include "agnocast_memory_allocator.h"
 
+#include <linux/anon_inodes.h>
 #include <linux/device.h>
 #include <linux/eventfd.h>
+#include <linux/file.h>  // fput, fd_install, get_unused_fd_flags
 #include <linux/fs.h>
 #include <linux/hashtable.h>
 #include <linux/kernel.h>
@@ -32,9 +34,12 @@ extern struct device * agnocast_device;
 //   2. topic->rwsem           (per-topic, in struct topic_struct)
 //   3. mempool_lock           (agnocast_memory_allocator.c)
 //
-// Global rwsem for hashtables (topic_hashtable, proc_info_htable, bridge_htable)
+// Global rwsem for hashtables (topic_hashtable, proc_info_htable, bridge_htable) and
+// spawn_grant_list
 // - Read lock (down_read): when searching hashtables and operating within a topic
 // - Write lock (down_write): when adding/removing entries from hashtables
+// The spawn-right file's ->release takes it from __fput context and nothing else, so that path
+// cannot invert the order.
 extern struct rw_semaphore global_htables_rwsem;
 
 // =========================================
@@ -266,6 +271,22 @@ struct discovery_agent_info
 };
 
 extern DECLARE_HASHTABLE(discovery_agent_htable, DISCOVERY_AGENT_HASH_BITS);
+
+// The exclusive right to fork one daemon. Handed out as an anon_inode fd because fork() passes it
+// to the child and the file refcount returns it through ->release however the child dies, which is
+// the only way to notice a child that dies before registering: sched_process_exit filters on
+// is_agnocast_pid(). It therefore covers just the fork()-to-registration window, after which
+// proc_info_htable is authoritative and the grant is settled -- unlinked from spawn_grant_list,
+// which is a list because only a handful of entries are ever outstanding at once.
+struct spawn_grant
+{
+  enum agnocast_spawn_kind kind;
+  const struct ipc_namespace * ipc_ns;
+  uint32_t domain_id;  // AGNOCAST_DOMAIN_ID_NONE for the unlink daemon, which is namespace-scoped
+  struct list_head node;
+};
+
+extern struct list_head spawn_grant_list;
 
 // Both require global_htables_rwsem held (read for find, write for remove).
 struct discovery_agent_info * agnocast_find_discovery_agent(

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -818,9 +818,100 @@ static bool has_alive_unlink_daemon(const struct ipc_namespace * ipc_ns)
   return false;
 }
 
+// The unlink daemon is one per namespace, so its grant ignores the caller's domain.
+static uint32_t spawn_grant_scope(const enum agnocast_spawn_kind kind, const uint32_t domain_id)
+{
+  return (kind == AGNOCAST_SPAWN_UNLINK_DAEMON) ? AGNOCAST_DOMAIN_ID_NONE : domain_id;
+}
+
+// Caller holds global_htables_rwsem.
+static struct spawn_grant * find_spawn_grant(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  struct spawn_grant * grant;
+  const uint32_t scope = spawn_grant_scope(kind, domain_id);
+  list_for_each_entry(grant, &spawn_grant_list, node)
+  {
+    if (grant->kind == kind && ipc_eq(grant->ipc_ns, ipc_ns) && grant->domain_id == scope) {
+      return grant;
+    }
+  }
+  return NULL;
+}
+
+// Caller holds global_htables_rwsem.
+static bool has_alive_daemon(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  if (kind == AGNOCAST_SPAWN_UNLINK_DAEMON) return has_alive_unlink_daemon(ipc_ns);
+  if (kind == AGNOCAST_SPAWN_BRIDGE_MANAGER) return has_alive_bridge_manager(ipc_ns, domain_id);
+  if (kind == AGNOCAST_SPAWN_DISCOVERY_AGENT) {
+    return agnocast_find_discovery_agent(ipc_ns, domain_id) != NULL;
+  }
+
+  return true;  // never hand out a right for a kind this module does not know
+}
+
+// Caller holds global_htables_rwsem (write).
+static struct spawn_grant * spawn_grant_acquire_locked(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  if (has_alive_daemon(kind, ipc_ns, domain_id)) return NULL;
+  if (find_spawn_grant(kind, ipc_ns, domain_id)) return NULL;
+
+  struct spawn_grant * grant = kmalloc(sizeof(struct spawn_grant), GFP_KERNEL);
+  if (!grant) return NULL;
+
+  grant->kind = kind;
+  grant->ipc_ns = ipc_ns;
+  grant->domain_id = spawn_grant_scope(kind, domain_id);
+  list_add(&grant->node, &spawn_grant_list);
+  return grant;
+}
+
+// Caller holds global_htables_rwsem (write). Settling here rather than when the holder dies is
+// what lets agnocast_commit_exit_process() deregister a still-running daemon and have the next
+// process spawn its replacement.
+static void spawn_grant_settle_locked(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  struct spawn_grant * grant = find_spawn_grant(kind, ipc_ns, domain_id);
+  if (grant) list_del_init(&grant->node);
+}
+
+void agnocast_spawn_grant_release(struct spawn_grant * grant)
+{
+  if (!grant) return;
+
+  down_write(&global_htables_rwsem);
+  list_del_init(&grant->node);  // already settled by the daemon's registration: no-op
+  up_write(&global_htables_rwsem);
+
+  kfree(grant);
+}
+
+// Runs from __fput(), which is sleepable in both its task-work and delayed_fput forms, and
+// unordered with respect to the exit worker draining the same pid.
+static int spawn_right_release(struct inode * inode, struct file * file)
+{
+  agnocast_spawn_grant_release(file->private_data);
+  return 0;
+}
+
+static const struct file_operations spawn_right_fops = {
+  .owner = THIS_MODULE,
+  .release = spawn_right_release,
+  .llseek = noop_llseek,
+};
+
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const enum process_role role,
-  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret)
+  const uint32_t domain_id, struct agnocast_spawn_grants * spawn,
+  union ioctl_add_process_args * ioctl_ret)
 {
   int ret = 0;
 
@@ -849,16 +940,12 @@ int agnocast_ioctl_add_process(
     ret = -EINVAL;
     goto unlock;
   }
-  ioctl_ret->ret_unlink_daemon_exist = has_alive_unlink_daemon(ipc_ns);
-  ioctl_ret->ret_bridge_daemon_exist = has_alive_bridge_manager(ipc_ns, domain_id);
-  ioctl_ret->ret_discovery_agent_exist = (agnocast_find_discovery_agent(ipc_ns, domain_id) != NULL);
-
   // Deciding under the write lock add_process already holds is what stops two daemons starting
   // at once from both registering.
-  if (role == PROCESS_ROLE_BRIDGE_MANAGER && ioctl_ret->ret_bridge_daemon_exist) {
-    goto unlock;
-  }
-  if (role == PROCESS_ROLE_UNLINK_DAEMON && ioctl_ret->ret_unlink_daemon_exist) {
+  ioctl_ret->ret_role_already_taken =
+    (role == PROCESS_ROLE_BRIDGE_MANAGER && has_alive_bridge_manager(ipc_ns, domain_id)) ||
+    (role == PROCESS_ROLE_UNLINK_DAEMON && has_alive_unlink_daemon(ipc_ns));
+  if (ioctl_ret->ret_role_already_taken) {
     goto unlock;
   }
 
@@ -894,6 +981,19 @@ int agnocast_ioctl_add_process(
 
   ioctl_ret->ret_addr = new_proc_info->mempool_entry->addr;
   ioctl_ret->ret_shm_size = mempool_size_bytes;
+
+  if (role == PROCESS_ROLE_UNLINK_DAEMON) {
+    spawn_grant_settle_locked(AGNOCAST_SPAWN_UNLINK_DAEMON, ipc_ns, domain_id);
+  } else if (role == PROCESS_ROLE_BRIDGE_MANAGER) {
+    spawn_grant_settle_locked(AGNOCAST_SPAWN_BRIDGE_MANAGER, ipc_ns, domain_id);
+  }
+
+  if (spawn) {
+    for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+      if (!(spawn->requested_mask & AGNOCAST_SPAWN_MASK(kind))) continue;
+      spawn->granted[kind] = spawn_grant_acquire_locked(kind, ipc_ns, domain_id);
+    }
+  }
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -2952,6 +3052,7 @@ int agnocast_ioctl_add_discovery_agent(
   INIT_HLIST_NODE(&agent->node);
   hash_add_rcu(discovery_agent_htable, &agent->node, hash_min(pid, DISCOVERY_AGENT_HASH_BITS));
   ioctl_ret->ret_owned_by_caller = true;
+  spawn_grant_settle_locked(AGNOCAST_SPAWN_DISCOVERY_AGENT, ipc_ns, domain_id);
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -3001,21 +3102,127 @@ static long get_version_cmd(struct ioctl_get_version_args __user * arg)
   return ret;
 }
 
+struct spawn_right_files
+{
+  int fds[AGNOCAST_SPAWN_KIND_NUM];
+  struct file * files[AGNOCAST_SPAWN_KIND_NUM];
+};
+
+static void spawn_right_files_put(struct spawn_right_files * srf)
+{
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    if (srf->fds[kind] < 0) continue;
+    put_unused_fd(srf->fds[kind]);
+    srf->fds[kind] = -1;
+    fput(srf->files[kind]);
+    srf->files[kind] = NULL;
+  }
+}
+
+// Reserving before the decision leaves copy_to_user as the only thing after it that can fail. A
+// kind that cannot be reserved is withdrawn from the request rather than failing the call: the
+// caller still has to register, which none of this gates, and the right stays free for the next
+// process.
+static uint32_t spawn_right_files_reserve(
+  struct spawn_right_files * srf, const uint32_t requested_mask, const pid_t pid)
+{
+  uint32_t reserved_mask = requested_mask;
+
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    srf->fds[kind] = -1;
+    srf->files[kind] = NULL;
+  }
+
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    if (!(reserved_mask & AGNOCAST_SPAWN_MASK(kind))) continue;
+
+    int fd = get_unused_fd_flags(O_CLOEXEC);
+    // O_CLOEXEC is safe because fork() copies the descriptor regardless, and it stops an exec in
+    // the parent from leaking the right into an unrelated process.
+    struct file * file =
+      (fd < 0)
+        ? ERR_PTR(fd)
+        : anon_inode_getfile("[agnocast-spawn]", &spawn_right_fops, NULL, O_RDWR | O_CLOEXEC);
+    if (IS_ERR(file)) {
+      dev_warn(
+        agnocast_device, "Process (pid=%d) cannot be granted spawn kind %u: %ld. (%s)\n", pid,
+        (uint32_t)kind, PTR_ERR(file), __func__);
+      if (fd >= 0) put_unused_fd(fd);
+      reserved_mask &= ~AGNOCAST_SPAWN_MASK(kind);
+      continue;
+    }
+    srf->fds[kind] = fd;
+    srf->files[kind] = file;
+  }
+
+  return reserved_mask;
+}
+
+// Attaching the grant is what makes the file own the right, so from here its ->release returns it.
+static void spawn_right_files_attach(
+  struct spawn_right_files * srf, const struct agnocast_spawn_grants * spawn,
+  union ioctl_add_process_args * ioctl_ret)
+{
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    if (spawn->granted[kind]) srf->files[kind]->private_data = spawn->granted[kind];
+  }
+
+  ioctl_ret->ret_unlink_daemon_spawn_fd =
+    spawn->granted[AGNOCAST_SPAWN_UNLINK_DAEMON] ? srf->fds[AGNOCAST_SPAWN_UNLINK_DAEMON] : -1;
+  ioctl_ret->ret_bridge_daemon_spawn_fd =
+    spawn->granted[AGNOCAST_SPAWN_BRIDGE_MANAGER] ? srf->fds[AGNOCAST_SPAWN_BRIDGE_MANAGER] : -1;
+  ioctl_ret->ret_discovery_agent_spawn_fd =
+    spawn->granted[AGNOCAST_SPAWN_DISCOVERY_AGENT] ? srf->fds[AGNOCAST_SPAWN_DISCOVERY_AGENT] : -1;
+}
+
+// Only after copy_to_user: an installed fd whose number never reached userspace would hold its
+// right forever.
+static void spawn_right_files_install(
+  struct spawn_right_files * srf, const struct agnocast_spawn_grants * spawn)
+{
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    if (srf->fds[kind] < 0) continue;
+    if (spawn->granted[kind]) {
+      fd_install(srf->fds[kind], srf->files[kind]);
+    } else {
+      put_unused_fd(srf->fds[kind]);
+      fput(srf->files[kind]);
+    }
+  }
+}
+
 static long add_process_cmd(union ioctl_add_process_args __user * arg)
 {
-  int ret = 0;
   const pid_t pid = current->tgid;
   const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
   union ioctl_add_process_args add_process_args;
   if (copy_from_user(&add_process_args, arg, sizeof(add_process_args))) return -EFAULT;
-  enum process_role role = (enum process_role)add_process_args.role;
-  uint32_t domain_id = add_process_args.domain_id;
-  ret = agnocast_ioctl_add_process(pid, ipc_ns, role, domain_id, &add_process_args);
-  if (ret == 0) {
-    if (copy_to_user(arg, &add_process_args, sizeof(add_process_args))) return -EFAULT;
+  // spawn_request_mask overlaps ret_shm_size, so every request field is read out of the union
+  // before anything writes a ret_ one into it.
+  const enum process_role role = (enum process_role)add_process_args.role;
+  const uint32_t domain_id = add_process_args.domain_id;
+
+  struct spawn_right_files srf;
+  struct agnocast_spawn_grants spawn = {
+    .requested_mask = spawn_right_files_reserve(
+      &srf, add_process_args.spawn_request_mask & AGNOCAST_SPAWN_MASK_ALL, pid)};
+
+  int ret = agnocast_ioctl_add_process(pid, ipc_ns, role, domain_id, &spawn, &add_process_args);
+  if (ret != 0) {
+    spawn_right_files_put(&srf);
+    return ret;
   }
-  return ret;
+
+  spawn_right_files_attach(&srf, &spawn, &add_process_args);
+
+  if (copy_to_user(arg, &add_process_args, sizeof(add_process_args))) {
+    spawn_right_files_put(&srf);
+    return -EFAULT;
+  }
+
+  spawn_right_files_install(&srf, &spawn);
+  return 0;
 }
 
 static long add_subscriber_cmd(union ioctl_add_subscriber_args __user * arg)
@@ -3807,6 +4014,26 @@ int agnocast_get_discovery_agent_num(void)
   }
   up_read(&global_htables_rwsem);
   return count;
+}
+
+bool agnocast_daemon_alive(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  down_read(&global_htables_rwsem);
+  bool alive = has_alive_daemon(kind, ipc_ns, domain_id);
+  up_read(&global_htables_rwsem);
+  return alive;
+}
+
+bool agnocast_spawn_grant_outstanding(
+  const enum agnocast_spawn_kind kind, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_id)
+{
+  down_read(&global_htables_rwsem);
+  bool outstanding = find_spawn_grant(kind, ipc_ns, domain_id) != NULL;
+  up_read(&global_htables_rwsem);
+  return outstanding;
 }
 
 bool agnocast_is_proc_exited(const pid_t pid)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
@@ -17,7 +17,7 @@ static void setup_process_in_domain(struct kunit * test, const pid_t pid, const 
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &args),
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &args),
     0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -8,6 +8,37 @@
 #include <linux/delay.h>
 
 static pid_t pid = 1000;
+
+// ipc_eq() compares pointers and nothing dereferences an ipc_ns, so a distinct address is a
+// distinct namespace here. init_ipc_ns is not exported to modules.
+static struct ipc_namespace other_ns;
+
+static int add_process(
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const enum process_role role,
+  const uint32_t domain_id, struct agnocast_spawn_grants * spawn)
+{
+  union ioctl_add_process_args args = {};
+  return agnocast_ioctl_add_process(pid, ipc_ns, role, domain_id, spawn, &args);
+}
+
+// Asks for every kind on behalf of an application process, the way agnocastlib does when nothing
+// in its own configuration rules a daemon out.
+static struct agnocast_spawn_grants request_all(
+  struct kunit * test, const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
+{
+  struct agnocast_spawn_grants spawn = {.requested_mask = AGNOCAST_SPAWN_MASK_ALL};
+  KUNIT_ASSERT_EQ(test, add_process(pid++, ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &spawn), 0);
+  return spawn;
+}
+
+static void release_all(struct agnocast_spawn_grants * spawn)
+{
+  for (enum agnocast_spawn_kind kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    agnocast_spawn_grant_release(spawn->granted[kind]);
+    spawn->granted[kind] = NULL;
+  }
+}
+
 void test_case_add_process_normal(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
@@ -15,7 +46,7 @@ void test_case_add_process_normal(struct kunit * test)
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
   int ret = agnocast_ioctl_add_process(
-    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
@@ -34,13 +65,13 @@ void test_case_add_process_many(struct kunit * test)
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
     agnocast_ioctl_add_process(
-      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
   }
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
   int ret = agnocast_ioctl_add_process(
-    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
 
   // ================================================
   // Assert
@@ -59,9 +90,9 @@ void test_case_add_process_twice(struct kunit * test)
   pid_t local_pid = pid++;
   union ioctl_add_process_args args;
   int ret1 = agnocast_ioctl_add_process(
-    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
   int ret2 = agnocast_ioctl_add_process(
-    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, ret2, -EINVAL);
@@ -78,29 +109,29 @@ void test_case_add_process_bridge_manager_per_domain(struct kunit * test)
 
   union ioctl_add_process_args args_d0;
   int ret_d0 = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &args_d0);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &args_d0);
   KUNIT_EXPECT_EQ(test, ret_d0, 0);
-  KUNIT_EXPECT_FALSE(test, args_d0.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_FALSE(test, args_d0.ret_role_already_taken);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
 
   // Different domain: not suppressed, so it is added and sees no existing manager.
   union ioctl_add_process_args args_d1;
   int ret_d1 = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, &args_d1);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, NULL, &args_d1);
   KUNIT_EXPECT_EQ(test, ret_d1, 0);
-  KUNIT_EXPECT_FALSE(test, args_d1.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_FALSE(test, args_d1.ret_role_already_taken);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
 
   // Same domain as the first: a manager already exists, so it is suppressed.
   union ioctl_add_process_args args_d0_again;
   int ret_d0_again = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &args_d0_again);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &args_d0_again);
   KUNIT_EXPECT_EQ(test, ret_d0_again, 0);
-  KUNIT_EXPECT_TRUE(test, args_d0_again.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_TRUE(test, args_d0_again.ret_role_already_taken);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
 }
 
-// ret_unlink_daemon_exist reports a registered daemon, not a non-empty namespace.
+// A registered daemon, not a non-empty namespace, is what makes the daemon read as alive.
 void test_case_add_process_unlink_daemon_registration(struct kunit * test)
 {
   // Arrange
@@ -109,25 +140,29 @@ void test_case_add_process_unlink_daemon_registration(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &app_args),
     0);
-  KUNIT_ASSERT_FALSE(test, app_args.ret_unlink_daemon_exist);
+  KUNIT_ASSERT_FALSE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 
   // Act
   union ioctl_add_process_args daemon_args;
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_FALSE(test, daemon_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_FALSE(test, daemon_args.ret_role_already_taken);
   union ioctl_add_process_args later_args;
   KUNIT_EXPECT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &later_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &later_args),
     0);
-  KUNIT_EXPECT_TRUE(test, later_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 }
 
 // Two processes starting at once can both decide to spawn a daemon; only one may register.
@@ -139,18 +174,18 @@ void test_case_add_process_unlink_daemon_duplicate_refused(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &first_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &first_args),
     0);
   KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 1);
 
   // Act
   union ioctl_add_process_args second_args;
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &second_args);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &second_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_TRUE(test, second_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_TRUE(test, second_args.ret_role_already_taken);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
 }
 
@@ -164,14 +199,14 @@ void test_case_add_process_unlink_daemon_respawns_after_death(struct kunit * tes
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &app_args),
     0);
   const pid_t daemon_pid = pid++;
   union ioctl_add_process_args daemon_args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
   agnocast_process_exit_cleanup(app_pid);
   agnocast_process_exit_cleanup(daemon_pid);
@@ -180,11 +215,13 @@ void test_case_add_process_unlink_daemon_respawns_after_death(struct kunit * tes
   // Act
   union ioctl_add_process_args next_args;
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &next_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_FALSE(test, next_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 }
 
 // The daemon is what drains the table, so on its own it has to be told the namespace is done.
@@ -196,7 +233,7 @@ void test_case_add_process_unlink_daemon_is_not_counted_as_work(struct kunit * t
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
 
   // Act
@@ -217,14 +254,14 @@ void test_case_add_process_unlink_daemon_removed_on_death(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &app_args),
     0);
   const pid_t daemon_pid = pid++;
   union ioctl_add_process_args daemon_args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
 
   // Act
@@ -251,14 +288,14 @@ void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct 
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &app_args),
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &app_args),
     0);
   const pid_t daemon_pid = pid++;
   union ioctl_add_process_args daemon_args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
   agnocast_process_exit_cleanup(app_pid);
 
@@ -273,9 +310,11 @@ void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct 
   KUNIT_EXPECT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &next_args),
     0);
-  KUNIT_EXPECT_TRUE(test, next_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 }
 
 // A process starting between the exit decision and the daemon's death spawns a replacement.
@@ -288,7 +327,7 @@ void test_case_add_process_unlink_daemon_deregisters_when_told_to_exit(struct ku
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
 
   // Act
@@ -303,9 +342,11 @@ void test_case_add_process_unlink_daemon_deregisters_when_told_to_exit(struct ku
   KUNIT_EXPECT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &next_args),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &next_args),
     0);
-  KUNIT_EXPECT_FALSE(test, next_args.ret_unlink_daemon_exist);
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 }
 
 // Deregistering the daemon early must release its mempool slot too, which nothing else will:
@@ -319,7 +360,7 @@ void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(s
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, &daemon_args),
+      daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL, &daemon_args),
     0);
   bool daemon_should_exit = false;
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, -1, daemon_pid, &daemon_should_exit);
@@ -330,7 +371,7 @@ void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(s
   for (int i = 0; i < mempool_num; i++) {
     union ioctl_add_process_args args;
     ret = agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
     if (ret != 0) break;
   }
 
@@ -346,7 +387,8 @@ void test_case_add_process_rejects_unknown_role(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, (enum process_role)(PROCESS_ROLE_UNLINK_DAEMON + 1), 0, &args);
+    pid++, current->nsproxy->ipc_ns, (enum process_role)(PROCESS_ROLE_UNLINK_DAEMON + 1), 0, NULL,
+    &args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -360,7 +402,8 @@ void test_case_add_process_rejects_the_daemon_domain_id(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, AGNOCAST_DOMAIN_ID_NONE, &args);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, AGNOCAST_DOMAIN_ID_NONE, NULL,
+    &args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -375,7 +418,8 @@ void test_case_add_process_daemon_may_send_the_daemon_domain_id(struct kunit * t
 
   // Act
   int ret = agnocast_ioctl_add_process(
-    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, AGNOCAST_DOMAIN_ID_NONE, &args);
+    pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, AGNOCAST_DOMAIN_ID_NONE, NULL,
+    &args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -393,12 +437,12 @@ void test_case_add_process_too_many(struct kunit * test)
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
     agnocast_ioctl_add_process(
-      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+      local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
   }
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
   int ret = agnocast_ioctl_add_process(
-    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &args);
+    local_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &args);
 
   // ================================================
   // Assert
@@ -406,4 +450,229 @@ void test_case_add_process_too_many(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, -ENOMEM);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), mempool_num);
   KUNIT_EXPECT_FALSE(test, agnocast_is_proc_exited(local_pid));
+}
+
+// The point of the whole mechanism: the second process to start is not told to fork a daemon of
+// its own while the first process's child is still on its way to registering.
+void test_case_add_process_spawn_right_granted_once(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants first = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, first.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  struct agnocast_spawn_grants second = request_all(test, current->nsproxy->ipc_ns, 0);
+
+  // Assert
+  KUNIT_EXPECT_NULL(test, second.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&first);
+  release_all(&second);
+}
+
+// What the fd's ->release does when a child dies before registering.
+void test_case_add_process_spawn_right_released_right_is_regrantable(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants first = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, first.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  release_all(&first);
+
+  // Assert
+  struct agnocast_spawn_grants second = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_EXPECT_NOT_NULL(test, second.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&second);
+}
+
+// Once the daemon registers, proc_info_htable is authoritative and the right stops being
+// outstanding, so a later process is refused because the daemon is alive rather than because
+// somebody still holds the right.
+void test_case_add_process_spawn_right_settled_by_daemon_registration(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  int ret = add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_spawn_grant_outstanding(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
+
+  release_all(&spawn);
+}
+
+// The bridge manager settles its own right on registration, like the unlink daemon but scoped to
+// its domain.
+void test_case_add_process_spawn_right_settled_by_bridge_manager_registration(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = request_all(test, current->nsproxy->ipc_ns, 3);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+
+  // Act
+  int ret = add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 3, NULL);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_FALSE(
+    test,
+    agnocast_spawn_grant_outstanding(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 3));
+
+  release_all(&spawn);
+}
+
+// agnocast_commit_exit_process() deregisters the daemon while it is still running, so that a
+// process starting in that window spawns the replacement. Holding the right for the daemon's
+// lifetime instead of settling it at registration would leave that process with nothing to do.
+void test_case_add_process_spawn_right_regranted_after_early_deregistration(struct kunit * test)
+{
+  // Arrange: only the daemon, since get_process_num_except_unlink_daemon() counts every other
+  // entry in the namespace and a live one would veto the exit this hangs off.
+  const pid_t daemon_pid = pid++;
+  KUNIT_ASSERT_EQ(
+    test, add_process(daemon_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL),
+    0);
+
+  // Act
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, -1, daemon_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  struct agnocast_spawn_grants next = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_EXPECT_NOT_NULL(test, next.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&next);
+}
+
+void test_case_add_process_spawn_right_not_granted_while_daemon_alive(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL), 0);
+
+  // Act
+  struct agnocast_spawn_grants spawn = request_all(test, current->nsproxy->ipc_ns, 0);
+
+  // Assert
+  KUNIT_EXPECT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&spawn);
+}
+
+// The bridge manager is one per (namespace, domain), so its right must be too.
+void test_case_add_process_spawn_right_bridge_is_per_domain(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants d0 = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, d0.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+
+  // Act
+  struct agnocast_spawn_grants d1 = request_all(test, current->nsproxy->ipc_ns, 1);
+  struct agnocast_spawn_grants d0_again = request_all(test, current->nsproxy->ipc_ns, 0);
+
+  // Assert
+  KUNIT_EXPECT_NOT_NULL(test, d1.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+  KUNIT_EXPECT_NULL(test, d0_again.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+  // The unlink daemon is namespace-scoped, so the other domain does not get a second one.
+  KUNIT_EXPECT_NULL(test, d1.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&d0);
+  release_all(&d1);
+  release_all(&d0_again);
+}
+
+void test_case_add_process_spawn_right_unlink_is_per_namespace(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants here = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, here.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  struct agnocast_spawn_grants there = request_all(test, &other_ns, 0);
+
+  // Assert
+  KUNIT_EXPECT_NOT_NULL(test, there.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&here);
+  release_all(&there);
+}
+
+// A process that cannot fork a daemon must not be handed the right to, or nobody would.
+void test_case_add_process_spawn_right_only_requested_kinds_are_granted(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = {
+    .requested_mask = AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_BRIDGE_MANAGER)};
+
+  // Act
+  int ret = add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &spawn);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+  KUNIT_EXPECT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+  KUNIT_EXPECT_NULL(test, spawn.granted[AGNOCAST_SPAWN_DISCOVERY_AGENT]);
+  // Still ungranted, so the next process gets it.
+  struct agnocast_spawn_grants next = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_EXPECT_NOT_NULL(test, next.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  release_all(&spawn);
+  release_all(&next);
+}
+
+// The daemon holds its fd past its own registration, so ->release runs on a right that is already
+// settled. It must free that grant without disturbing the entries still on the list.
+void test_case_add_process_spawn_right_release_is_idempotent_after_settle(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_BRIDGE_MANAGER]);
+  KUNIT_ASSERT_EQ(
+    test, add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_UNLINK_DAEMON, 0, NULL), 0);
+
+  // Act
+  agnocast_spawn_grant_release(spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+  spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON] = NULL;
+
+  // Assert
+  KUNIT_EXPECT_TRUE(
+    test,
+    agnocast_spawn_grant_outstanding(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
+  KUNIT_EXPECT_TRUE(
+    test,
+    agnocast_spawn_grant_outstanding(AGNOCAST_SPAWN_DISCOVERY_AGENT, current->nsproxy->ipc_ns, 0));
+
+  release_all(&spawn);
+}
+
+// Why the right has to be an fd: the exit path filters on is_agnocast_pid(), so a child that dies
+// between fork() and its own registration is invisible to it. Only the file's ->release returns
+// the right.
+void test_case_add_process_spawn_right_survives_exit_of_an_unregistered_process(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = request_all(test, current->nsproxy->ipc_ns, 0);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  agnocast_process_exit_cleanup(pid++);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_spawn_grant_outstanding(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
+
+  release_all(&spawn);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -17,7 +17,18 @@
     KUNIT_CASE(test_case_add_process_rejects_the_daemon_domain_id),                        \
     KUNIT_CASE(test_case_add_process_daemon_may_send_the_daemon_domain_id),                \
     KUNIT_CASE(test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot), \
-    KUNIT_CASE(test_case_add_process_unlink_daemon_stays_registered_while_draining)
+    KUNIT_CASE(test_case_add_process_unlink_daemon_stays_registered_while_draining),       \
+    KUNIT_CASE(test_case_add_process_spawn_right_granted_once),                            \
+    KUNIT_CASE(test_case_add_process_spawn_right_released_right_is_regrantable),           \
+    KUNIT_CASE(test_case_add_process_spawn_right_settled_by_daemon_registration),          \
+    KUNIT_CASE(test_case_add_process_spawn_right_settled_by_bridge_manager_registration),  \
+    KUNIT_CASE(test_case_add_process_spawn_right_regranted_after_early_deregistration),    \
+    KUNIT_CASE(test_case_add_process_spawn_right_not_granted_while_daemon_alive),          \
+    KUNIT_CASE(test_case_add_process_spawn_right_bridge_is_per_domain),                    \
+    KUNIT_CASE(test_case_add_process_spawn_right_unlink_is_per_namespace),                 \
+    KUNIT_CASE(test_case_add_process_spawn_right_only_requested_kinds_are_granted),        \
+    KUNIT_CASE(test_case_add_process_spawn_right_release_is_idempotent_after_settle),      \
+    KUNIT_CASE(test_case_add_process_spawn_right_survives_exit_of_an_unregistered_process)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
@@ -35,3 +46,15 @@ void test_case_add_process_rejects_the_daemon_domain_id(struct kunit * test);
 void test_case_add_process_daemon_may_send_the_daemon_domain_id(struct kunit * test);
 void test_case_add_process_unlink_daemon_deregistration_frees_its_mempool_slot(struct kunit * test);
 void test_case_add_process_unlink_daemon_stays_registered_while_draining(struct kunit * test);
+void test_case_add_process_spawn_right_granted_once(struct kunit * test);
+void test_case_add_process_spawn_right_released_right_is_regrantable(struct kunit * test);
+void test_case_add_process_spawn_right_settled_by_daemon_registration(struct kunit * test);
+void test_case_add_process_spawn_right_settled_by_bridge_manager_registration(struct kunit * test);
+void test_case_add_process_spawn_right_regranted_after_early_deregistration(struct kunit * test);
+void test_case_add_process_spawn_right_not_granted_while_daemon_alive(struct kunit * test);
+void test_case_add_process_spawn_right_bridge_is_per_domain(struct kunit * test);
+void test_case_add_process_spawn_right_unlink_is_per_namespace(struct kunit * test);
+void test_case_add_process_spawn_right_only_requested_kinds_are_granted(struct kunit * test);
+void test_case_add_process_spawn_right_release_is_idempotent_after_settle(struct kunit * test);
+void test_case_add_process_spawn_right_survives_exit_of_an_unregistered_process(
+  struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -19,7 +19,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
@@ -27,7 +27,7 @@ static void setup_process_domain(struct kunit * test, const pid_t pid, const uin
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
@@ -8,54 +8,54 @@
 static pid_t pid_bs = 8000;
 
 // Registering as a bridge manager should succeed and record the role
-// so that subsequent processes see ret_bridge_daemon_exist=true
+// so that subsequent processes see the manager as alive
 void test_case_bridge_manager_flag_set_on_registration(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
   int ret = agnocast_ioctl_add_process(
-    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Verify the flag was set by checking a new process sees it
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
   ret = agnocast_ioctl_add_process(
-    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_TRUE(test, normal_args.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
 }
 
-// When a bridge manager is already registered, a new process calling add_process
-// should receive ret_bridge_daemon_exist=true
+// When a bridge manager is already registered, a new process must see it as alive
 void test_case_bridge_manager_detected_by_new_process(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
   int ret = agnocast_ioctl_add_process(
-    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register normal process - should see bridge manager exists
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
   ret = agnocast_ioctl_add_process(
-    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_TRUE(test, normal_args.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
 }
 
-// notify_bridge_shutdown clears the bridge manager role, so a new process
-// should receive ret_bridge_daemon_exist=false
+// notify_bridge_shutdown clears the bridge manager role, so the manager stops reading as alive
 void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
 {
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
   int ret = agnocast_ioctl_add_process(
-    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Notify shutdown
@@ -65,7 +65,8 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
   ret = agnocast_ioctl_add_process(
-    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_FALSE(test, normal_args.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -15,7 +15,7 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
   int ret = agnocast_ioctl_add_process(
-    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - only bridge manager exists (process_num == 1)
@@ -29,9 +29,10 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   pid_t normal_pid = pid_carbs++;
   union ioctl_add_process_args normal_args = {};
   ret = agnocast_ioctl_add_process(
-    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &normal_args);
+    normal_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_FALSE(test, normal_args.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
 }
 
 // When other processes exist, check_and_request_bridge_shutdown
@@ -42,14 +43,14 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
   int ret = agnocast_ioctl_add_process(
-    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, &bridge_args);
+    bridge_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 0, NULL, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register another process
   pid_t other_pid = pid_carbs++;
   union ioctl_add_process_args other_args = {};
   ret = agnocast_ioctl_add_process(
-    other_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &other_args);
+    other_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - other process exists (process_num > 1)
@@ -63,9 +64,10 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   pid_t new_pid = pid_carbs++;
   union ioctl_add_process_args new_args = {};
   ret = agnocast_ioctl_add_process(
-    new_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &new_args);
+    new_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &new_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_TRUE(test, new_args.ret_bridge_daemon_exist);
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_BRIDGE_MANAGER, current->nsproxy->ipc_ns, 0));
 }
 
 // A per-(ipc_ns, domain) manager shuts down once its own domain is empty, even if
@@ -76,14 +78,14 @@ void test_case_check_and_request_bridge_shutdown_per_domain(struct kunit * test)
   pid_t mgr_d1 = pid_carbs++;
   union ioctl_add_process_args mgr_args = {};
   int ret = agnocast_ioctl_add_process(
-    mgr_d1, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, &mgr_args);
+    mgr_d1, current->nsproxy->ipc_ns, PROCESS_ROLE_BRIDGE_MANAGER, 1, NULL, &mgr_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // A normal process keeps domain 2 busy.
   pid_t other_d2 = pid_carbs++;
   union ioctl_add_process_args other_args = {};
   ret = agnocast_ioctl_add_process(
-    other_d2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 2, &other_args);
+    other_d2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 2, NULL, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Domain 1 holds only the manager, so it should shut down despite domain 2 being busy.

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.c
@@ -70,9 +70,10 @@ void test_case_discovery_agent_exist_reflects_registration(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, &before),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, NULL, &before),
     0);
-  KUNIT_EXPECT_FALSE(test, before.ret_discovery_agent_exist);  // process alive, no agent yet
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_DISCOVERY_AGENT, current->nsproxy->ipc_ns, 12));
 
   struct ioctl_add_discovery_agent_args reg;
   KUNIT_ASSERT_EQ(
@@ -82,9 +83,10 @@ void test_case_discovery_agent_exist_reflects_registration(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, &after),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 12, NULL, &after),
     0);
-  KUNIT_EXPECT_TRUE(test, after.ret_discovery_agent_exist);  // now an agent is registered
+  KUNIT_EXPECT_TRUE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_DISCOVERY_AGENT, current->nsproxy->ipc_ns, 12));
 }
 
 // commit on an empty domain deregisters the agent and tells it to exit.
@@ -121,7 +123,7 @@ void test_case_discovery_agent_commit_exit_vetoed_when_busy(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 14, &proc),
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 14, NULL, &proc),
     0);
 
   bool should_exit = true;
@@ -175,9 +177,12 @@ void test_case_discovery_agent_orphan_race(struct kunit * test)
   union ioctl_add_process_args p2;
   KUNIT_ASSERT_EQ(
     test,
-    agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 16, &p2),
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 16, NULL, &p2),
     0);
-  KUNIT_EXPECT_FALSE(test, p2.ret_discovery_agent_exist);  // A is gone -> P2 must spawn one
+  // A is gone, so P2 must spawn one
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_daemon_alive(AGNOCAST_SPAWN_DISCOVERY_AGENT, current->nsproxy->ipc_ns, 16));
 
   const pid_t agent_b = pid++;
   struct ioctl_add_discovery_agent_args reg_b;
@@ -227,7 +232,7 @@ void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 19, &app),
+      app_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 19, NULL, &app),
     0);
 
   agnocast_enqueue_exit_pid(app_pid);
@@ -242,4 +247,58 @@ void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test
     0);
   KUNIT_EXPECT_TRUE(test, should_exit);                          // exited process does not veto
   KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 0);  // agent deregistered
+}
+
+// Takes the right to fork an agent for (ns, domain), the way an application process does.
+static struct spawn_grant * take_agent_spawn_right(struct kunit * test, const uint32_t domain_id)
+{
+  struct agnocast_spawn_grants spawn = {
+    .requested_mask = AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_DISCOVERY_AGENT)};
+  union ioctl_add_process_args args = {};
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      pid++, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &spawn, &args),
+    0);
+  return spawn.granted[AGNOCAST_SPAWN_DISCOVERY_AGENT];
+}
+
+// The agent claims through its own ioctl before exec, so that is where its right settles.
+void test_case_discovery_agent_claim_settles_the_spawn_right(struct kunit * test)
+{
+  // Arrange
+  struct spawn_grant * grant = take_agent_spawn_right(test, 7);
+  KUNIT_ASSERT_NOT_NULL(test, grant);
+
+  // Act
+  struct ioctl_add_discovery_agent_args claim = {};
+  int ret = agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 7, &claim);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_TRUE(test, claim.ret_owned_by_caller);
+  KUNIT_EXPECT_FALSE(
+    test,
+    agnocast_spawn_grant_outstanding(AGNOCAST_SPAWN_DISCOVERY_AGENT, current->nsproxy->ipc_ns, 7));
+
+  agnocast_spawn_grant_release(grant);
+}
+
+void test_case_discovery_agent_spawn_right_regranted_after_exit(struct kunit * test)
+{
+  // Arrange
+  agnocast_spawn_grant_release(take_agent_spawn_right(test, 8));
+  const pid_t agent_pid = pid++;
+  struct ioctl_add_discovery_agent_args claim = {};
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_pid, current->nsproxy->ipc_ns, 8, &claim), 0);
+
+  // Act
+  agnocast_process_exit_cleanup(agent_pid);
+
+  // Assert
+  struct spawn_grant * next = take_agent_spawn_right(test, 8);
+  KUNIT_EXPECT_NOT_NULL(test, next);
+
+  agnocast_spawn_grant_release(next);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_discovery_agent.h
@@ -2,17 +2,19 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_DISCOVERY_AGENT                                      \
-  KUNIT_CASE(test_case_discovery_agent_register_first_wins),            \
-    KUNIT_CASE(test_case_discovery_agent_register_duplicate_loses),     \
-    KUNIT_CASE(test_case_discovery_agent_same_pid_reclaim_wins),        \
-    KUNIT_CASE(test_case_discovery_agent_exist_reflects_registration),  \
-    KUNIT_CASE(test_case_discovery_agent_commit_exit_when_idle),        \
-    KUNIT_CASE(test_case_discovery_agent_commit_exit_vetoed_when_busy), \
-    KUNIT_CASE(test_case_discovery_agent_reaped_on_exit),               \
-    KUNIT_CASE(test_case_discovery_agent_orphan_race),                  \
-    KUNIT_CASE(test_case_discovery_agent_exists_ioctl),                 \
-    KUNIT_CASE(test_case_discovery_agent_commit_ignores_exited_process)
+#define TEST_CASES_DISCOVERY_AGENT                                       \
+  KUNIT_CASE(test_case_discovery_agent_register_first_wins),             \
+    KUNIT_CASE(test_case_discovery_agent_register_duplicate_loses),      \
+    KUNIT_CASE(test_case_discovery_agent_same_pid_reclaim_wins),         \
+    KUNIT_CASE(test_case_discovery_agent_exist_reflects_registration),   \
+    KUNIT_CASE(test_case_discovery_agent_commit_exit_when_idle),         \
+    KUNIT_CASE(test_case_discovery_agent_commit_exit_vetoed_when_busy),  \
+    KUNIT_CASE(test_case_discovery_agent_reaped_on_exit),                \
+    KUNIT_CASE(test_case_discovery_agent_orphan_race),                   \
+    KUNIT_CASE(test_case_discovery_agent_exists_ioctl),                  \
+    KUNIT_CASE(test_case_discovery_agent_commit_ignores_exited_process), \
+    KUNIT_CASE(test_case_discovery_agent_claim_settles_the_spawn_right), \
+    KUNIT_CASE(test_case_discovery_agent_spawn_right_regranted_after_exit)
 
 void test_case_discovery_agent_register_first_wins(struct kunit * test);
 void test_case_discovery_agent_register_duplicate_loses(struct kunit * test);
@@ -24,3 +26,5 @@ void test_case_discovery_agent_reaped_on_exit(struct kunit * test);
 void test_case_discovery_agent_orphan_race(struct kunit * test);
 void test_case_discovery_agent_exists_ioctl(struct kunit * test);
 void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test);
+void test_case_discovery_agent_claim_settles_the_spawn_right(struct kunit * test);
+void test_case_discovery_agent_spawn_right_regranted_after_exit(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -25,7 +25,7 @@ static void setup_processes(struct kunit * test, const int process_num)
   for (int i = 0; i < process_num; i++) {
     const pid_t pid = PID_BASE + i;
     int ret = agnocast_ioctl_add_process(
-      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &ioctl_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));
   }
@@ -36,7 +36,7 @@ static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -31,7 +31,7 @@ static uint64_t setup_process_in_domain(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &args),
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &args),
     0);
   return args.ret_addr;
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.c
@@ -20,7 +20,7 @@ static void setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
@@ -61,4 +61,29 @@ void test_case_exit_free_data_releases_notify_context(struct kunit * test)
     KUNIT_EXPECT_EQ(test, slot->put_count, 1);
   }
   KUNIT_EXPECT_EQ(test, agnocast_kunit_eventfd_outstanding(), (int64_t)0);
+}
+
+// A grant is normally freed by its file's ->release, so unload is the one path that has to drain
+// the list itself. In the KUnit build it is also what keeps one test case from leaking a grant
+// into the next.
+void test_case_exit_free_data_drains_outstanding_spawn_grants(struct kunit * test)
+{
+  // Arrange
+  struct agnocast_spawn_grants spawn = {
+    .requested_mask = AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_UNLINK_DAEMON)};
+  union ioctl_add_process_args add_process_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      PID_BASE, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &spawn, &add_process_args),
+    0);
+  KUNIT_ASSERT_NOT_NULL(test, spawn.granted[AGNOCAST_SPAWN_UNLINK_DAEMON]);
+
+  // Act
+  agnocast_exit_free_data();
+
+  // Assert: the grant is freed, so it must not be dereferenced again from here.
+  KUNIT_EXPECT_FALSE(
+    test, agnocast_spawn_grant_outstanding(
+            AGNOCAST_SPAWN_UNLINK_DAEMON, current->nsproxy->ipc_ns, AGNOCAST_DOMAIN_ID_NONE));
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_exit_free_data.h
@@ -2,6 +2,9 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_EXIT_FREE_DATA KUNIT_CASE(test_case_exit_free_data_releases_notify_context)
+#define TEST_CASES_EXIT_FREE_DATA                               \
+  KUNIT_CASE(test_case_exit_free_data_releases_notify_context), \
+    KUNIT_CASE(test_case_exit_free_data_drains_outstanding_spawn_grants)
 
 void test_case_exit_free_data_releases_notify_context(struct kunit * test);
+void test_case_exit_free_data_drains_outstanding_spawn_grants(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -17,7 +17,7 @@ static void setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &ioctl_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
@@ -21,7 +21,7 @@ static uint64_t setup_process(struct kunit * test, const pid_t pid, const uint32
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   return add_process_args.ret_addr;
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -16,7 +16,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -16,7 +16,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -19,7 +19,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -37,7 +37,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -54,7 +54,7 @@ static void setup_one_publisher_with_bridge(struct kunit * test, char * topic_na
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -184,7 +184,7 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -15,7 +15,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -20,7 +20,7 @@ static void setup_one_subscriber_impl(
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
     &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -49,7 +49,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -66,7 +66,7 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    intra_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    intra_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -96,7 +96,7 @@ static void setup_current_publisher_in_domain(
 {
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    current->tgid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+    current->tgid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
     &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -15,7 +15,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -15,7 +15,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
@@ -23,7 +23,7 @@ static void setup_process_domain(struct kunit * test, const pid_t pid, const uin
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -15,7 +15,7 @@ static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
@@ -23,7 +23,7 @@ static void setup_process_domain(struct kunit * test, const pid_t pid, const uin
 {
   union ioctl_add_process_args add_process_args;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -48,7 +48,7 @@ static topic_local_id_t setup_one_subscriber_in_domain_with_eventfd(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
       &add_process_args),
     0);
   return add_subscriber_with_eventfd(
@@ -77,7 +77,7 @@ static void setup_publisher_in_domain(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args),
+      pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL, &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
 
@@ -444,7 +444,8 @@ void test_case_publish_msg_does_not_signal_take_sub(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL,
+      &add_process_args),
     0);
 
   const int take_eventfd = 0;
@@ -485,7 +486,8 @@ void test_case_publish_msg_signals_large_fanout(struct kunit * test)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL,
+      &add_process_args),
     0);
   for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
     add_subscriber_with_eventfd(test, subscriber_pid, eventfd, false, is_bridge);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -26,7 +26,7 @@ static void setup_subscriber_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
       &add_process_args),
     0);
 
@@ -67,7 +67,7 @@ static void setup_publisher_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
       &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
@@ -937,7 +937,7 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -980,7 +980,7 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -1018,7 +1018,7 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -1245,7 +1245,7 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1289,7 +1289,7 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -23,7 +23,7 @@ static void setup_one_publisher(
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    PUBLISHER_PID, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    PUBLISHER_PID, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH,
@@ -103,7 +103,7 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -151,7 +151,8 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid1 = 1000;
   union ioctl_add_process_args add_process_args1;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid1, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args1);
+    subscriber_pid1, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL,
+    &add_process_args1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -170,7 +171,8 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid2 = 1001;
   union ioctl_add_process_args add_process_args2;
   int ret5 = agnocast_ioctl_add_process(
-    subscriber_pid2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args2);
+    subscriber_pid2, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL,
+    &add_process_args2);
   KUNIT_ASSERT_EQ(test, ret5, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
@@ -227,7 +229,7 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -21,7 +21,7 @@ static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -22,7 +22,7 @@ static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
   int ret = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &ioctl_ret);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -15,7 +15,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -18,7 +18,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -26,7 +26,7 @@ static void setup_subscriber_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
       &add_process_args),
     0);
 
@@ -67,7 +67,7 @@ static void setup_publisher_impl(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, NULL,
       &add_process_args),
     0);
   *ret_addr = add_process_args.ret_addr;
@@ -796,7 +796,7 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -842,7 +842,7 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
   int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    publisher_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth1 = 10;
@@ -884,7 +884,7 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -1045,7 +1045,7 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1091,7 +1091,7 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args);
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, NULL, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -71,6 +71,16 @@ enum process_role {
   PROCESS_ROLE_UNLINK_DAEMON = 2,
 };
 
+// Mirrors enum agnocast_spawn_kind in the kernel module.
+enum agnocast_spawn_kind {
+  AGNOCAST_SPAWN_UNLINK_DAEMON = 0,
+  AGNOCAST_SPAWN_BRIDGE_MANAGER = 1,
+  AGNOCAST_SPAWN_DISCOVERY_AGENT = 2,
+  AGNOCAST_SPAWN_KIND_NUM,
+};
+
+#define AGNOCAST_SPAWN_MASK(kind) (1u << (kind))
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 union ioctl_add_process_args {
@@ -78,14 +88,20 @@ union ioctl_add_process_args {
   {
     uint32_t role;       // enum process_role
     uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
+    // The daemons this caller is willing to fork, so a granted right is never one it will not use.
+    uint32_t spawn_request_mask;
   };
   struct
   {
     uint64_t ret_addr;
     uint64_t ret_shm_size;
-    bool ret_unlink_daemon_exist;
-    bool ret_bridge_daemon_exist;
-    bool ret_discovery_agent_exist;
+    // The exclusive right to fork this daemon, or -1. The forked child inherits the fd, and the
+    // right comes back when its last holder closes it or dies.
+    int32_t ret_unlink_daemon_spawn_fd;
+    int32_t ret_bridge_daemon_spawn_fd;
+    int32_t ret_discovery_agent_spawn_fd;
+    // Daemon roles only: one is already registered, so stand down.
+    bool ret_role_already_taken;
   };
 };
 #pragma GCC diagnostic pop

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -172,7 +172,9 @@ void initialize_bridge_allocator(void * mempool_ptr, size_t mempool_size)
   }
 }
 
-initialize_agnocast_result acquire_agnocast_resources_for_bridge()
+void daemonize_current_process();
+
+initialize_agnocast_result acquire_agnocast_resources_for_bridge(const int spawn_fd)
 {
   union ioctl_add_process_args add_process_args = {};
   add_process_args.role = PROCESS_ROLE_BRIDGE_MANAGER;
@@ -180,8 +182,10 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge()
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     throw std::runtime_error(std::string("AGNOCAST_ADD_PROCESS_CMD failed: ") + strerror(errno));
   }
+  // The kernel module is authoritative from here, so hand the right back.
+  close(spawn_fd);
 
-  if (add_process_args.ret_bridge_daemon_exist) {
+  if (add_process_args.ret_role_already_taken) {
     close(agnocast_fd);
     exit(EXIT_SUCCESS);
   }
@@ -199,10 +203,9 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge()
   };
 }
 
-void poll_for_unlink()
+void poll_for_unlink(const int spawn_fd)
 {
-  // Register so the kernel module can tell a live daemon from a dead one. No domain_id: the
-  // kernel module records this daemon as belonging to none.
+  // No domain_id: the kernel module records this daemon as belonging to none.
   union ioctl_add_process_args add_process_args = {};
   add_process_args.role = PROCESS_ROLE_UNLINK_DAEMON;
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
@@ -210,12 +213,15 @@ void poll_for_unlink()
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+  close(spawn_fd);
 
   // Another daemon won the race and registered first; this one has nothing to do.
-  if (add_process_args.ret_unlink_daemon_exist) {
+  if (add_process_args.ret_role_already_taken) {
     close(agnocast_fd);
     exit(EXIT_SUCCESS);
   }
+
+  daemonize_current_process();
 
   while (true) {
     sleep(1);
@@ -242,10 +248,11 @@ void poll_for_unlink()
   exit(0);
 }
 
-void poll_for_bridge_manager()
+void poll_for_bridge_manager(const int spawn_fd)
 {
   try {
-    const auto resources = acquire_agnocast_resources_for_bridge();
+    const auto resources = acquire_agnocast_resources_for_bridge(spawn_fd);
+    daemonize_current_process();
     initialize_bridge_allocator(resources.mempool_ptr, resources.mempool_size);
     BridgeManager manager;
     manager.run();
@@ -451,8 +458,7 @@ bool discovery_agent_auto_fork_disabled()
          (strcmp(v, "1") == 0 || strcasecmp(v, "true") == 0 || strcasecmp(v, "yes") == 0);
 }
 
-template <typename Func>
-pid_t spawn_daemon_process(Func && func)
+void daemonize_current_process()
 {
   auto fail = [](const char * err_fmt) {
     RCLCPP_ERROR(logger, err_fmt, strerror(errno));
@@ -460,60 +466,80 @@ pid_t spawn_daemon_process(Func && func)
     exit(EXIT_FAILURE);
   };
 
+  unsetenv("LD_PRELOAD");
+
+  // Redirect stdio to /dev/null when stdout or stderr is an inherited pipe or socket. In that
+  // case, a process may be reading from the pipe and waiting on it to close, which can cause
+  // the process to hang because the daemon never closes it. Redirecting to /dev/null works around
+  // this issue.
+  struct stat st_out = {};
+  struct stat st_err = {};
+  if (fstat(STDOUT_FILENO, &st_out) < 0) {
+    fail("fstat for stdout failed: %s");
+  }
+  if (fstat(STDERR_FILENO, &st_err) < 0) {
+    fail("fstat for stderr failed: %s");
+  }
+
+  if (
+    S_ISFIFO(st_out.st_mode) || S_ISFIFO(st_err.st_mode) || S_ISSOCK(st_out.st_mode) ||
+    S_ISSOCK(st_err.st_mode)) {
+    int devnull = open("/dev/null", O_RDWR);
+    if (devnull < 0) {
+      fail("Failed to open /dev/null: %s");
+    }
+
+    // Send the output to the terminal rather than discarding it. Must be opened before setsid(),
+    // which drops the controlling terminal /dev/tty resolves against. stdin stays on /dev/null
+    // because this is write-only, so reads see EOF rather than EBADF.
+    const int tty = open("/dev/tty", O_WRONLY);
+    const int out_fd = (tty >= 0) ? tty : devnull;
+
+    if (dup2(devnull, STDIN_FILENO) < 0) {
+      fail("dup2 for stdin failed: %s");
+    }
+    if (dup2(out_fd, STDOUT_FILENO) < 0) {
+      fail("dup2 for stdout failed: %s");
+    }
+    if (dup2(out_fd, STDERR_FILENO) < 0) {
+      fail("dup2 for stderr failed: %s");
+    }
+    if (out_fd != devnull) {
+      close(out_fd);
+    }
+    close(devnull);
+  }
+
+  if (setsid() == -1) {
+    fail("setsid failed: %s");
+  }
+}
+
+// fork() copies the whole descriptor table, so a daemon child inherits its siblings' rights as
+// well as its own. One left open in a daemon that runs for the lifetime of the namespace would
+// keep that right from ever coming back, so every child keeps only the kind it was forked for.
+void disown_other_spawn_fds(
+  const std::array<int, AGNOCAST_SPAWN_KIND_NUM> & spawn_fds, const enum agnocast_spawn_kind owned)
+{
+  for (int kind = 0; kind < AGNOCAST_SPAWN_KIND_NUM; kind++) {
+    if (kind != owned && spawn_fds[kind] >= 0) close(spawn_fds[kind]);
+  }
+}
+
+template <typename Func>
+pid_t spawn_daemon_process(
+  const std::array<int, AGNOCAST_SPAWN_KIND_NUM> & spawn_fds, const enum agnocast_spawn_kind owned,
+  Func && func)
+{
   pid_t pid = fork();
   if (pid < 0) {
-    fail("fork failed: %s");
+    RCLCPP_ERROR(logger, "fork failed: %s", strerror(errno));
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
   }
   if (pid == 0) {
     agnocast::is_bridge_process = true;
-    unsetenv("LD_PRELOAD");
-
-    // Redirect stdio to /dev/null when stdout or stderr is an inherited pipe or socket. In that
-    // case, a process may be reading from the pipe and waiting on it to close, which can cause
-    // the process to hang because the daemon never closes it. Redirecting to /dev/null works around
-    // this issue.
-    struct stat st_out = {};
-    struct stat st_err = {};
-    if (fstat(STDOUT_FILENO, &st_out) < 0) {
-      fail("fstat for stdout failed: %s");
-    }
-    if (fstat(STDERR_FILENO, &st_err) < 0) {
-      fail("fstat for stderr failed: %s");
-    }
-
-    if (
-      S_ISFIFO(st_out.st_mode) || S_ISFIFO(st_err.st_mode) || S_ISSOCK(st_out.st_mode) ||
-      S_ISSOCK(st_err.st_mode)) {
-      int devnull = open("/dev/null", O_RDWR);
-      if (devnull < 0) {
-        fail("Failed to open /dev/null: %s");
-      }
-
-      // Send the output to the terminal rather than discarding it. Must be opened before setsid(),
-      // which drops the controlling terminal /dev/tty resolves against. stdin stays on /dev/null
-      // because this is write-only, so reads see EOF rather than EBADF.
-      const int tty = open("/dev/tty", O_WRONLY);
-      const int out_fd = (tty >= 0) ? tty : devnull;
-
-      if (dup2(devnull, STDIN_FILENO) < 0) {
-        fail("dup2 for stdin failed: %s");
-      }
-      if (dup2(out_fd, STDOUT_FILENO) < 0) {
-        fail("dup2 for stdout failed: %s");
-      }
-      if (dup2(out_fd, STDERR_FILENO) < 0) {
-        fail("dup2 for stderr failed: %s");
-      }
-      if (out_fd != devnull) {
-        close(out_fd);
-      }
-      close(devnull);
-    }
-
-    if (setsid() == -1) {
-      fail("setsid failed: %s");
-    }
-
+    disown_other_spawn_fds(spawn_fds, owned);
     func();
     exit(0);
   }
@@ -552,7 +578,7 @@ struct initialize_agnocast_result initialize_agnocast(
     exit(EXIT_FAILURE);
   }
 
-  // add_process_args is a union, so ADD_PROCESS overwrites domain_id with its ret_* fields.
+  // add_process_args is a union, so ADD_PROCESS overwrites the request fields with its ret_ ones.
   const uint32_t domain_id = get_ros_domain_id();
   if (domain_id == AGNOCAST_DOMAIN_ID_NONE) {
     RCLCPP_ERROR(logger, "ROS_DOMAIN_ID=%u is reserved by Agnocast", domain_id);
@@ -560,50 +586,67 @@ struct initialize_agnocast_result initialize_agnocast(
     exit(EXIT_FAILURE);
   }
 
+  // Decided before ADD_PROCESS: whether this process can spawn each daemon is per-process
+  // configuration the kernel module cannot see, and it grants only what is requested here.
+  const bool wants_bridge = get_bridge_mode() == BridgeMode::On;
+  const bool wants_agent = !discovery_agent_auto_fork_disabled();
+  const std::string agent_path = wants_agent ? resolve_discovery_agent_path() : std::string();
+  if (wants_agent && agent_path.empty()) {
+    RCLCPP_WARN(
+      logger,
+      "The discovery agent executable was not found in AMENT_PREFIX_PATH, so it is not "
+      "auto-started. Source the workspace that installs ros2agnocast_discovery_agent to enable "
+      "Agnocast observability.");
+  }
+
   union ioctl_add_process_args add_process_args = {};
   add_process_args.role = PROCESS_ROLE_APPLICATION;
   add_process_args.domain_id = domain_id;
+  add_process_args.spawn_request_mask =
+    AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_UNLINK_DAEMON) |
+    (wants_bridge ? AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_BRIDGE_MANAGER) : 0u) |
+    (agent_path.empty() ? 0u : AGNOCAST_SPAWN_MASK(AGNOCAST_SPAWN_DISCOVERY_AGENT));
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_PROCESS_CMD failed: %s", strerror(errno));
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
 
-  bool should_spawn_bridge = false;
-  auto bridge_mode = get_bridge_mode();
+  // The parent keeps its own copies until every fork is done, so that all children inherit the
+  // same set and none of them closes a descriptor number that has since been reused.
+  std::array<int, AGNOCAST_SPAWN_KIND_NUM> spawn_fds{};
+  spawn_fds[AGNOCAST_SPAWN_UNLINK_DAEMON] = add_process_args.ret_unlink_daemon_spawn_fd;
+  spawn_fds[AGNOCAST_SPAWN_BRIDGE_MANAGER] = add_process_args.ret_bridge_daemon_spawn_fd;
+  spawn_fds[AGNOCAST_SPAWN_DISCOVERY_AGENT] = add_process_args.ret_discovery_agent_spawn_fd;
 
-  // Create a shm_unlink daemon process if it doesn't exist in its ipc namespace.
-  // ret_unlink_daemon_exist is only an early-out hint: poll_for_unlink() makes the singleton
-  // decision when it registers.
-  if (!add_process_args.ret_unlink_daemon_exist) {
-    spawn_daemon_process([]() { poll_for_unlink(); });
-  }
-  if (bridge_mode == BridgeMode::On && !add_process_args.ret_bridge_daemon_exist) {
-    should_spawn_bridge = true;
+  const int unlink_spawn_fd = spawn_fds[AGNOCAST_SPAWN_UNLINK_DAEMON];
+  if (unlink_spawn_fd >= 0) {
+    spawn_daemon_process(spawn_fds, AGNOCAST_SPAWN_UNLINK_DAEMON, [unlink_spawn_fd]() {
+      poll_for_unlink(unlink_spawn_fd);
+    });
   }
 
-  if (should_spawn_bridge) {
-    spawn_daemon_process([]() { poll_for_bridge_manager(); });
+  const int bridge_spawn_fd = spawn_fds[AGNOCAST_SPAWN_BRIDGE_MANAGER];
+  if (bridge_spawn_fd >= 0) {
+    spawn_daemon_process(spawn_fds, AGNOCAST_SPAWN_BRIDGE_MANAGER, [bridge_spawn_fd]() {
+      poll_for_bridge_manager(bridge_spawn_fd);
+    });
   }
 
   // The forked agent inherits this process's IPC namespace and ROS_DOMAIN_ID, and self-exits when
   // the scope empties. A missing agent is not fatal because the data plane does not depend on
   // the observer; a fork() failure still is, as for the other daemons spawned here.
-  // ret_discovery_agent_exist is only an early-out hint.
-  if (!add_process_args.ret_discovery_agent_exist && !discovery_agent_auto_fork_disabled()) {
-    const std::string agent_path = resolve_discovery_agent_path();
-    if (agent_path.empty()) {
-      RCLCPP_WARN(
-        logger,
-        "The discovery agent executable was not found in AMENT_PREFIX_PATH, so it is not "
-        "auto-started. Source the workspace that installs ros2agnocast_discovery_agent to enable "
-        "Agnocast observability.");
-    } else {
-      spawn_daemon_process([domain_id, agent_path]() {
-        // Claiming here rather than in the agent keeps the launch O(1): N processes starting at
-        // once cost one fork each, not N Python interpreters.
-        switch (claim_discovery_agent(domain_id)) {
+  const int agent_spawn_fd = spawn_fds[AGNOCAST_SPAWN_DISCOVERY_AGENT];
+  if (agent_spawn_fd >= 0) {
+    spawn_daemon_process(
+      spawn_fds, AGNOCAST_SPAWN_DISCOVERY_AGENT, [domain_id, agent_path, agent_spawn_fd]() {
+        // Claiming here rather than in the agent keeps the losing case cheap: a fork that ends in
+        // _exit, not a Python interpreter that starts up only to find it lost.
+        const claim_result result = claim_discovery_agent(domain_id);
+        close(agent_spawn_fd);
+        switch (result) {
           case claim_result::won:
+            daemonize_current_process();
             exec_discovery_agent(agent_path.c_str());
           case claim_result::lost:
             _exit(EXIT_SUCCESS);
@@ -611,7 +654,10 @@ struct initialize_agnocast_result initialize_agnocast(
             _exit(EXIT_FAILURE);
         }
       });
-    }
+  }
+
+  for (const int fd : spawn_fds) {
+    if (fd >= 0) close(fd);
   }
 
   void * mempool_ptr =


### PR DESCRIPTION
## Description

`ret_unlink_daemon_exist` and its two siblings were only hints: the singleton was decided when the forked child itself called `AGNOCAST_ADD_PROCESS_CMD`, so every process that started before that forked a daemon of its own. N processes starting at once cost 3N forks, of which 3N-3 exited immediately.

Make the right to fork exclusive under the write lock `add_process` already holds, and hand it to the winner as an `anon_inode` fd. `fork()` passes it to the child, and the kernel's file refcount returns it through `->release` however the child dies, so a child that dies before registering strands nothing and no deadline is involved.

The right is settled the moment the daemon registers, not held for its lifetime: `agnocast_commit_exit_process()` deliberately deregisters the daemon *before* it dies so a process starting in that window spawns the replacement, and a lifetime-held right would block exactly that.

The three `ret_*_daemon_exist` bools become three `int32_t` spawn fds plus one `ret_role_already_taken` for a losing daemon's stand-down. A new `spawn_request_mask` lets the caller ask only for the daemons it can actually fork, since `AGNOCAST_BRIDGE_MODE`, `AGNOCAST_NO_DISCOVERY_AGENT` and the agent's path are invisible to the kernel module and a right handed to a process that turns out not to want it would leave the namespace with no daemon. Each daemon now registers as the first thing it does after `fork()`, which shrinks the window in which a child holds the right while still being invisible to the `sched_process_exit` probe to a single ioctl.

The discovery agent is folded in rather than left for a follow-up, since the ioctl argument size changes here and doing it later would mean a second minor version bump.

**Why an fd rather than a pid.** The alternative is to keep the right on the parent and move it to the child with a second ioctl after `fork()`. That needs no new `file_operations` and keeps process death on one mechanism, where this adds a second alongside the `sched_process_exit` probe. It was not taken because it has to name the child, so it depends on the pid being live, on `real_parent`, and on ordering against the exit probe -- and #1595 will perturb all three: after double-forking, the parent no longer knows the daemon's pid, the daemon is reparented, and reaping makes pids reusable again. Inheriting an fd through `fork()` does not care about any of that, and the second mechanism is where #1610 wants process death to go anyway, so this converges with it rather than away from it. The cost is fd hygiene: each child has to disown its siblings' rights, and the reservation is best-effort.

## Related links

Closes #1594. Follow-up to #1582. Part of #1612.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

**Accepted trade-off.** If the elected spawner's child dies before registering, `->release` returns the right, but the processes already told not to spawn do not ask again until one of them restarts, so the namespace runs without that daemon until the next process starts. On `main` every racing process forked a candidate, so this could not happen.

**Descriptor reservation is best-effort.** `get_unused_fd_flags()` failing withdraws that kind from the request rather than failing the call: no right is taken, so the next process is offered it, and a process near its descriptor limit is not stopped from starting for a right it does not need to run.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-minor-update`



