### PR TITLE
fix(agnocastlib): count same-process subscribers like rclcpp does

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -58,7 +58,7 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 | `get_notify_guard_condition()` | ✗ | **Throws Exception** | Yes | Not needed as agnocast uses epoll instead of condition variables, but planned for loading into Component Container |
 | `get_associated_with_executor_atomic()` | ✓ | **Full Support** | - | |
 | `resolve_topic_or_service_name()` | ✓ | **Full Support** | - | Used by NodeTopics and (future) NodeServices |
-| `get_use_intra_process_default()` | ⚠ | **API Only** | No | Returns value while logging a warning. agnocast uses its own shared memory IPC, so rclcpp's intra_process_communication is not used. |
+| `get_use_intra_process_default()` | ⚠ | **API Only** | No | Returns value passed from NodeOptions. agnocast uses its own shared memory IPC, so rclcpp's intra_process_communication is not used; the node constructor warns about that once when the option is set. |
 | `get_enable_topic_statistics_default()` | ⚠ | **API Only** | Yes | Returns value passed from NodeOptions. |
 
 ---
@@ -187,7 +187,7 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 | `get_node_names_with_enclaves()` | ✗ | **Throws Exception** | No | |
 | `get_node_names_and_namespaces()` | ✗ | **Throws Exception** | No | To support this, namespace must be managed within the kmod; however, they are currently not managed |
 | `count_publishers()` | ✓ | **Full Support** | - | Counts agnocast and ROS 2 publishers, excluding those created by bridges. `agnocast::Node::count_publishers()` delegates here |
-| `count_subscribers()` | ✓ | **Partial Support** | - | Counts agnocast and ROS 2 subscribers, excluding those created by bridges. Agnocast subscribers in the caller's own process are not counted. `agnocast::Node::count_subscribers()` delegates here |
+| `count_subscribers()` | ✓ | **Full Support** | - | Counts agnocast and ROS 2 subscribers, excluding those created by bridges. `agnocast::Node::count_subscribers()` delegates here |
 | `get_graph_guard_condition()` | ✗ | **Throws Exception** | No | |
 | `notify_graph_change()` | - | **No-op** | No | agnocast has no graph events, so there is nothing to notify. Made a no-op because rclcpp utilities call it unconditionally |
 | `notify_shutdown()` | - | **No-op** | No | Same as `notify_graph_change()` |

--- a/src/agnocast_e2e_test/src/test_publisher.cpp
+++ b/src/agnocast_e2e_test/src/test_publisher.cpp
@@ -31,8 +31,7 @@ class TestPublisher : public rclcpp::Node
 
   bool check_connection_counts()
   {
-    const auto total_sub_count =
-      publisher_->get_subscription_count() + publisher_->get_intra_subscription_count();
+    const auto total_sub_count = publisher_->get_subscription_count();
     if (
       total_sub_count < planned_sub_count_ ||
       this->count_publishers(topic_name_) < planned_pub_count_) {

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -286,6 +286,17 @@ if(BUILD_TESTING)
     LABELS "requires_kernel_module;requires_heaphook"
   )
 
+  # Publisher subscriber-count integration test (requires kernel module, no mock)
+  ament_add_gmock(test_integration_agnocast_publisher_counts_${PROJECT_NAME}
+    test/integration/test_agnocast_publisher_counts.cpp)
+  target_link_libraries(test_integration_agnocast_publisher_counts_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_agnocast_publisher_counts_${PROJECT_NAME} std_msgs)
+  set_tests_properties(test_integration_agnocast_publisher_counts_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
   # Parameter service integration test (requires kernel module, no mock).
   ament_add_gmock(test_integration_agnocast_parameter_service_${PROJECT_NAME}
     test/integration/test_agnocast_parameter_service.cpp)

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -121,7 +121,7 @@ public:
    * including Agnocast subscribers in the publisher's own process.
    *
    * A same-process subscriber that set `ignore_local_publications` is counted even though it never
-   * receives, matching what rclcpp reports for such a subscription.
+   * receives.
    * @return Total subscriber count.
    */
   AGNOCAST_PUBLIC

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -119,6 +119,9 @@ public:
   /**
    * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge),
    * including Agnocast subscribers in the publisher's own process.
+   *
+   * A same-process subscriber that set `ignore_local_publications` is counted even though it never
+   * receives, matching what rclcpp reports for such a subscription.
    * @return Total subscriber count.
    */
   AGNOCAST_PUBLIC

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -28,7 +28,7 @@ union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle, /* for CARET */ const std::string & topic_name,
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address);
 uint32_t get_subscription_count_core(const std::string & topic_name);
-uint32_t get_intra_subscription_count_core(const std::string & topic_name);
+uint32_t get_same_process_subscription_count_core(const std::string & topic_name);
 void increment_borrowed_publisher_num();
 void decrement_borrowed_publisher_num();
 
@@ -117,20 +117,42 @@ public:
   topic_local_id_t get_id() const { return id_; }
 
   /**
-   * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge).
+   * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge),
+   * including Agnocast subscribers in the publisher's own process.
    * @return Total subscriber count.
    */
   AGNOCAST_PUBLIC
   uint32_t get_subscription_count() const { return get_subscription_count_core(topic_name_); }
 
   /**
-   * @brief Return the number of Agnocast intra-process subscribers only (excludes ROS 2).
-   * @return Agnocast subscriber count.
+   * @brief Return the number of Agnocast subscribers in the publisher's own process.
+   *
+   * Unlike `rclcpp::Publisher::get_intra_process_subscription_count()`, this does not depend on
+   * `use_intra_process_comms` or on QoS compatibility: Agnocast has no equivalent of rclcpp's
+   * intra-process manager to exclude a subscriber from. The count can therefore be larger than
+   * what rclcpp reports for the same configuration.
+   *
+   * @return Intra-process subscriber count.
    */
   AGNOCAST_PUBLIC
-  uint32_t get_intra_subscription_count() const
+  uint32_t get_intra_process_subscription_count() const
   {
-    return get_intra_subscription_count_core(topic_name_);
+    return get_same_process_subscription_count_core(topic_name_);
+  }
+
+  /**
+   * @brief Return the number of Agnocast subscribers in the publisher's own process.
+   * @deprecated Renamed to get_intra_process_subscription_count(). Note that
+   * get_subscription_count() now includes these subscribers, so adding the two together
+   * double-counts them.
+   * @return Agnocast same-process subscriber count.
+   */
+  [[deprecated(
+    "Renamed to get_intra_process_subscription_count(). Note that get_subscription_count() now "
+    "includes these subscribers, so adding the two together double-counts them.")]]
+  AGNOCAST_PUBLIC uint32_t get_intra_subscription_count() const
+  {
+    return get_intra_process_subscription_count();
   }
 
   /**

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -109,7 +109,8 @@ uint32_t get_subscription_count_core(const std::string & topic_name)
   }
 
   uint32_t inter_count = args.ret_other_process_subscriber_num;
-  // If an A2R bridge exists, exclude the agnocast subscriber created by the bridge
+  // If an A2R bridge exists, exclude the agnocast subscriber created by the bridge. The bridge
+  // runs in a forked process, so it is never part of the same-process count.
   if (args.ret_a2r_bridge_exist && inter_count > 0) {
     inter_count--;
   }
@@ -120,10 +121,10 @@ uint32_t get_subscription_count_core(const std::string & topic_name)
     ros2_count--;
   }
 
-  return inter_count + ros2_count;
+  return inter_count + args.ret_same_process_subscriber_num + ros2_count;
 }
 
-uint32_t get_intra_subscription_count_core(const std::string & topic_name)
+uint32_t get_same_process_subscription_count_core(const std::string & topic_name)
 {
   union ioctl_get_subscriber_num_args get_subscriber_count_args = {};
   get_subscriber_count_args.topic_name = {topic_name.c_str(), topic_name.size()};

--- a/src/agnocastlib/src/node/node_interfaces/node_base.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_base.cpp
@@ -104,6 +104,16 @@ NodeBase::NodeBase(
   if (context_ && context_->is_valid()) {
     notify_guard_condition_.emplace(context_);
   }
+
+  // Warned here rather than in get_use_intra_process_default() so that the count is one line per
+  // node that opted in, however many times the getter is called.
+  if (use_intra_process_default_) {
+    RCLCPP_WARN(
+      rclcpp::get_logger(node_name_),
+      "use_intra_process_comms setting has no effect when using Agnocast. "
+      "Agnocast uses its own zero-copy intra/inter-process communication mechanism instead of "
+      "rclcpp's intra-process communication.");
+  }
 }
 
 const char * NodeBase::get_name() const
@@ -238,12 +248,8 @@ rclcpp::GuardCondition & NodeBase::get_notify_guard_condition()
 bool NodeBase::get_use_intra_process_default() const
 {
   // Note: rclcpp's intra-process communication is not used in Agnocast.
-  // This value is propagated from NodeOptions but has no effect currently.
-  RCLCPP_WARN(
-    rclcpp::get_logger(node_name_),
-    "use_intra_process_comms setting has no effect when using Agnocast. "
-    "Agnocast uses its own zero-copy intra/inter-process communication mechanism instead of "
-    "rclcpp's intra-process communication.");
+  // This value is propagated from NodeOptions but has no effect currently. The constructor warns
+  // about that once, so this getter is silent.
   return use_intra_process_default_;
 }
 

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -139,11 +139,6 @@ std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_n
 // Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
 // agnocast::Node::count_publishers()/count_subscribers() delegate here, so the resolution and the
 // bridge bookkeeping live in one place.
-//
-// Note that count_subscribers() does not see agnocast subscribers in the caller's own process:
-// get_subscription_count_core() reports ret_other_process_subscriber_num, because its original
-// caller (agnocast::Publisher::get_subscription_count()) asks how many peers receive a published
-// message. count_publishers() has no such split.
 size_t NodeGraph::count_publishers(const std::string & topic_name) const
 {
   return get_publisher_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));

--- a/src/agnocastlib/test/integration/test_agnocast_publisher_counts.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_publisher_counts.cpp
@@ -1,0 +1,88 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+using StringMsg = std_msgs::msg::String;
+
+// Subscriber counts as seen by a publisher. Agnocast delivers to every same-process subscriber
+// through shared memory, so such a subscriber is counted by both getters, and neither count
+// depends on `use_intra_process_comms`.
+class PublisherCountIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { agnocast::init(0, nullptr); }
+
+  void TearDown() override
+  {
+    if (agnocast::ok()) {
+      agnocast::shutdown();
+    }
+  }
+
+  static std::shared_ptr<agnocast::Node> make_node(
+    const std::string & name, bool use_intra_process = false)
+  {
+    rclcpp::NodeOptions options;
+    options.use_intra_process_comms(use_intra_process);
+    return std::make_shared<agnocast::Node>(name, options);
+  }
+};
+
+TEST_F(PublisherCountIntegrationTest, counts_are_zero_without_a_subscriber)
+{
+  auto node = make_node("test_pub_count_no_sub");
+  auto pub = node->create_publisher<StringMsg>("/test_pub_count_no_sub", 1);
+
+  EXPECT_EQ(pub->get_subscription_count(), 0u);
+  EXPECT_EQ(pub->get_intra_process_subscription_count(), 0u);
+}
+
+TEST_F(PublisherCountIntegrationTest, same_process_subscriber_is_counted)
+{
+  auto node = make_node("test_pub_count_same_process");
+  const std::string topic = "/test_pub_count_same_process";
+  auto pub = node->create_publisher<StringMsg>(topic, 1);
+  auto sub = node->create_subscription<StringMsg>(
+    topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+
+  EXPECT_EQ(pub->get_subscription_count(), 1u);
+  EXPECT_EQ(pub->get_intra_process_subscription_count(), 1u);
+}
+
+TEST_F(PublisherCountIntegrationTest, counts_do_not_depend_on_use_intra_process_comms)
+{
+  for (const bool use_intra_process : {false, true}) {
+    const std::string suffix = use_intra_process ? "_on" : "_off";
+    auto node = make_node("test_pub_count_option" + suffix, use_intra_process);
+    const std::string topic = "/test_pub_count_option" + suffix;
+    auto pub = node->create_publisher<StringMsg>(topic, 1);
+    auto sub = node->create_subscription<StringMsg>(
+      topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+
+    EXPECT_EQ(pub->get_subscription_count(), 1u) << "use_intra_process_comms=" << use_intra_process;
+    EXPECT_EQ(pub->get_intra_process_subscription_count(), 1u)
+      << "use_intra_process_comms=" << use_intra_process;
+  }
+}
+
+TEST_F(PublisherCountIntegrationTest, counts_drop_when_the_subscriber_is_destroyed)
+{
+  auto node = make_node("test_pub_count_sub_destroyed");
+  const std::string topic = "/test_pub_count_sub_destroyed";
+  auto pub = node->create_publisher<StringMsg>(topic, 1);
+  {
+    auto sub = node->create_subscription<StringMsg>(
+      topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+    ASSERT_EQ(pub->get_subscription_count(), 1u);
+    ASSERT_EQ(pub->get_intra_process_subscription_count(), 1u);
+  }
+
+  EXPECT_EQ(pub->get_subscription_count(), 0u);
+  EXPECT_EQ(pub->get_intra_process_subscription_count(), 0u);
+}

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -82,16 +82,13 @@ TEST_F(NodeGraphIntegrationTest, count_publishers_drops_when_the_publisher_is_de
   EXPECT_EQ(graph_->count_publishers(topic), 0u);
 }
 
-// count_subscribers() reports ret_other_process_subscriber_num, so a subscriber living in the
-// caller's own process is not counted. This is the documented limitation, not an accident: the
-// underlying helper exists to tell a publisher how many peers receive a published message.
-TEST_F(NodeGraphIntegrationTest, count_subscribers_does_not_see_same_process_subscriber)
+TEST_F(NodeGraphIntegrationTest, count_subscribers_counts_a_same_process_subscriber)
 {
   const std::string topic = "/test_node_graph_count_sub";
 
   auto sub = node_->create_subscription<StringMsg>(
     topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
-  EXPECT_EQ(graph_->count_subscribers(topic), 0u);
+  EXPECT_EQ(graph_->count_subscribers(topic), 1u);
 }
 
 TEST_F(NodeGraphIntegrationTest, count_publishers_resolves_a_relative_topic_name)

--- a/src/agnocastlib/test/unit/test_agnocast_generic_publisher.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_generic_publisher.cpp
@@ -44,6 +44,8 @@ public:
   LogCapture()
   {
     g_captured_log.clear();
+    const rcutils_ret_t ret = rcutils_logging_initialize();
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
     previous_ = rcutils_logging_get_output_handler();
     rcutils_logging_set_output_handler(log_capture_handler);
   }

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -40,6 +40,8 @@ public:
   {
     captured_log.clear();
     captured_warn_count = 0;
+    const rcutils_ret_t ret = rcutils_logging_initialize();
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
     previous_ = rcutils_logging_get_output_handler();
     rcutils_logging_set_output_handler(capture_log_handler);
   }

--- a/src/agnocastlib/test/unit/test_node_base.cpp
+++ b/src/agnocastlib/test/unit/test_node_base.cpp
@@ -4,6 +4,67 @@
 #include "rclcpp/version.h"
 
 #include <gtest/gtest.h>
+#include <rcutils/logging.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <utility>
+
+namespace
+{
+
+// An rcutils output handler is a plain function pointer, so what it counts into lives here.
+const std::string * g_capture_needle = nullptr;
+int * g_capture_count = nullptr;
+
+void count_matching_warnings(
+  const rcutils_log_location_t * /*location*/, int severity, const char * /*name*/,
+  rcutils_time_point_value_t /*timestamp*/, const char * format, va_list * args)
+{
+  if (severity != RCUTILS_LOG_SEVERITY_WARN) {
+    return;
+  }
+  char buf[1024];
+  va_list args_copy;
+  va_copy(args_copy, *args);
+  vsnprintf(buf, sizeof(buf), format, args_copy);
+  va_end(args_copy);
+  if (std::string(buf).find(*g_capture_needle) != std::string::npos) {
+    ++(*g_capture_count);
+  }
+}
+
+// Counts WARN records whose message contains `needle` while this object is alive. Matching the
+// message rather than the logger keeps the count from moving when an unrelated warning is added.
+class WarningCapture
+{
+public:
+  WarningCapture(std::string needle, int * count) : needle_(std::move(needle))
+  {
+    const rcutils_ret_t ret = rcutils_logging_initialize();
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    previous_ = rcutils_logging_get_output_handler();
+    g_capture_needle = &needle_;
+    g_capture_count = count;
+    rcutils_logging_set_output_handler(count_matching_warnings);
+  }
+
+  ~WarningCapture()
+  {
+    rcutils_logging_set_output_handler(previous_);
+    g_capture_needle = nullptr;
+    g_capture_count = nullptr;
+  }
+
+private:
+  std::string needle_;
+  rcutils_logging_output_handler_t previous_ = nullptr;
+};
+
+constexpr const char * kIntraProcessWarning = "use_intra_process_comms setting has no effect";
+
+}  // namespace
 
 class TestNodeBase : public ::testing::Test
 {
@@ -500,6 +561,9 @@ TEST_F(TestNodeBase, trigger_notify_guard_condition_throws_runtime_error)
 // Specification:
 //   - get_use_intra_process_default() and get_enable_topic_statistics_default()
 //     return the corresponding NodeOptions flags (false when unset).
+//   - The constructor warns once that use_intra_process_comms has no effect,
+//     and only when it was set. The getter is silent however many times it is
+//     called.
 // =============================================================================
 
 TEST_F(TestNodeBase, get_use_intra_process_default_is_false_when_unset)
@@ -542,6 +606,25 @@ TEST_F(TestNodeBase, get_use_intra_process_default_reflects_node_options_false)
 
   // Assert
   EXPECT_FALSE(value);
+}
+
+TEST_F(TestNodeBase, construction_warns_once_when_use_intra_process_comms_is_set)
+{
+  // Arrange
+  auto options = node_options_without_parameter_services();
+  options.use_intra_process_comms(true);
+
+  // Act
+  int warn_count = 0;
+  {
+    WarningCapture capture(kIntraProcessWarning, &warn_count);
+    auto node = std::make_shared<agnocast::Node>("my_node", "/my_ns", options);
+    node->get_node_base_interface()->get_use_intra_process_default();
+    node->get_node_base_interface()->get_use_intra_process_default();
+  }
+
+  // Assert
+  EXPECT_EQ(1, warn_count);
 }
 
 TEST_F(TestNodeBase, get_enable_topic_statistics_default_is_false_when_unset)

--- a/src/agnocastlib/test/unit/test_node_base.cpp
+++ b/src/agnocastlib/test/unit/test_node_base.cpp
@@ -627,6 +627,23 @@ TEST_F(TestNodeBase, construction_warns_once_when_use_intra_process_comms_is_set
   EXPECT_EQ(1, warn_count);
 }
 
+TEST_F(TestNodeBase, construction_does_not_warn_when_use_intra_process_comms_is_unset)
+{
+  // Arrange
+  auto options = node_options_without_parameter_services();
+
+  // Act
+  int warn_count = 0;
+  {
+    WarningCapture capture(kIntraProcessWarning, &warn_count);
+    auto node = std::make_shared<agnocast::Node>("my_node", "/my_ns", options);
+    node->get_node_base_interface()->get_use_intra_process_default();
+  }
+
+  // Assert
+  EXPECT_EQ(0, warn_count);
+}
+
 TEST_F(TestNodeBase, get_enable_topic_statistics_default_is_false_when_unset)
 {
   // Arrange


### PR DESCRIPTION
## Description

`Publisher::get_subscription_count()` reported `ret_other_process_subscriber_num`, so a publisher whose only subscriber lives in its own process reported 0, while `rclcpp::Publisher::get_subscription_count()` reports every matched subscription. It now includes the same-process count, and `NodeGraph::count_subscribers()`, which delegates here, stops missing them too.

`get_intra_process_subscription_count()` is added. It reports the same-process count unconditionally, because Agnocast delivers to every same-process subscriber through shared memory. It deliberately does not reproduce the number `rclcpp::Publisher::get_intra_process_subscription_count()` returns: rclcpp also excludes a subscriber whose own endpoint has intra-process disabled, and one whose QoS is incompatible, neither of which Agnocast tracks, so reading `use_intra_process_comms` here would buy no parity while making the count a function of `NodeOptions` rather than of the running system. Reporting the same-process count also keeps rclcpp's own comparison for "is an inter-process publish needed" working here.

`get_intra_subscription_count()` is deprecated, because its callers summed it with `get_subscription_count()` to get a total that now double-counts. It is a renamed alias of `get_intra_process_subscription_count()`.

`NodeBase::get_use_intra_process_default()` warned on every call without looking at the value, so the warning fired even for the `rclcpp::NodeOptions` default of `false`. The warning moves to the `NodeBase` constructor and fires only when the option was set, once per node; the getter is now silent.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

The existing log-capture helpers in `test_agnocast_utils.cpp` and `test_agnocast_generic_publisher.cpp` now call `rcutils_logging_initialize()` before taking the output handler, matching the new helper in `test_node_base.cpp`. Two lines each, unrelated to the counts.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Interface changes

`agnocast::PublisherBase` gains `get_intra_process_subscription_count()`. `get_intra_subscription_count()` is marked `[[deprecated]]` and delegates to it. The internal helper `get_intra_subscription_count_core()` is renamed to `get_same_process_subscription_count_core()`.

`agnocast::node_interfaces::NodeBase::get_use_intra_process_default()` no longer logs; the signature is unchanged.

## Effects on system behavior

`Publisher::get_subscription_count()` and `NodeGraph::count_subscribers()` now include Agnocast subscribers in the caller's own process. Code that summed `get_subscription_count()` and `get_intra_subscription_count()` to get a total double-counts them; `agnocast_e2e_test`'s publisher is updated accordingly.

A same-process subscriber that set `ignore_local_publications` is counted even though the kernel module never delivers to it. Whether rclcpp counts such a subscription depends on the RMW: rmw_cyclonedds sets the option as a DDS QoS so the endpoints never match and it drops out, while rmw_fastrtps applies it when taking a message and keeps it. Only the exception is documented here.

A node created with `use_intra_process_comms` set now logs one warning at construction, where previously nothing was logged unless something called `get_use_intra_process_default()`. A node that leaves the option at its default logs nothing.

