### PR TITLE
fix(agnocastlib): read global arguments from the node's rclcpp context

### DIFF
--- a/src/agnocastlib/include/agnocast/node/agnocast_arguments.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_arguments.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <rclcpp/context.hpp>
 #include <rclcpp/parameter.hpp>
 #include <rclcpp/parameter_value.hpp>
 
@@ -38,6 +39,14 @@ private:
 };
 
 ParsedArguments parse_arguments(const std::vector<std::string> & arguments);
+
+// Resolve the global arguments a node must honour, for NodeOptions::use_global_arguments().
+// agnocast::init() parses them when it is called; a process whose main() belongs to someone else,
+// such as a component container, parses the command line into its rclcpp context instead, and that
+// is where they are then. Reading both makes the option mean the same thing for agnocast::Node as
+// it does for rclcpp::Node. Returns nullptr when neither source has any. The result points into
+// whichever source it came from, so the caller must keep `context` alive while it uses it.
+const rcl_arguments_t * resolve_global_arguments(const rclcpp::Context::SharedPtr & context);
 
 // Resolve parameter overrides from multiple sources.
 // Corresponds to rclcpp::detail::resolve_parameter_overrides.

--- a/src/agnocastlib/src/node/agnocast_arguments.cpp
+++ b/src/agnocastlib/src/node/agnocast_arguments.cpp
@@ -1,5 +1,7 @@
 #include "agnocast/node/agnocast_arguments.hpp"
 
+#include "agnocast/node/agnocast_context.hpp"
+
 #include <rclcpp/parameter_map.hpp>
 
 #include <rcl_yaml_param_parser/parser.h>
@@ -101,6 +103,24 @@ ParsedArguments parse_arguments(const std::vector<std::string> & arguments)
   ParsedArguments result;
   result.parse(arguments);
   return result;
+}
+
+const rcl_arguments_t * resolve_global_arguments(const rclcpp::Context::SharedPtr & context)
+{
+  {
+    std::lock_guard<std::mutex> lock(g_context_mtx);
+    if (g_context.is_initialized()) {
+      const rcl_arguments_t * agnocast_args = g_context.get_parsed_arguments();
+      if (agnocast_args != nullptr) {
+        return agnocast_args;
+      }
+    }
+  }
+
+  if (context && context->is_valid()) {
+    return &context->get_rcl_context()->global_arguments;
+  }
+  return nullptr;
 }
 
 std::map<std::string, rclcpp::ParameterValue> resolve_parameter_overrides(

--- a/src/agnocastlib/src/node/node_interfaces/node_base.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_base.cpp
@@ -1,6 +1,5 @@
 #include "agnocast/node/node_interfaces/node_base.hpp"
 
-#include "agnocast/node/agnocast_context.hpp"
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/logging.hpp"
 
@@ -35,12 +34,8 @@ NodeBase::NodeBase(
     namespace_ = ns;
   }
 
-  // Get global arguments from context
   if (use_global_arguments) {
-    std::lock_guard<std::mutex> lock(g_context_mtx);
-    if (g_context.is_initialized()) {
-      global_args_ = g_context.get_parsed_arguments();
-    }
+    global_args_ = resolve_global_arguments(context_);
   }
 
   rcl_allocator_t allocator = rcl_get_default_allocator();

--- a/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
@@ -1,7 +1,6 @@
 #include "agnocast/node/node_interfaces/node_parameters.hpp"
 
 #include "agnocast/node/agnocast_arguments.hpp"
-#include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/agnocast_parameter_service.hpp"
 #include "rclcpp/exceptions/exceptions.hpp"
 
@@ -351,13 +350,8 @@ NodeParameters::NodeParameters(
   bool automatically_declare_parameters_from_overrides)
 : node_base_(std::move(node_base)), allow_undeclared_(allow_undeclared_parameters)
 {
-  const rcl_arguments_t * global_args = nullptr;
-  if (use_global_arguments) {
-    std::lock_guard<std::mutex> lock(g_context_mtx);
-    if (g_context.is_initialized()) {
-      global_args = g_context.get_parsed_arguments();
-    }
-  }
+  const rcl_arguments_t * global_args =
+    use_global_arguments ? resolve_global_arguments(node_base_->get_context()) : nullptr;
 
   std::string combined_name = node_base_->get_fully_qualified_name();
   parameter_overrides_ =

--- a/src/agnocastlib/test/integration/test_agnocast_node.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_node.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 #include "rclcpp/callback_group.hpp"
+#include "rclcpp/context.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/parameter.hpp"
 
@@ -90,6 +91,26 @@ TEST_F(AgnocastNodeConstructionTest, use_global_arguments_true_inherits_global_u
   auto node = std::make_shared<agnocast::Node>("test_node_global_args_on", options);
 
   EXPECT_TRUE(node->get_parameter("use_sim_time").as_bool());
+}
+
+// A node loaded into a component container resolves its parameter overrides from the container's
+// rclcpp context, since that is what parsed the command line. use_clock_thread is off because the
+// clock thread is beside the point here.
+TEST_F(AgnocastNodeConstructionTest, use_global_arguments_true_inherits_use_sim_time_from_context)
+{
+  const char * argv[] = {"test_agnocast_node", "--ros-args", "-p", "use_sim_time:=true"};
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(static_cast<int>(sizeof(argv) / sizeof(argv[0])), argv);
+  {
+    rclcpp::NodeOptions options;
+    options.context(context);
+    options.use_global_arguments(true);
+    options.use_clock_thread(false);
+    auto node = std::make_shared<agnocast::Node>("test_node_ctx_global_args_on", options);
+
+    EXPECT_TRUE(node->get_parameter("use_sim_time").as_bool());
+  }
+  context->shutdown("test cleanup");
 }
 
 TEST_F(AgnocastNodeConstructionTest, use_global_arguments_false_ignores_global_use_sim_time)

--- a/src/agnocastlib/test/unit/test_node_base.cpp
+++ b/src/agnocastlib/test/unit/test_node_base.cpp
@@ -803,10 +803,10 @@ TEST_F(TestNodeBase, on_callback_group_created_fires_after_group_is_registered)
 //   - get_local_args() returns the rcl_arguments_t parsed from
 //     NodeOptions::arguments() (non-null even with no arguments).
 //   - get_global_args() returns nullptr when NodeOptions::use_global_arguments
-//     is false, or when it is true but agnocast::init() has not been called.
-//     Only when use_global_arguments is true AND agnocast::init() has been
-//     called does it return a non-null pointer reflecting the global agnocast
-//     context.
+//     is false, and when it is true but neither agnocast::init() nor the node's
+//     rclcpp context holds a command line. With use_global_arguments true it
+//     reflects agnocast::init()'s arguments when there are any, and the node's
+//     rclcpp context's otherwise.
 // =============================================================================
 
 TEST_F(TestNodeBase, get_local_args_is_non_null_for_default_options)
@@ -856,4 +856,67 @@ TEST_F(TestNodeBase, get_global_args_is_non_null_when_g_context_is_initialized)
     EXPECT_NE(nullptr, global_args);
   }
   agnocast::shutdown();
+}
+
+TEST_F(TestNodeBase, global_args_come_from_the_node_rclcpp_context_without_agnocast_init)
+{
+  // Arrange: a component container parses the command line into its rclcpp context instead of
+  // through agnocast::init(). Use a context of this test's own to leave the global default alone.
+  const char * argv[] = {"test_node_base", "--ros-args", "-r", "__ns:=/from_rclcpp"};
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(static_cast<int>(sizeof(argv) / sizeof(argv[0])), argv);
+  {
+    auto options = node_options_without_parameter_services();
+    options.context(context);
+
+    // Act
+    auto node = std::make_shared<agnocast::Node>("my_node", options);
+
+    // Assert
+    EXPECT_EQ("/from_rclcpp", node->get_namespace());
+  }
+  context->shutdown("test cleanup");
+}
+
+TEST_F(TestNodeBase, global_args_from_the_node_rclcpp_context_need_use_global_arguments)
+{
+  // Arrange
+  const char * argv[] = {"test_node_base", "--ros-args", "-r", "__ns:=/from_rclcpp"};
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(static_cast<int>(sizeof(argv) / sizeof(argv[0])), argv);
+  {
+    auto options = node_options_without_parameter_services();
+    options.context(context);
+    options.use_global_arguments(false);
+
+    // Act
+    auto node = std::make_shared<agnocast::Node>("my_node", options);
+
+    // Assert
+    EXPECT_EQ("/", node->get_namespace());
+  }
+  context->shutdown("test cleanup");
+}
+
+TEST_F(TestNodeBase, agnocast_init_arguments_win_over_the_node_rclcpp_context)
+{
+  // Arrange: both sources carry a namespace remap. The explicit init() is the stronger statement.
+  const char * context_argv[] = {"test_node_base", "--ros-args", "-r", "__ns:=/from_rclcpp"};
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(static_cast<int>(sizeof(context_argv) / sizeof(context_argv[0])), context_argv);
+
+  const char * agnocast_argv[] = {"test_node_base", "--ros-args", "-r", "__ns:=/from_agnocast"};
+  agnocast::init(static_cast<int>(sizeof(agnocast_argv) / sizeof(agnocast_argv[0])), agnocast_argv);
+  {
+    auto options = node_options_without_parameter_services();
+    options.context(context);
+
+    // Act
+    auto node = std::make_shared<agnocast::Node>("my_node", options);
+
+    // Assert
+    EXPECT_EQ("/from_agnocast", node->get_namespace());
+  }
+  agnocast::shutdown();
+  context->shutdown("test cleanup");
 }


### PR DESCRIPTION
## Description

`NodeOptions::use_global_arguments()` was honoured only for a command line that `agnocast::init()` had parsed. In a process whose `main()` belongs to someone else — a component container — nobody calls `agnocast::init()`, so the option did nothing.

rclcpp parses the command line into the `rclcpp::Context`, which is where a component finds it. Whether a loaded component reads it at all is what a LoadNode request's `forward_global_arguments` switches on, and measured against `agnocast_component_container` started with `--ros-args -r __ns:=/globalns`:

| Loaded with | rclcpp component | `agnocast::Node` component |
|---|---|---|
| no extra arguments | `/cie_subscriber` | `/no_rclcpp_subscriber` |
| `-e forward_global_arguments:=true` | `/globalns/cie_subscriber` | `/no_rclcpp_subscriber` |

So the option worked for one node type and was silently ignored for the other.

`resolve_global_arguments()` now reads the node's `rclcpp::Context` when Agnocast has no command line of its own, which makes the option mean the same thing for both. It covers the two places that need global arguments — node name and namespace remapping in `NodeBase`, parameter overrides in `NodeParameters` — instead of each deriving them separately. An explicit `agnocast::init()` still wins, since it is the stronger statement.

The result points into whichever source it came from. `NodeBase` keeps a strong reference to the context, which is the same guarantee rcl relies on for `rcl_context_t::global_arguments`.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

`e2e_test_1to1.bash` / `e2e_test_2to2.bash` are still outstanding and need to be run before this leaves draft. The kernel module is untouched, so kunit does not apply.

`colcon test --packages-select agnocastlib` passes **669/669** with the kernel module and heaphook loaded.

The table above is the sample-application check, repeated after the change: the `agnocast::Node` component now loads as `/globalns/no_rclcpp_subscriber`, matching the rclcpp one.

Four cases added:

- `global_args_come_from_the_node_rclcpp_context_without_agnocast_init` pins the remapping path. Checked against a build with the fallback disabled: it is the only one that fails there.
- `global_args_from_the_node_rclcpp_context_need_use_global_arguments` and `agnocast_init_arguments_win_over_the_node_rclcpp_context` guard the two ways the new source must not apply. Both hold with the fallback disabled as well — they pin the boundaries, not the fallback itself.
- `use_global_arguments_true_inherits_use_sim_time_from_context` covers the parameter-override path, which is the one the `use_sim_time` case runs through.

Compiled against Jazzy in a `ros:jazzy-ros-base` container. That container has no kernel module, so nothing was run there.

## Notes for reviewers

- **The two call sites were resolving global arguments independently.** `NodeBase` read them for remapping and `NodeParameters` for parameter overrides, each with its own `g_context` lookup. Only fixing one would have left `forward_global_arguments` half-working — remaps applying but parameter overrides not, or the reverse.
- **Precedence is `agnocast::init()` first, then the context.** A process that passed a command line to Agnocast explicitly said what it wants; the context is the fallback for a process that never got the chance.
- **#1517 documents the previous behaviour.** Its `docs/agnocast_node_interface_comparison.md` §5.1 has a "Global arguments do not apply" bullet for lazily initialized nodes. Whichever of the two merges second should drop it.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
