### PR TITLE
fix(agnocast_kmod): skip response topics and raise the topic list limit

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -363,7 +363,7 @@ struct ioctl_add_domain_bridge_prefix_args
 // ================================================
 // ros2cli ioctls
 
-#define MAX_TOPIC_NUM 1024
+#define MAX_TOPIC_NUM 2048
 
 union ioctl_topic_list_args {
   struct
@@ -476,7 +476,8 @@ int agnocast_ioctl_get_publisher_num(
   union ioctl_get_publisher_num_args * ioctl_ret);
 
 int agnocast_ioctl_get_topic_list(
-  const struct ipc_namespace * ipc_ns, union ioctl_topic_list_args * topic_list_args);
+  const struct ipc_namespace * ipc_ns, char * topic_name_buf, uint32_t * domain_id_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num);
 
 int agnocast_ioctl_get_node_names(
   const struct ipc_namespace * ipc_ns, const pid_t pid, char * buf, const uint32_t buf_node_num,

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -523,12 +523,12 @@ int agnocast_ioctl_get_topic_publisher_info(
   union ioctl_topic_info_args * topic_info_args);
 
 int agnocast_ioctl_get_node_subscriber_topics(
-  const struct ipc_namespace * ipc_ns, const char * node_name,
-  union ioctl_node_info_args * node_info_args);
+  const struct ipc_namespace * ipc_ns, const char * node_name, char * topic_name_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num);
 
 int agnocast_ioctl_get_node_publisher_topics(
-  const struct ipc_namespace * ipc_ns, const char * node_name,
-  union ioctl_node_info_args * node_info_args);
+  const struct ipc_namespace * ipc_ns, const char * node_name, char * topic_name_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num);
 
 int agnocast_ioctl_check_and_request_bridge_shutdown(
   const pid_t pid, const struct ipc_namespace * ipc_ns,

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1708,13 +1708,10 @@ int agnocast_ioctl_get_topic_list(
       goto unlock;
     }
 
-    memcpy(
+    strscpy_pad(
       topic_name_buf + (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE, wrapper->key,
-      strlen(wrapper->key) + 1);
-
-    if (domain_id_buf) {
-      domain_id_buf[topic_num] = wrapper->domain_id;
-    }
+      TOPIC_NAME_BUFFER_SIZE);
+    domain_id_buf[topic_num] = wrapper->domain_id;
 
     topic_num++;
   }
@@ -3280,17 +3277,14 @@ static long get_topic_list_cmd(union ioctl_topic_list_args __user * arg)
   uint32_t __user * user_domain_id_buf =
     (uint32_t __user *)u64_to_user_ptr(topic_list_args.domain_id_buffer_addr);
 
-  char * topic_name_buf = kvzalloc((size_t)buf_topic_num * TOPIC_NAME_BUFFER_SIZE, GFP_KERNEL);
+  // One allocation for both arrays: a name slot is TOPIC_NAME_BUFFER_SIZE bytes, so the domain ids
+  // that follow the names stay uint32_t-aligned. agnocast_ioctl_get_topic_list writes every byte
+  // that is copied out, so the scratch needs no zeroing.
+  const size_t names_bytes = (size_t)buf_topic_num * TOPIC_NAME_BUFFER_SIZE;
+  char * topic_name_buf =
+    kvmalloc(names_bytes + (size_t)buf_topic_num * sizeof(uint32_t), GFP_KERNEL);
   if (!topic_name_buf) return -ENOMEM;
-
-  uint32_t * domain_id_buf = NULL;
-  if (user_domain_id_buf) {
-    domain_id_buf = kvcalloc(buf_topic_num, sizeof(*domain_id_buf), GFP_KERNEL);
-    if (!domain_id_buf) {
-      kvfree(topic_name_buf);
-      return -ENOMEM;
-    }
-  }
+  uint32_t * domain_id_buf = (uint32_t *)(topic_name_buf + names_bytes);
 
   uint32_t topic_num = 0;
   long ret =
@@ -3311,7 +3305,7 @@ static long get_topic_list_cmd(union ioctl_topic_list_args __user * arg)
   }
 
   if (
-    domain_id_buf &&
+    user_domain_id_buf &&
     copy_to_user(user_domain_id_buf, domain_id_buf, (size_t)topic_num * sizeof(*domain_id_buf))) {
     ret = -EFAULT;
     goto free;
@@ -3321,7 +3315,6 @@ static long get_topic_list_cmd(union ioctl_topic_list_args __user * arg)
   if (copy_to_user(arg, &topic_list_args, sizeof(topic_list_args))) ret = -EFAULT;
 
 free:
-  kvfree(domain_id_buf);
   kvfree(topic_name_buf);
   return ret;
 }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -205,7 +205,7 @@ static bool is_parameter_service_topic(const char * key)
 // the request topic's endpoints.
 static bool is_service_response_topic(const char * key)
 {
-  return strncmp(key, "/AGNOCAST_SRV_RESPONSE", sizeof("/AGNOCAST_SRV_RESPONSE") - 1) == 0;
+  return str_has_prefix(key, "/AGNOCAST_SRV_RESPONSE");
 }
 
 static struct subscriber_info * find_subscriber_info(

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1858,8 +1858,8 @@ unlock:
 }
 
 int agnocast_ioctl_get_node_subscriber_topics(
-  const struct ipc_namespace * ipc_ns, const char * node_name,
-  union ioctl_node_info_args * node_info_args)
+  const struct ipc_namespace * ipc_ns, const char * node_name, char * topic_name_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num)
 {
   int ret = 0;
   uint32_t topic_num = 0;
@@ -1891,28 +1891,20 @@ int agnocast_ioctl_get_node_subscriber_topics(
     up_read(&wrapper->topic->rwsem);
 
     if (found) {
-      if (topic_num >= MAX_TOPIC_NUM || topic_num >= node_info_args->topic_name_buffer_size) {
-        dev_warn(
-          agnocast_device,
-          "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n", MAX_TOPIC_NUM,
-          node_info_args->topic_name_buffer_size);
+      if (topic_num >= buf_topic_num) {
         ret = -ENOBUFS;
         goto unlock;
       }
 
-      if (copy_to_user(
-            (char __user *)(node_info_args->topic_name_buffer_addr +
-                            topic_num * TOPIC_NAME_BUFFER_SIZE),
-            wrapper->key, strlen(wrapper->key) + 1)) {
-        ret = -EFAULT;
-        goto unlock;
-      }
+      strscpy_pad(
+        topic_name_buf + (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE, wrapper->key,
+        TOPIC_NAME_BUFFER_SIZE);
 
       topic_num++;
     }
   }
 
-  node_info_args->ret_topic_num = topic_num;
+  *ret_topic_num = topic_num;
 
 unlock:
   up_read(&global_htables_rwsem);
@@ -1920,8 +1912,8 @@ unlock:
 }
 
 int agnocast_ioctl_get_node_publisher_topics(
-  const struct ipc_namespace * ipc_ns, const char * node_name,
-  union ioctl_node_info_args * node_info_args)
+  const struct ipc_namespace * ipc_ns, const char * node_name, char * topic_name_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num)
 {
   int ret = 0;
   uint32_t topic_num = 0;
@@ -1953,28 +1945,20 @@ int agnocast_ioctl_get_node_publisher_topics(
     up_read(&wrapper->topic->rwsem);
 
     if (found) {
-      if (topic_num >= MAX_TOPIC_NUM || topic_num >= node_info_args->topic_name_buffer_size) {
-        dev_warn(
-          agnocast_device,
-          "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n", MAX_TOPIC_NUM,
-          node_info_args->topic_name_buffer_size);
+      if (topic_num >= buf_topic_num) {
         ret = -ENOBUFS;
         goto unlock;
       }
 
-      if (copy_to_user(
-            (char __user *)(node_info_args->topic_name_buffer_addr +
-                            topic_num * TOPIC_NAME_BUFFER_SIZE),
-            wrapper->key, strlen(wrapper->key) + 1)) {
-        ret = -EFAULT;
-        goto unlock;
-      }
+      strscpy_pad(
+        topic_name_buf + (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE, wrapper->key,
+        TOPIC_NAME_BUFFER_SIZE);
 
       topic_num++;
     }
   }
 
-  node_info_args->ret_topic_num = topic_num;
+  *ret_topic_num = topic_num;
 
 unlock:
   up_read(&global_htables_rwsem);
@@ -3355,39 +3339,91 @@ static long get_node_names_cmd(union ioctl_get_node_names_args __user * arg)
 
 static long get_node_subscriber_topics_cmd(union ioctl_node_info_args __user * arg)
 {
-  int ret = 0;
   const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
-  union ioctl_node_info_args node_info_sub_args;
-  if (copy_from_user(&node_info_sub_args, arg, sizeof(node_info_sub_args))) return -EFAULT;
+  union ioctl_node_info_args node_info_args;
+  if (copy_from_user(&node_info_args, arg, sizeof(node_info_args))) return -EFAULT;
 
   char node_name_buf[NODE_NAME_BUFFER_SIZE];
-  ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_sub_args.node_name);
-  if (ret) return ret;
+  int name_ret =
+    copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_args.node_name);
+  if (name_ret) return name_ret;
 
-  ret = agnocast_ioctl_get_node_subscriber_topics(ipc_ns, node_name_buf, &node_info_sub_args);
-  if (ret == 0) {
-    if (copy_to_user(arg, &node_info_sub_args, sizeof(node_info_sub_args))) return -EFAULT;
+  // ret_topic_num shares the union with topic_name_buffer_size, so read the size out first.
+  const uint32_t buf_topic_num =
+    min_t(uint32_t, node_info_args.topic_name_buffer_size, MAX_TOPIC_NUM);
+  char __user * user_buf = (char __user *)u64_to_user_ptr(node_info_args.topic_name_buffer_addr);
+
+  char * buf = kvmalloc((size_t)buf_topic_num * TOPIC_NAME_BUFFER_SIZE, GFP_KERNEL);
+  if (!buf) return -ENOMEM;
+
+  uint32_t topic_num = 0;
+  long ret = agnocast_ioctl_get_node_subscriber_topics(
+    ipc_ns, node_name_buf, buf, buf_topic_num, &topic_num);
+  if (ret != 0) {
+    if (ret == -ENOBUFS) {
+      dev_warn(
+        agnocast_device, "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n",
+        MAX_TOPIC_NUM, node_info_args.topic_name_buffer_size);
+    }
+    goto free;
   }
+
+  if (copy_to_user(user_buf, buf, (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE)) {
+    ret = -EFAULT;
+    goto free;
+  }
+
+  node_info_args.ret_topic_num = topic_num;
+  if (copy_to_user(arg, &node_info_args, sizeof(node_info_args))) ret = -EFAULT;
+
+free:
+  kvfree(buf);
   return ret;
 }
 
 static long get_node_publisher_topics_cmd(union ioctl_node_info_args __user * arg)
 {
-  int ret = 0;
   const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
-  union ioctl_node_info_args node_info_pub_args;
-  if (copy_from_user(&node_info_pub_args, arg, sizeof(node_info_pub_args))) return -EFAULT;
+  union ioctl_node_info_args node_info_args;
+  if (copy_from_user(&node_info_args, arg, sizeof(node_info_args))) return -EFAULT;
 
   char node_name_buf[NODE_NAME_BUFFER_SIZE];
-  ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_pub_args.node_name);
-  if (ret) return ret;
+  int name_ret =
+    copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_args.node_name);
+  if (name_ret) return name_ret;
 
-  ret = agnocast_ioctl_get_node_publisher_topics(ipc_ns, node_name_buf, &node_info_pub_args);
-  if (ret == 0) {
-    if (copy_to_user(arg, &node_info_pub_args, sizeof(node_info_pub_args))) return -EFAULT;
+  // ret_topic_num shares the union with topic_name_buffer_size, so read the size out first.
+  const uint32_t buf_topic_num =
+    min_t(uint32_t, node_info_args.topic_name_buffer_size, MAX_TOPIC_NUM);
+  char __user * user_buf = (char __user *)u64_to_user_ptr(node_info_args.topic_name_buffer_addr);
+
+  char * buf = kvmalloc((size_t)buf_topic_num * TOPIC_NAME_BUFFER_SIZE, GFP_KERNEL);
+  if (!buf) return -ENOMEM;
+
+  uint32_t topic_num = 0;
+  long ret =
+    agnocast_ioctl_get_node_publisher_topics(ipc_ns, node_name_buf, buf, buf_topic_num, &topic_num);
+  if (ret != 0) {
+    if (ret == -ENOBUFS) {
+      dev_warn(
+        agnocast_device, "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n",
+        MAX_TOPIC_NUM, node_info_args.topic_name_buffer_size);
+    }
+    goto free;
   }
+
+  if (copy_to_user(user_buf, buf, (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE)) {
+    ret = -EFAULT;
+    goto free;
+  }
+
+  node_info_args.ret_topic_num = topic_num;
+  if (copy_to_user(arg, &node_info_args, sizeof(node_info_args))) ret = -EFAULT;
+
+free:
+  kvfree(buf);
   return ret;
 }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -200,6 +200,14 @@ static bool is_parameter_service_topic(const char * key)
          strstr(key, "/list_parameters");
 }
 
+// A response topic exists per (service, client), and every consumer of the topic list keys a
+// service off its request topic instead: the discovery agent reads the roles it bridges on from
+// the request topic's endpoints.
+static bool is_service_response_topic(const char * key)
+{
+  return strncmp(key, "/AGNOCAST_SRV_RESPONSE", sizeof("/AGNOCAST_SRV_RESPONSE") - 1) == 0;
+}
+
 static struct subscriber_info * find_subscriber_info(
   const struct topic_wrapper * wrapper, const topic_local_id_t subscriber_id)
 {
@@ -1675,7 +1683,8 @@ void agnocast_commit_exit_process(
 // `ros2 topic list_agnocast`). Revisit by adding a domain input if a strictly
 // per-domain enumeration is ever needed.
 int agnocast_ioctl_get_topic_list(
-  const struct ipc_namespace * ipc_ns, union ioctl_topic_list_args * topic_list_args)
+  const struct ipc_namespace * ipc_ns, char * topic_name_buf, uint32_t * domain_id_buf,
+  const uint32_t buf_topic_num, uint32_t * ret_topic_num)
 {
   int ret = 0;
   uint32_t topic_num = 0;
@@ -1690,36 +1699,27 @@ int agnocast_ioctl_get_topic_list(
       continue;
     }
 
-    if (topic_num >= MAX_TOPIC_NUM || topic_num >= topic_list_args->topic_name_buffer_size) {
-      dev_warn(
-        agnocast_device, "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n",
-        MAX_TOPIC_NUM, topic_list_args->topic_name_buffer_size);
+    if (is_service_response_topic(wrapper->key)) {
+      continue;
+    }
+
+    if (topic_num >= buf_topic_num) {
       ret = -ENOBUFS;
       goto unlock;
     }
 
-    if (copy_to_user(
-          (char __user *)(topic_list_args->topic_name_buffer_addr +
-                          topic_num * TOPIC_NAME_BUFFER_SIZE),
-          wrapper->key, strlen(wrapper->key) + 1)) {
-      ret = -EFAULT;
-      goto unlock;
-    }
+    memcpy(
+      topic_name_buf + (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE, wrapper->key,
+      strlen(wrapper->key) + 1);
 
-    if (topic_list_args->domain_id_buffer_addr) {
-      uint32_t domain_id = wrapper->domain_id;
-      uint32_t __user * domain_id_buffer =
-        (uint32_t __user *)u64_to_user_ptr(topic_list_args->domain_id_buffer_addr);
-      if (copy_to_user(domain_id_buffer + topic_num, &domain_id, sizeof(domain_id))) {
-        ret = -EFAULT;
-        goto unlock;
-      }
+    if (domain_id_buf) {
+      domain_id_buf[topic_num] = wrapper->domain_id;
     }
 
     topic_num++;
   }
 
-  topic_list_args->ret_topic_num = topic_num;
+  *ret_topic_num = topic_num;
 
 unlock:
   up_read(&global_htables_rwsem);
@@ -3268,15 +3268,61 @@ static long get_exit_process_cmd(struct ioctl_get_exit_process_args __user * arg
 
 static long get_topic_list_cmd(union ioctl_topic_list_args __user * arg)
 {
-  int ret = 0;
   const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
   union ioctl_topic_list_args topic_list_args;
   if (copy_from_user(&topic_list_args, arg, sizeof(topic_list_args))) return -EFAULT;
-  ret = agnocast_ioctl_get_topic_list(ipc_ns, &topic_list_args);
-  if (ret == 0) {
-    if (copy_to_user(arg, &topic_list_args, sizeof(topic_list_args))) return -EFAULT;
+
+  const uint32_t buf_topic_num =
+    min_t(uint32_t, topic_list_args.topic_name_buffer_size, MAX_TOPIC_NUM);
+  char __user * user_topic_name_buf =
+    (char __user *)u64_to_user_ptr(topic_list_args.topic_name_buffer_addr);
+  uint32_t __user * user_domain_id_buf =
+    (uint32_t __user *)u64_to_user_ptr(topic_list_args.domain_id_buffer_addr);
+
+  char * topic_name_buf = kvzalloc((size_t)buf_topic_num * TOPIC_NAME_BUFFER_SIZE, GFP_KERNEL);
+  if (!topic_name_buf) return -ENOMEM;
+
+  uint32_t * domain_id_buf = NULL;
+  if (user_domain_id_buf) {
+    domain_id_buf = kvcalloc(buf_topic_num, sizeof(*domain_id_buf), GFP_KERNEL);
+    if (!domain_id_buf) {
+      kvfree(topic_name_buf);
+      return -ENOMEM;
+    }
   }
+
+  uint32_t topic_num = 0;
+  long ret =
+    agnocast_ioctl_get_topic_list(ipc_ns, topic_name_buf, domain_id_buf, buf_topic_num, &topic_num);
+  if (ret != 0) {
+    if (ret == -ENOBUFS) {
+      dev_warn(
+        agnocast_device, "Topic count exceeds limit: MAX_TOPIC_NUM=%d, topic_name_buffer_size=%u\n",
+        MAX_TOPIC_NUM, topic_list_args.topic_name_buffer_size);
+    }
+    goto free;
+  }
+
+  if (copy_to_user(
+        user_topic_name_buf, topic_name_buf, (size_t)topic_num * TOPIC_NAME_BUFFER_SIZE)) {
+    ret = -EFAULT;
+    goto free;
+  }
+
+  if (
+    domain_id_buf &&
+    copy_to_user(user_domain_id_buf, domain_id_buf, (size_t)topic_num * sizeof(*domain_id_buf))) {
+    ret = -EFAULT;
+    goto free;
+  }
+
+  topic_list_args.ret_topic_num = topic_num;
+  if (copy_to_user(arg, &topic_list_args, sizeof(topic_list_args))) ret = -EFAULT;
+
+free:
+  kvfree(domain_id_buf);
+  kvfree(topic_name_buf);
   return ret;
 }
 

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -27,6 +27,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_get_version.o \
   agnocast_kunit_bridge_shutdown.o \
   agnocast_kunit_check_and_request_bridge_shutdown.o \
+  agnocast_kunit_get_topic_list.o \
   agnocast_kunit_get_topic_subscriber_info.o \
   agnocast_kunit_get_topic_publisher_info.o \
   agnocast_kunit_init_memory_allocator.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -23,7 +23,8 @@ static void setup_process(struct kunit * test, const pid_t pid)
 void test_case_get_node_pub_topics_exact_match(struct kunit * test)
 {
   union ioctl_add_publisher_args add_pub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -33,18 +34,18 @@ void test_case_get_node_pub_topics_exact_match(struct kunit * test)
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  // copy_to_user inside ioctl_get_node_publisher_topics returns -EFAULT in KUnit (kernel thread)
-  // context, but reaching it confirms that the node name match was found.
-  node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
-  ret =
-    agnocast_ioctl_get_node_publisher_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
-  KUNIT_EXPECT_TRUE(test, ret == -EFAULT || (ret == 0 && node_info_args.ret_topic_num == 1));
+  ret = agnocast_ioctl_get_node_publisher_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, ARRAY_SIZE(buf), &topic_num);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, topic_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf[0], TOPIC_NAME);
 }
 
 void test_case_get_node_pub_topics_prefix_no_match(struct kunit * test)
 {
   union ioctl_add_publisher_args add_pub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -54,19 +55,18 @@ void test_case_get_node_pub_topics_prefix_no_match(struct kunit * test)
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
-  ret =
-    agnocast_ioctl_get_node_publisher_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
+  ret = agnocast_ioctl_get_node_publisher_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, ARRAY_SIZE(buf), &topic_num);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ_MSG(
-    test, node_info_args.ret_topic_num, (uint32_t)0,
-    "Prefix of node name should not match (strcmp, not strncmp)");
+    test, topic_num, (uint32_t)0, "Prefix of node name should not match (strcmp, not strncmp)");
 }
 
 void test_case_get_node_pub_topics_buffer_size_exceeded(struct kunit * test)
 {
   union ioctl_add_publisher_args add_pub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -76,9 +76,8 @@ void test_case_get_node_pub_topics_buffer_size_exceeded(struct kunit * test)
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  // Set topic_name_buffer_size to 0 so the buffer cannot hold any entry.
-  node_info_args.topic_name_buffer_size = 0;
-  ret =
-    agnocast_ioctl_get_node_publisher_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
+  ret = agnocast_ioctl_get_node_publisher_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, 0, &topic_num);
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+  KUNIT_EXPECT_EQ(test, topic_num, UINT_MAX);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -23,7 +23,8 @@ static void setup_process(struct kunit * test, const pid_t pid)
 void test_case_get_node_sub_topics_exact_match(struct kunit * test)
 {
   union ioctl_add_subscriber_args add_sub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -33,18 +34,18 @@ void test_case_get_node_sub_topics_exact_match(struct kunit * test)
     IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  // copy_to_user inside ioctl_get_node_subscriber_topics returns -EFAULT in KUnit (kernel thread)
-  // context, but reaching it confirms that the node name match was found.
-  node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
-  ret =
-    agnocast_ioctl_get_node_subscriber_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
-  KUNIT_EXPECT_TRUE(test, ret == -EFAULT || (ret == 0 && node_info_args.ret_topic_num == 1));
+  ret = agnocast_ioctl_get_node_subscriber_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, ARRAY_SIZE(buf), &topic_num);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, topic_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf[0], TOPIC_NAME);
 }
 
 void test_case_get_node_sub_topics_prefix_no_match(struct kunit * test)
 {
   union ioctl_add_subscriber_args add_sub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -54,19 +55,18 @@ void test_case_get_node_sub_topics_prefix_no_match(struct kunit * test)
     false, false, IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
-  ret =
-    agnocast_ioctl_get_node_subscriber_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
+  ret = agnocast_ioctl_get_node_subscriber_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, ARRAY_SIZE(buf), &topic_num);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ_MSG(
-    test, node_info_args.ret_topic_num, (uint32_t)0,
-    "Prefix of node name should not match (strcmp, not strncmp)");
+    test, topic_num, (uint32_t)0, "Prefix of node name should not match (strcmp, not strncmp)");
 }
 
 void test_case_get_node_sub_topics_buffer_size_exceeded(struct kunit * test)
 {
   union ioctl_add_subscriber_args add_sub_args;
-  union ioctl_node_info_args node_info_args = {0};
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
   int ret;
 
   setup_process(test, PID);
@@ -76,9 +76,8 @@ void test_case_get_node_sub_topics_buffer_size_exceeded(struct kunit * test)
     IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
-  // Set topic_name_buffer_size to 0 so the buffer cannot hold any entry.
-  node_info_args.topic_name_buffer_size = 0;
-  ret =
-    agnocast_ioctl_get_node_subscriber_topics(current->nsproxy->ipc_ns, NODE_NAME, &node_info_args);
+  ret = agnocast_ioctl_get_node_subscriber_topics(
+    current->nsproxy->ipc_ns, NODE_NAME, (char *)buf, 0, &topic_num);
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+  KUNIT_EXPECT_EQ(test, topic_num, UINT_MAX);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_get_topic_list.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+static const char * TOPIC_NAME = "/kunit_test_topic";
+static const char * TOPIC_NAME2 = "/kunit_test_topic2";
+static const char * SRV_REQUEST_TOPIC_NAME = "/AGNOCAST_SRV_REQUEST/kunit_test_service";
+static const char * SRV_RESPONSE_TOPIC_NAME =
+  "/AGNOCAST_SRV_RESPONSE/kunit_test_service_SEP_/kunit_test_node_SEP_0";
+static const char * NODE_NAME = "/kunit_test_node";
+static const pid_t PID = 1000;
+static const pid_t PID2 = 2000;
+static const uint32_t QOS_DEPTH = 1;
+static const uint32_t DOMAIN_ID = 1;
+static const uint32_t OTHER_DOMAIN_ID = 2;
+
+static void setup_process(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret = agnocast_ioctl_add_process(
+    pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static void add_subscriber(struct kunit * test, const char * topic_name, const pid_t pid)
+{
+  union ioctl_add_subscriber_args add_sub_args;
+  int ret = agnocast_ioctl_add_subscriber(
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, pid, QOS_DEPTH, false, true, false, false,
+    false, -1, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+// Returns the index of `name` in `buf`, or `num` when it is absent.
+static uint32_t index_of(const char * buf, const uint32_t num, const char * name)
+{
+  uint32_t i;
+
+  for (i = 0; i < num; i++) {
+    if (strcmp(&buf[i * TOPIC_NAME_BUFFER_SIZE], name) == 0) return i;
+  }
+
+  return num;
+}
+
+void test_case_get_topic_list_no_topic(struct kunit * test)
+{
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = UINT_MAX;
+
+  // Act
+  int ret = agnocast_ioctl_get_topic_list(
+    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, topic_num, 0);
+}
+
+void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
+{
+  char buf[2][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = 0;
+
+  // Arrange
+  setup_process(test, PID, DOMAIN_ID);
+  add_subscriber(test, TOPIC_NAME, PID);
+  add_subscriber(test, SRV_RESPONSE_TOPIC_NAME, PID);
+
+  // Act
+  int ret = agnocast_ioctl_get_topic_list(
+    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, topic_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf[0], TOPIC_NAME);
+}
+
+// A comparison shorter than the whole response prefix would skip this topic too.
+void test_case_get_topic_list_lists_service_request_topic(struct kunit * test)
+{
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = 0;
+
+  // Arrange
+  setup_process(test, PID, DOMAIN_ID);
+  add_subscriber(test, SRV_REQUEST_TOPIC_NAME, PID);
+
+  // Act
+  int ret = agnocast_ioctl_get_topic_list(
+    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, topic_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf[0], SRV_REQUEST_TOPIC_NAME);
+}
+
+// One list covers every domain in the namespace, so a name only means something paired with the
+// domain id at the same index.
+void test_case_get_topic_list_pairs_each_topic_with_its_domain_id(struct kunit * test)
+{
+  char buf[2][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[2] = {UINT_MAX, UINT_MAX};
+  uint32_t topic_num = 0;
+  uint32_t i;
+  uint32_t j;
+
+  // Arrange
+  setup_process(test, PID, DOMAIN_ID);
+  setup_process(test, PID2, OTHER_DOMAIN_ID);
+  add_subscriber(test, TOPIC_NAME, PID);
+  add_subscriber(test, TOPIC_NAME2, PID2);
+
+  // Act
+  int ret = agnocast_ioctl_get_topic_list(
+    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_ASSERT_EQ(test, topic_num, 2);
+  i = index_of((const char *)buf, topic_num, TOPIC_NAME);
+  j = index_of((const char *)buf, topic_num, TOPIC_NAME2);
+  KUNIT_ASSERT_LT(test, i, topic_num);
+  KUNIT_ASSERT_LT(test, j, topic_num);
+  KUNIT_EXPECT_EQ(test, domain_ids[i], DOMAIN_ID);
+  KUNIT_EXPECT_EQ(test, domain_ids[j], OTHER_DOMAIN_ID);
+}
+
+void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test)
+{
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t topic_num = 0;
+
+  // Arrange
+  setup_process(test, PID, DOMAIN_ID);
+  add_subscriber(test, TOPIC_NAME, PID);
+  add_subscriber(test, TOPIC_NAME2, PID);
+
+  // Act
+  int ret = agnocast_ioctl_get_topic_list(
+    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
@@ -61,25 +61,25 @@ void test_case_get_topic_list_no_topic(struct kunit * test)
   KUNIT_EXPECT_EQ(test, topic_num, 0);
 }
 
+// No room for a single topic, so a response topic that reached the buffer bound at all would fail
+// with -ENOBUFS, whichever one the walk happens to reach first.
 void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
 {
   char buf[1][TOPIC_NAME_BUFFER_SIZE];
   uint32_t domain_ids[1];
-  uint32_t topic_num = 0;
+  uint32_t topic_num = UINT_MAX;
 
   // Arrange
   setup_process(test, PID, DOMAIN_ID);
-  add_subscriber(test, TOPIC_NAME, PID);
   add_subscriber(test, SRV_RESPONSE_TOPIC_NAME, PID);
 
   // Act
-  int ret = agnocast_ioctl_get_topic_list(
-    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
+  int ret =
+    agnocast_ioctl_get_topic_list(current->nsproxy->ipc_ns, (char *)buf, domain_ids, 0, &topic_num);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_EQ(test, topic_num, 1);
-  KUNIT_EXPECT_STREQ(test, buf[0], TOPIC_NAME);
+  KUNIT_EXPECT_EQ(test, topic_num, 0);
 }
 
 // A comparison shorter than the whole response prefix would skip this topic too.

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
@@ -63,8 +63,8 @@ void test_case_get_topic_list_no_topic(struct kunit * test)
 
 void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
 {
-  char buf[2][TOPIC_NAME_BUFFER_SIZE];
-  uint32_t domain_ids[2];
+  char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[1];
   uint32_t topic_num = 0;
 
   // Arrange
@@ -138,7 +138,7 @@ void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test)
 {
   char buf[1][TOPIC_NAME_BUFFER_SIZE];
   uint32_t domain_ids[1];
-  uint32_t topic_num = 0;
+  uint32_t topic_num = UINT_MAX;
 
   // Arrange
   setup_process(test, PID, DOMAIN_ID);
@@ -151,4 +151,5 @@ void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+  KUNIT_EXPECT_EQ(test, topic_num, UINT_MAX);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.c
@@ -49,11 +49,12 @@ static uint32_t index_of(const char * buf, const uint32_t num, const char * name
 void test_case_get_topic_list_no_topic(struct kunit * test)
 {
   char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[1];
   uint32_t topic_num = UINT_MAX;
 
   // Act
   int ret = agnocast_ioctl_get_topic_list(
-    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -63,6 +64,7 @@ void test_case_get_topic_list_no_topic(struct kunit * test)
 void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
 {
   char buf[2][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[2];
   uint32_t topic_num = 0;
 
   // Arrange
@@ -72,7 +74,7 @@ void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_get_topic_list(
-    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -84,6 +86,7 @@ void test_case_get_topic_list_skips_service_response_topic(struct kunit * test)
 void test_case_get_topic_list_lists_service_request_topic(struct kunit * test)
 {
   char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[1];
   uint32_t topic_num = 0;
 
   // Arrange
@@ -92,7 +95,7 @@ void test_case_get_topic_list_lists_service_request_topic(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_get_topic_list(
-    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -134,6 +137,7 @@ void test_case_get_topic_list_pairs_each_topic_with_its_domain_id(struct kunit *
 void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test)
 {
   char buf[1][TOPIC_NAME_BUFFER_SIZE];
+  uint32_t domain_ids[1];
   uint32_t topic_num = 0;
 
   // Arrange
@@ -143,7 +147,7 @@ void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_get_topic_list(
-    current->nsproxy->ipc_ns, (char *)buf, NULL, ARRAY_SIZE(buf), &topic_num);
+    current->nsproxy->ipc_ns, (char *)buf, domain_ids, ARRAY_SIZE(buf), &topic_num);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_list.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_GET_TOPIC_LIST                                             \
+  KUNIT_CASE(test_case_get_topic_list_no_topic),                              \
+    KUNIT_CASE(test_case_get_topic_list_skips_service_response_topic),        \
+    KUNIT_CASE(test_case_get_topic_list_lists_service_request_topic),         \
+    KUNIT_CASE(test_case_get_topic_list_pairs_each_topic_with_its_domain_id), \
+    KUNIT_CASE(test_case_get_topic_list_fails_when_buffer_is_full)
+
+void test_case_get_topic_list_no_topic(struct kunit * test);
+void test_case_get_topic_list_skips_service_response_topic(struct kunit * test);
+void test_case_get_topic_list_lists_service_request_topic(struct kunit * test);
+void test_case_get_topic_list_pairs_each_topic_with_its_domain_id(struct kunit * test);
+void test_case_get_topic_list_fails_when_buffer_is_full(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -19,6 +19,7 @@
 #include "agnocast_kunit/agnocast_kunit_get_publisher_qos.h"
 #include "agnocast_kunit/agnocast_kunit_get_subscriber_num.h"
 #include "agnocast_kunit/agnocast_kunit_get_subscriber_qos.h"
+#include "agnocast_kunit/agnocast_kunit_get_topic_list.h"
 #include "agnocast_kunit/agnocast_kunit_get_topic_publisher_info.h"
 #include "agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h"
 #include "agnocast_kunit/agnocast_kunit_get_version.h"
@@ -65,6 +66,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_GET_NODE_SUBSCRIBER_TOPICS,
   TEST_CASES_GET_NODE_NAMES,
   TEST_CASES_GET_NODE_PUBLISHER_TOPICS,
+  TEST_CASES_GET_TOPIC_LIST,
   TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO,
   TEST_CASES_GET_TOPIC_PUBLISHER_INFO,
   TEST_CASES_GET_VERSION,

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -8,7 +8,7 @@
 #define MAX_SUBSCRIBER_NUM \
   (MAX_TOPIC_LOCAL_ID - MAX_PUBLISHER_NUM)  // Maximum number of subscribers per topic
 
-#define MAX_TOPIC_NUM 1024
+#define MAX_TOPIC_NUM 2048
 #define MAX_TOPIC_INFO_RET_NUM std::max(MAX_PUBLISHER_NUM, MAX_SUBSCRIBER_NUM)
 
 #define TOPIC_NAME_BUFFER_SIZE 256

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -24,12 +24,6 @@ def service_name_from_request_topic(topic_name):
         return None
     return topic_name[len(prefix):]
 
-def service_name_from_response_topic(topic_name):
-    prefix = '/AGNOCAST_SRV_RESPONSE'
-    if not topic_name.startswith(prefix):
-        return None
-    return topic_name[len(prefix):].split('_SEP_')[0]
-
 class NodeInfoAgnocastVerb(VerbExtension):
     "Output information about a node including Agnocast"
 
@@ -59,8 +53,6 @@ class NodeInfoAgnocastVerb(VerbExtension):
             def get_agnocast_node_topics(target_node_name):
                 sub_topic_list = []
                 pub_topic_list = []
-                # service_name_from_response_topic strips the _SEP_<id> suffix,
-                # so multiple response topics can collapse to the same service name.
                 server_set = set()
                 client_set = set()
                 # type_name resolved from gossip, keyed by topic name.
@@ -75,13 +67,10 @@ class NodeInfoAgnocastVerb(VerbExtension):
 
                         service_name = service_name_from_request_topic(topic.topic_name)
                         if service_name is not None:
+                            # A server subscribes to the request topic; a client publishes on it.
                             if is_sub:
                                 server_set.add(service_name)
-                            continue
-
-                        service_name = service_name_from_response_topic(topic.topic_name)
-                        if service_name is not None:
-                            if is_sub:
+                            if is_pub:
                                 client_set.add(service_name)
                             continue
 


### PR DESCRIPTION
## Description

`GET_TOPIC_LIST` fails with `-ENOBUFS` as soon as one IPC namespace holds `MAX_TOPIC_NUM` topics, so the discovery agent gets no topics at all and requests no bridges. A full Autoware launch reaches 1205 topics.

- Skip `/AGNOCAST_SRV_RESPONSE/...` topics. Nothing reads them: `decide_service_bridges()` keys a service off its request topic, and `decide_bridges()` skips both service prefixes. They were roughly 40% of the 1205, mostly the six parameter services of every `agnocast::Node`.
- Raise `MAX_TOPIC_NUM` to 2048.
- Fill kernel scratch under `global_htables_rwsem` and `copy_to_user()` after `up_read()`, the shape `GET_NODE_NAMES` already uses. The per-topic copy under the lock could sleep, and the higher limit widens that window.

A namespace above the new limit still fails with `-ENOBUFS`. Truncating instead needs a return field in `union ioctl_topic_list_args`, so it is left to a follow-up.

`union ioctl_topic_list_args` is unchanged, and a kmod/wrapper skew on `MAX_TOPIC_NUM` degrades to the lower of the two, hence `need-patch-update`.

## Related links

None.

## How was this PR tested?

- [x] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

- `ros2 topic list_agnocast` no longer shows response topics. They were only ever per-client plumbing.
- The load itself is untouched: on Humble `ServiceBridgeItem::ros2_client_exists()` returns `true` unconditionally (`count_clients()` needs Jazzy), so every parameter service of every node gets an R2A bridge and a response topic with it. Worth a separate issue.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
