### PR TITLE
refactor(agnocast_cie_thread_configurator): share the announcement wiring between the two nodes

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(agnocast_thread_configurator_core PUBLIC yaml-cpp)
 add_library(agnocast_thread_configurator SHARED
   src/util.cpp
   src/non_ros_thread_ipc.cpp
+  src/announcement_sources.cpp
 )
 ament_target_dependencies(agnocast_thread_configurator rclcpp agnocast_cie_config_msgs)
 

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/announcement_sources.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/announcement_sources.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "agnocast_cie_thread_configurator/non_ros_thread_ipc.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// The two channels through which threads announce themselves to a daemon,
+// namely the CallbackGroupInfo topic (one subscription per ROS domain) and
+// the non-ROS thread socket. Each extra domain gets its own node, which the
+// caller must add to its executor (domain_nodes()).
+//
+// on_callback_group runs on the executor. on_non_ros_thread runs on the
+// listener's private thread until stop() joins it.
+class AnnouncementSources
+{
+public:
+  using CallbackGroupInfo = agnocast_cie_config_msgs::msg::CallbackGroupInfo;
+  using CallbackGroupCallback =
+    std::function<void(size_t /*domain_id*/, CallbackGroupInfo::SharedPtr)>;
+
+  // The default-domain subscription lives on node; a domain_ids entry equal
+  // to default_domain_id is skipped.
+  AnnouncementSources(
+    rclcpp::Node & node, size_t default_domain_id, const std::set<size_t> & domain_ids,
+    CallbackGroupCallback on_callback_group, NonRosThreadInfoListener::Callback on_non_ros_thread);
+
+  const std::vector<rclcpp::Node::SharedPtr> & domain_nodes() const;
+  void stop() noexcept;
+
+private:
+  NonRosThreadInfoListener non_ros_thread_listener_;
+  std::vector<rclcpp::Node::SharedPtr> domain_nodes_;
+  std::vector<rclcpp::Subscription<CallbackGroupInfo>::SharedPtr> subscriptions_;
+};
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/announcement_sources.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/announcement_sources.hpp
@@ -34,8 +34,8 @@ public:
     rclcpp::Node & node, size_t default_domain_id, const std::set<size_t> & domain_ids,
     CallbackGroupCallback on_callback_group, NonRosThreadInfoListener::Callback on_non_ros_thread);
 
-  const std::vector<rclcpp::Node::SharedPtr> & domain_nodes() const;
-  void stop() noexcept;
+  const std::vector<rclcpp::Node::SharedPtr> & domain_nodes() const { return domain_nodes_; }
+  void stop() noexcept { non_ros_thread_listener_.stop(); }
 
 private:
   NonRosThreadInfoListener non_ros_thread_listener_;

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -15,6 +15,11 @@
 namespace agnocast_cie_thread_configurator
 {
 
+// Topic on which the agnocastlib client publishers announce callback groups
+// to the daemons.
+constexpr const char k_callback_group_info_topic[] =
+  "/agnocast_cie_thread_configurator/callback_group_info";
+
 // Get default domain ID from ROS_DOMAIN_ID environment variable
 size_t get_default_domain_id();
 

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -17,7 +17,7 @@ namespace agnocast_cie_thread_configurator
 
 // Topic on which the agnocastlib client publishers announce callback groups
 // to the daemons.
-constexpr const char k_callback_group_info_topic[] =
+constexpr const char * k_callback_group_info_topic =
   "/agnocast_cie_thread_configurator/callback_group_info";
 
 // Get default domain ID from ROS_DOMAIN_ID environment variable

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "agnocast_cie_thread_configurator/non_ros_thread_ipc.hpp"
+#include "agnocast_cie_thread_configurator/announcement_sources.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -27,11 +27,7 @@ private:
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
 
-  std::vector<rclcpp::Node::SharedPtr> nodes_for_each_domain_;
-  std::vector<rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr>
-    subs_for_each_domain_;
-  std::unique_ptr<agnocast_cie_thread_configurator::NonRosThreadInfoListener>
-    non_ros_thread_listener_;
+  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
 
   // (domain_id, callback_group_id) pairs. Guarded by domain_and_cbg_ids_mutex_
   // during callbacks; dump_yaml_config reads it post-spin without the lock.

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
@@ -27,8 +27,6 @@ private:
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
 
-  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
-
   // (domain_id, callback_group_id) pairs. Guarded by domain_and_cbg_ids_mutex_
   // during callbacks; dump_yaml_config reads it post-spin without the lock.
   std::set<std::pair<size_t, std::string>> domain_and_cbg_ids_;
@@ -38,4 +36,7 @@ private:
   // main.cpp calls node->stop() (which joins the listener) and after
   // executor->spin() returns, so no mutex is needed.
   std::set<std::string> non_ros_thread_names_;
+  // Declared last so it is destroyed first. The listener thread must be
+  // joined before any state its callback touches goes away.
+  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
 };

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -82,7 +82,6 @@ private:
     const std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Request> request,
     std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Response> response);
 
-  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
   rclcpp::Service<agnocast_cie_config_msgs::srv::ReapplyConfig>::SharedPtr reapply_service_;
 
   std::vector<ThreadConfig> callback_group_configs_;
@@ -105,4 +104,7 @@ private:
   const std::string config_file_;
   const size_t default_domain_id_;
   std::mutex non_ros_state_mutex_;
+  // Declared last so it is destroyed first. The listener thread must be
+  // joined before any state its callback touches goes away.
+  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
 };

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "agnocast_cie_thread_configurator/non_ros_thread_ipc.hpp"
+#include "agnocast_cie_thread_configurator/announcement_sources.hpp"
 #include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -82,11 +82,7 @@ private:
     const std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Request> request,
     std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Response> response);
 
-  std::vector<rclcpp::Node::SharedPtr> nodes_for_each_domain_;
-  std::vector<rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr>
-    subs_for_each_domain_;
-  std::unique_ptr<agnocast_cie_thread_configurator::NonRosThreadInfoListener>
-    non_ros_thread_listener_;
+  std::unique_ptr<agnocast_cie_thread_configurator::AnnouncementSources> sources_;
   rclcpp::Service<agnocast_cie_config_msgs::srv::ReapplyConfig>::SharedPtr reapply_service_;
 
   std::vector<ThreadConfig> callback_group_configs_;

--- a/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
+++ b/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
@@ -1,7 +1,6 @@
 #include "agnocast_cie_thread_configurator/announcement_sources.hpp"
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
-#include "rclcpp/rclcpp.hpp"
 
 #include <cstddef>
 #include <set>
@@ -17,14 +16,6 @@ namespace
 constexpr const char * k_callback_group_info_topic =
   "/agnocast_cie_thread_configurator/callback_group_info";
 
-// Must stay compatible with the client publishers in agnocastlib
-// (cie_client_utils.cpp). reliable + transient_local so announcements made
-// before the daemon starts are still delivered.
-rclcpp::QoS callback_group_info_qos()
-{
-  return rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
-}
-
 }  // namespace
 
 AnnouncementSources::AnnouncementSources(
@@ -32,9 +23,13 @@ AnnouncementSources::AnnouncementSources(
   CallbackGroupCallback on_callback_group, NonRosThreadInfoListener::Callback on_non_ros_thread)
 : non_ros_thread_listener_(std::move(on_non_ros_thread), node.get_logger())
 {
-  const auto subscribe = [&on_callback_group](rclcpp::Node & target, size_t domain_id) {
+  // Must stay compatible with the client publishers in agnocastlib
+  // (cie_client_utils.cpp). reliable + transient_local so announcements made
+  // before the daemon starts are still delivered.
+  const auto qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
+  const auto subscribe = [&](rclcpp::Node & target, size_t domain_id) {
     return target.create_subscription<CallbackGroupInfo>(
-      k_callback_group_info_topic, callback_group_info_qos(),
+      k_callback_group_info_topic, qos,
       [on_callback_group, domain_id](CallbackGroupInfo::SharedPtr msg) {
         on_callback_group(domain_id, std::move(msg));
       });
@@ -51,16 +46,6 @@ AnnouncementSources::AnnouncementSources(
     domain_nodes_.push_back(std::move(domain_node));
     RCLCPP_INFO(node.get_logger(), "Created subscription for domain ID: %zu", domain_id);
   }
-}
-
-const std::vector<rclcpp::Node::SharedPtr> & AnnouncementSources::domain_nodes() const
-{
-  return domain_nodes_;
-}
-
-void AnnouncementSources::stop() noexcept
-{
-  non_ros_thread_listener_.stop();
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
+++ b/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
@@ -1,0 +1,66 @@
+#include "agnocast_cie_thread_configurator/announcement_sources.hpp"
+
+#include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <cstddef>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+
+constexpr const char * k_callback_group_info_topic =
+  "/agnocast_cie_thread_configurator/callback_group_info";
+
+// Must stay compatible with the client publishers in agnocastlib
+// (cie_client_utils.cpp). reliable + transient_local so announcements made
+// before the daemon starts are still delivered.
+rclcpp::QoS callback_group_info_qos()
+{
+  return rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
+}
+
+}  // namespace
+
+AnnouncementSources::AnnouncementSources(
+  rclcpp::Node & node, size_t default_domain_id, const std::set<size_t> & domain_ids,
+  CallbackGroupCallback on_callback_group, NonRosThreadInfoListener::Callback on_non_ros_thread)
+: non_ros_thread_listener_(std::move(on_non_ros_thread), node.get_logger())
+{
+  const auto subscribe = [&on_callback_group](rclcpp::Node & target, size_t domain_id) {
+    return target.create_subscription<CallbackGroupInfo>(
+      k_callback_group_info_topic, callback_group_info_qos(),
+      [on_callback_group, domain_id](CallbackGroupInfo::SharedPtr msg) {
+        on_callback_group(domain_id, std::move(msg));
+      });
+  };
+
+  subscriptions_.push_back(subscribe(node, default_domain_id));
+
+  for (const size_t domain_id : domain_ids) {
+    if (domain_id == default_domain_id) {
+      continue;
+    }
+    auto domain_node = create_node_for_domain(domain_id);
+    subscriptions_.push_back(subscribe(*domain_node, domain_id));
+    domain_nodes_.push_back(std::move(domain_node));
+    RCLCPP_INFO(node.get_logger(), "Created subscription for domain ID: %zu", domain_id);
+  }
+}
+
+const std::vector<rclcpp::Node::SharedPtr> & AnnouncementSources::domain_nodes() const
+{
+  return domain_nodes_;
+}
+
+void AnnouncementSources::stop() noexcept
+{
+  non_ros_thread_listener_.stop();
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
+++ b/src/agnocast_cie_thread_configurator/src/announcement_sources.cpp
@@ -10,14 +10,6 @@
 namespace agnocast_cie_thread_configurator
 {
 
-namespace
-{
-
-constexpr const char * k_callback_group_info_topic =
-  "/agnocast_cie_thread_configurator/callback_group_info";
-
-}  // namespace
-
 AnnouncementSources::AnnouncementSources(
   rclcpp::Node & node, size_t default_domain_id, const std::set<size_t> & domain_ids,
   CallbackGroupCallback on_callback_group, NonRosThreadInfoListener::Callback on_non_ros_thread)
@@ -41,9 +33,8 @@ AnnouncementSources::AnnouncementSources(
     if (domain_id == default_domain_id) {
       continue;
     }
-    auto domain_node = create_node_for_domain(domain_id);
-    subscriptions_.push_back(subscribe(*domain_node, domain_id));
-    domain_nodes_.push_back(std::move(domain_node));
+    domain_nodes_.push_back(create_node_for_domain(domain_id));
+    subscriptions_.push_back(subscribe(*domain_nodes_.back(), domain_id));
     RCLCPP_INFO(node.get_logger(), "Created subscription for domain ID: %zu", domain_id);
   }
 }

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -276,7 +276,5 @@ PrerunNode::~PrerunNode()
 
 void PrerunNode::stop() noexcept
 {
-  if (sources_) {
-    sources_->stop();
-  }
+  sources_->stop();
 }

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -67,45 +67,14 @@ PrerunNode::PrerunNode(const rclcpp::NodeOptions & options) : Node("prerun_node"
     domain_ids.insert(domain_id);
   }
 
-  size_t default_domain_id = agnocast_cie_thread_configurator::get_default_domain_id();
-
-  auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
-
-  non_ros_thread_listener_ =
-    std::make_unique<agnocast_cie_thread_configurator::NonRosThreadInfoListener>(
-      [this](agnocast_cie_thread_configurator::NonRosThreadInfo info) {
-        this->non_ros_thread_callback(std::move(info));
-      },
-      this->get_logger());
-
-  // Create subscription for default domain on this node. Uses the node's default
-  // callback group, mirroring the per-domain extra nodes below.
-  subs_for_each_domain_.push_back(
-    this->create_subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
-      "/agnocast_cie_thread_configurator/callback_group_info", cbg_qos,
-      [this,
-       default_domain_id](const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
-        this->topic_callback(default_domain_id, msg);
-      }));
-
-  // Create nodes and subscriptions for other domain IDs
-  for (size_t domain_id : domain_ids) {
-    if (domain_id == default_domain_id) {
-      continue;
-    }
-
-    auto node = agnocast_cie_thread_configurator::create_node_for_domain(domain_id);
-    nodes_for_each_domain_.push_back(node);
-
-    auto sub = node->create_subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
-      "/agnocast_cie_thread_configurator/callback_group_info", cbg_qos,
-      [this, domain_id](const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
-        this->topic_callback(domain_id, msg);
-      });
-    subs_for_each_domain_.push_back(sub);
-
-    RCLCPP_INFO(this->get_logger(), "Created subscription for domain ID: %zu", domain_id);
-  }
+  sources_ = std::make_unique<agnocast_cie_thread_configurator::AnnouncementSources>(
+    *this, agnocast_cie_thread_configurator::get_default_domain_id(), domain_ids,
+    [this](size_t domain_id, agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
+      this->topic_callback(domain_id, std::move(msg));
+    },
+    [this](agnocast_cie_thread_configurator::NonRosThreadInfo info) {
+      this->non_ros_thread_callback(std::move(info));
+    });
 }
 
 void PrerunNode::topic_callback(
@@ -143,7 +112,7 @@ void PrerunNode::non_ros_thread_callback(agnocast_cie_thread_configurator::NonRo
 
 const std::vector<rclcpp::Node::SharedPtr> & PrerunNode::get_domain_nodes() const
 {
-  return nodes_for_each_domain_;
+  return sources_->domain_nodes();
 }
 
 void PrerunNode::dump_yaml_config(std::filesystem::path path)
@@ -307,7 +276,7 @@ PrerunNode::~PrerunNode()
 
 void PrerunNode::stop() noexcept
 {
-  if (non_ros_thread_listener_) {
-    non_ros_thread_listener_->stop();
+  if (sources_) {
+    sources_->stop();
   }
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -165,41 +165,14 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
   }
 
-  auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
-
-  non_ros_thread_listener_ =
-    std::make_unique<agnocast_cie_thread_configurator::NonRosThreadInfoListener>(
-      [this](agnocast_cie_thread_configurator::NonRosThreadInfo info) {
-        this->non_ros_thread_callback(std::move(info));
-      },
-      this->get_logger());
-
-  subs_for_each_domain_.push_back(
-    this->create_subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
-      "/agnocast_cie_thread_configurator/callback_group_info", cbg_qos,
-      [this, default_domain_id = default_domain_id_](
-        const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
-        this->callback_group_callback(default_domain_id, msg);
-      }));
-
-  // Create nodes and subscriptions for other domain IDs
-  for (size_t domain_id : domain_ids) {
-    if (domain_id == default_domain_id_) {
-      continue;
-    }
-
-    auto node = agnocast_cie_thread_configurator::create_node_for_domain(domain_id);
-    nodes_for_each_domain_.push_back(node);
-
-    auto sub = node->create_subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
-      "/agnocast_cie_thread_configurator/callback_group_info", cbg_qos,
-      [this, domain_id](const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
-        this->callback_group_callback(domain_id, msg);
-      });
-    subs_for_each_domain_.push_back(sub);
-
-    RCLCPP_INFO(this->get_logger(), "Created subscription for domain ID: %zu", domain_id);
-  }
+  sources_ = std::make_unique<agnocast_cie_thread_configurator::AnnouncementSources>(
+    *this, default_domain_id_, domain_ids,
+    [this](size_t domain_id, agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
+      this->callback_group_callback(domain_id, std::move(msg));
+    },
+    [this](agnocast_cie_thread_configurator::NonRosThreadInfo info) {
+      this->non_ros_thread_callback(std::move(info));
+    });
 
   reapply_service_ = this->create_service<agnocast_cie_config_msgs::srv::ReapplyConfig>(
     "~/reapply_config",
@@ -295,8 +268,8 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode()
 
 void ThreadConfiguratorNode::stop() noexcept
 {
-  if (non_ros_thread_listener_) {
-    non_ros_thread_listener_->stop();
+  if (sources_) {
+    sources_->stop();
   }
 }
 
@@ -721,7 +694,7 @@ bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqConfig & config) c
 
 const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_nodes() const
 {
-  return nodes_for_each_domain_;
+  return sources_->domain_nodes();
 }
 
 void ThreadConfiguratorNode::callback_group_callback(

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -268,9 +268,7 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode()
 
 void ThreadConfiguratorNode::stop() noexcept
 {
-  if (sources_) {
-    sources_->stop();
-  }
+  sources_->stop();
 }
 
 void ThreadConfiguratorNode::print_all_unapplied()

--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
@@ -95,7 +96,7 @@ create_rclcpp_client_publisher()
   auto node = std::make_shared<rclcpp::Node>(
     "client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator", options);
   auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
-    "/agnocast_cie_thread_configurator/callback_group_info",
+    agnocast_cie_thread_configurator::k_callback_group_info_topic,
     rclcpp::QoS(CIE_QOS_DEPTH).keep_all().reliable().transient_local());
   return publisher;
 }
@@ -117,7 +118,7 @@ create_agnocast_client_publisher()
   auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
     // Note: agnocast Publisher does not support keep_all(), so KeepLast is used here
     // (unlike the rclcpp variant which uses keep_all()).
-    "/agnocast_cie_thread_configurator/callback_group_info",
+    agnocast_cie_thread_configurator::k_callback_group_info_topic,
     rclcpp::QoS(rclcpp::KeepLast(CIE_QOS_DEPTH)).reliable().transient_local());
   return publisher;
 }


### PR DESCRIPTION
## Description

`PrerunNode` and `ThreadConfiguratorNode` each built the same `NonRosThreadInfoListener`, the same `CallbackGroupInfo` subscription and the same per-domain node loop, so the topic name and QoS were repeated and the two daemons could drift apart (#1218).

This PR moves that wiring into `AnnouncementSources`. Both nodes now hold one `std::unique_ptr<AnnouncementSources>` and pass two callbacks, `on_callback_group(domain_id, msg)` and `on_non_ros_thread(info)`. The QoS lives only in `announcement_sources.cpp`, and the topic name moves to the installed `cie_thread_configurator.hpp` so the agnocastlib client publishers share the same constant. `sources_` is the last member of both nodes so the listener thread is joined before the state its callback touches is destroyed, including on constructor unwind. Behavior is unchanged.

Verified by building with `-DBUILD_TESTING=ON`, running the five gtests, and running both executables with multiple domains.

## Related links

- #1218

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.