### PR TITLE
[PENDING] refactor(agnocast_cie_thread_configurator)[needs major version update]: drop the deprecated CLI path from thread_configurator_node

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -37,7 +37,6 @@ add_executable(
   thread_configurator_node
   src/main.cpp
   src/thread_configurator_node.cpp
-  src/prerun_node.cpp
 )
 ament_target_dependencies(thread_configurator_node rclcpp agnocast_cie_config_msgs)
 target_link_libraries(thread_configurator_node

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
@@ -33,7 +33,7 @@ private:
   std::mutex domain_and_cbg_ids_mutex_;
   // non-ROS thread names. Written from the NonRosThreadInfoListener's
   // private reader thread; read by dump_yaml_config() only after
-  // main.cpp calls node->stop() (which joins the listener) and after
+  // prerun_node_main.cpp calls node->stop() (which joins the listener) and after
   // executor->spin() returns, so no mutex is needed.
   std::set<std::string> non_ros_thread_names_;
   // Declared last so it is destroyed first. The listener thread must be

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -1,98 +1,26 @@
-#include "agnocast_cie_thread_configurator/prerun_node.hpp"
 #include "agnocast_cie_thread_configurator/thread_configurator_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <filesystem>
 #include <iostream>
 #include <memory>
-#include <sstream>
-#include <string>
-
-static std::vector<int64_t> parse_domain_ids(const std::string & domains_str)
-{
-  std::vector<int64_t> domain_ids;
-  std::stringstream ss(domains_str);
-  std::string token;
-  while (std::getline(ss, token, ',')) {
-    if (!token.empty()) {
-      try {
-        domain_ids.push_back(static_cast<int64_t>(std::stol(token)));
-      } catch (const std::exception & e) {
-        std::cerr << "[WARN] Invalid domain ID value: " << token << ". Skipping." << std::endl;
-      }
-    }
-  }
-  return domain_ids;
-}
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  std::vector<std::string> args = rclcpp::remove_ros_arguments(argc, argv);
 
-  bool prerun_mode = false;
-  std::vector<int64_t> domain_ids;
-  std::string config_filename;
-
-  for (size_t i = 0; i < args.size(); ++i) {
-    if (args[i] == "--prerun") {
-      prerun_mode = true;
-    } else if (args[i] == "--domains" && i + 1 < args.size()) {
-      domain_ids = parse_domain_ids(args[i + 1]);
-      ++i;
-    } else if (args[i] == "--config-file" && i + 1 < args.size()) {
-      config_filename = args[i + 1];
-      ++i;
-    }
-  }
-
-  if (prerun_mode || !domain_ids.empty() || !config_filename.empty()) {
-    std::cerr << "[DEPRECATED] CLI arguments (--prerun, --domains, --config-file) are deprecated. "
-              << "Run prerun_node directly with ROS parameters or use the launch file "
-              << "(thread_configurator.launch.xml) instead." << std::endl;
-  }
-
-  // Backward-compatible CLI path: translates deprecated CLI args into ROS parameter overrides.
   try {
-    if (prerun_mode) {
-      std::cout << "prerun mode" << std::endl;
+    auto node = std::make_shared<ThreadConfiguratorNode>();
+    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-      rclcpp::NodeOptions options;
-      if (!domain_ids.empty()) {
-        options.append_parameter_override("domains", domain_ids);
-      }
-
-      auto node = std::make_shared<PrerunNode>(options);
-      auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-      executor->add_node(node);
-      for (const auto & sub_node : node->get_domain_nodes()) {
-        executor->add_node(sub_node);
-      }
-
-      executor->spin();
-
-      node->stop();
-      node->dump_yaml_config(std::filesystem::current_path());
-    } else {
-      rclcpp::NodeOptions options;
-      if (!config_filename.empty()) {
-        options.append_parameter_override("config_file", config_filename);
-      }
-
-      auto node = std::make_shared<ThreadConfiguratorNode>(options);
-      auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-      executor->add_node(node);
-      for (const auto & domain_node : node->get_domain_nodes()) {
-        executor->add_node(domain_node);
-      }
-
-      executor->spin();
-
-      node->stop();
-      node->print_all_unapplied();
+    executor->add_node(node);
+    for (const auto & domain_node : node->get_domain_nodes()) {
+      executor->add_node(domain_node);
     }
+
+    executor->spin();
+
+    node->stop();
+    node->print_all_unapplied();
   } catch (const std::exception & e) {
     std::cerr << "[ERROR] " << e.what() << std::endl;
     rclcpp::shutdown();


### PR DESCRIPTION
## Description

`thread_configurator_node` accepted `--prerun`, `--domains` and `--config-file`, printed a deprecation notice and translated them into ROS parameter overrides. This PR removes that path, so `main.cpp` is now the same executor loop as `prerun_node_main.cpp` and `prerun_node.cpp` is compiled only into `prerun_node`.

**Breaking change.** Use `prerun_node` with the `domains` parameter, or pass `config_file` as a ROS parameter, which is what `thread_configurator.launch.xml` already does. The old flags now fail with `'config_file' parameter must be provided with a valid YAML file path`.

Verified by building with `-DBUILD_TESTING=ON`, running the five gtests, and running `thread_configurator_node` with a multi-domain config through the `config_file` parameter.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1620. Only the last commit belongs to this PR.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
