### PR TITLE
fix(ci): drop the unused Chrome apt source before apt-get update

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -70,6 +70,7 @@ jobs:
     - name: Setup ROS 2 environment
       if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common curl gcovr ccache libunwind-dev
 

--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -70,7 +70,8 @@ jobs:
     - name: Setup ROS 2 environment
       if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
+        # Nothing here installs from Chrome's repo, and its broken index makes apt-get update exit 100.
+        grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common curl gcovr ccache libunwind-dev
 

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -24,7 +24,8 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | gpg --dearmor | sudo tee /usr/share/keyrings/ros-archive-keyring.gpg > /dev/null
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://repo.ros2.org/ubuntu/main $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list > /dev/null
 
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
+          # Nothing here installs from Chrome's repo, and its broken index makes apt-get update exit 100.
+          grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
           sudo apt-get update
           sudo apt-get install -y \
             git \

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -24,6 +24,7 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | gpg --dearmor | sudo tee /usr/share/keyrings/ros-archive-keyring.gpg > /dev/null
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://repo.ros2.org/ubuntu/main $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list > /dev/null
 
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
           sudo apt-get update
           sudo apt-get install -y \
             git \

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Install kunit.py prerequisites
         run: |
           set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential flex bison libelf-dev libssl-dev bc python3 \

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -58,7 +58,8 @@ jobs:
       - name: Install kunit.py prerequisites
         run: |
           set -euo pipefail
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
+          # Nothing here installs from Chrome's repo, and its broken index makes apt-get update exit 100.
+          grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential flex bison libelf-dev libssl-dev bc python3 \

--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -27,7 +27,8 @@ jobs:
       - name: Install sparse
         if: steps.check_changes.outputs.kmod_changed == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
+          # Nothing here installs from Chrome's repo, and its broken index makes apt-get update exit 100.
+          grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
           sudo apt-get update
           sudo apt-get install -y sparse
 

--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Install sparse
         if: steps.check_changes.outputs.kmod_changed == 'true'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list  # unused; upstream index hash mismatches break apt-get update
           sudo apt-get update
           sudo apt-get install -y sparse
 


### PR DESCRIPTION
## Description

CI jobs are failing during setup with an error that has nothing to do with the code under test:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

GitHub-hosted runners ship `/etc/apt/sources.list.d/google-chrome.list` preinstalled. `dl.google.com` intermittently serves a `Packages.gz` whose hash does not match the `Release` file it just published, and `apt-get update` exits 100 when any single index fails to download. No job in this repository installs anything from that repository, so the failure is pure collateral damage. Re-running does not help while the upstream mirror is inconsistent.

This removes the file before the first `apt-get update` in each job that runs one. The removal persists for the rest of the job, so later `apt-get update` calls in the same job are covered by the single line.

Affected workflows:

- `build-and-test-agnocastlib-components-heaphook.yaml`
- `cppcheck-differential.yaml`
- `kunit.yaml`
- `sparse-check.yaml`

`microsoft-prod.list` is left in place. It can be removed the same way if it ever breaks.

## Related links

Observed on https://github.com/autowarefoundation/agnocast/actions/runs/34383105370 (both matrix jobs, and again on re-run).

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.