### PR TITLE
feat(ros2agnocast_discovery_agent): read domain bridge rules from several configs

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -40,8 +40,6 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastTopic,
 )
 
-import yaml
-
 from . import bridge_decider
 from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
@@ -299,45 +297,47 @@ def _read_ros_domain_id() -> int:
     return value
 
 
+def _report_unloaded_config(logger, path, error, from_env) -> None:
+    """Report a config that contributed no rules, at the level its cause deserves."""
+    if isinstance(error, FileNotFoundError):
+        if from_env:
+            logger.warn(
+                f'{domain_bridge_config.CONFIG_ENV} lists {path}, which does not '
+                'exist; no cross-domain bridge will be forced for the topics it names')
+        else:
+            logger.info(
+                f'no domain bridge config at {path}; cross-domain bridge forcing '
+                f'is off (set {domain_bridge_config.CONFIG_ENV} to use another path)')
+        return
+    # One bad entry disables the whole file, not just its topic, and domain_bridge refuses the
+    # same file for anything yaml-cpp cannot convert. Hence error level.
+    logger.error(
+        f'cannot load {path} ({error}); cross-domain bridge forcing is off for every topic '
+        'it names, so any of them split across an IPC namespace and a ROS domain will not flow')
+
+
 def _load_domain_rules(logger=None) -> list:
-    """Return the domain bridge rules from the config, or [].
+    """Return the domain bridge rules from the configs, or [].
 
     Every outcome is logged: a silently empty rule list looks exactly like the
     cross-domain deadlock this forcing exists to break. A config that cannot be
     read is reported and skipped rather than fatal, so it never takes the gossip
     publication down.
     """
-    path, from_env = domain_bridge_config.resolve_config_path()
+    paths, from_env = domain_bridge_config.resolve_config_paths()
 
-    try:
-        rules, skipped = domain_bridge_config.load_domain_bridge_rules(path)
-    except FileNotFoundError:
+    rules = []
+    for result in domain_bridge_config.load_domain_bridge_rules(paths):
+        if result.error is not None:
+            if logger is not None:
+                _report_unloaded_config(logger, result.path, result.error, from_env)
+            continue
+        rules.extend(result.rules)
         if logger is not None:
-            if from_env:
+            logger.info(f'{result.path}: {len(result.rules)} domain bridge rule(s) loaded')
+            if result.skipped:
                 logger.warn(
-                    f'{domain_bridge_config.CONFIG_ENV} points at {path}, which does not '
-                    'exist; no cross-domain bridge will be forced')
-            else:
-                logger.info(
-                    f'no domain bridge config at {path}; cross-domain bridge forcing '
-                    f'is off (set {domain_bridge_config.CONFIG_ENV} to use another path)')
-        return []
-    except (OSError, yaml.YAMLError, ValueError, TypeError) as exc:
-        # One bad entry disables the whole config, not just its topic, and domain_bridge refuses
-        # the same file for anything yaml-cpp cannot convert. Say so at error level: forcing is
-        # off for every topic, and a topic split across a namespace and a domain then stops
-        # without another trace.
-        if logger is not None:
-            logger.error(
-                f'cannot load {path} ({exc}); cross-domain bridge forcing is off for ALL '
-                'topics, so any topic split across an IPC namespace and a ROS domain will '
-                'not flow')
-        return []
-
-    if logger is not None:
-        logger.info(f'{path}: {len(rules)} domain bridge rule(s) loaded')
-        if skipped:
-            logger.warn(f'{path}: no from_domain/to_domain for {", ".join(skipped)}')
+                    f'{result.path}: no from_domain/to_domain for {", ".join(result.skipped)}')
     return rules
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -325,6 +325,11 @@ def _load_domain_rules(logger=None) -> list:
     publication down.
     """
     paths, from_env = domain_bridge_config.resolve_config_paths()
+    if from_env and logger is not None:
+        shadowed = domain_bridge_config.shadowed_drop_ins()
+        if shadowed:
+            logger.warn(
+                f'{domain_bridge_config.SHADOWED_DROP_INS_NOTICE}: {", ".join(shadowed)}')
 
     rules = []
     for result in domain_bridge_config.load_domain_bridge_rules(paths):

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,11 +1,13 @@
-"""Parse a ROS 2 ``domain_bridge`` YAML into kmod rule tuples.
+"""Parse ROS 2 ``domain_bridge`` YAMLs into kmod rule tuples.
 
-Each rule is ``(from_topic, to_topic, from_domain, to_domain)``. The same YAML
-drives both the external ``domain_bridge`` node (cross-ECU, via DDS) and the kmod
+Each rule is ``(from_topic, to_topic, from_domain, to_domain)``. The same YAMLs
+drive both the external ``domain_bridge`` node (cross-ECU, via DDS) and the kmod
 rule injection that opens same-IPC-namespace zero-copy cross-domain delivery. The
 topic name, its ``remap`` target, and the domain pair matter here; ``type`` and
 other fields are ignored.
 """
+from collections import namedtuple
+import glob
 import os
 
 import yaml
@@ -17,15 +19,42 @@ CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
 # an env var set only where the registration tool runs never reaches the agent.
 DEFAULT_CONFIG_PATH = '/etc/agnocast/domain_bridge.yaml'
 
+# Several configs are listed the way PATH lists directories.
+CONFIG_PATH_SEP = ':'
+
 # Domain ids cross the ioctl boundary as ctypes.c_uint32, so an out-of-range
 # value would wrap silently; reject it here instead.
 _UINT32_MAX = 0xFFFFFFFF
 
 
-def resolve_config_path():
-    """Return ``(path, from_env)`` for the config every consumer should read."""
-    path = os.environ.get(CONFIG_ENV)
-    return (path, True) if path else (DEFAULT_CONFIG_PATH, False)
+def default_config_dir():
+    """Return the drop-in directory beside ``DEFAULT_CONFIG_PATH`` (``/etc/agnocast/domain_bridge.d``).
+
+    Derived, not a constant, so moving the default path in a test moves the directory too.
+    """
+    return os.path.splitext(DEFAULT_CONFIG_PATH)[0] + '.d'
+
+
+def _default_config_paths():
+    """Return the configs at the default location: the main file, then its ``.d`` drop-ins.
+
+    The layout systemd and sysctl use for a configuration file and its drop-in directory, but
+    not their precedence: a later file only adds. Two rules that pair one cell differently are
+    a configuration error the kmod rejects, not something an order resolves.
+
+    Names ``DEFAULT_CONFIG_PATH`` when neither exists, so the caller can say where a config
+    would go.
+    """
+    paths = [DEFAULT_CONFIG_PATH] if os.path.isfile(DEFAULT_CONFIG_PATH) else []
+    paths += sorted(glob.glob(os.path.join(default_config_dir(), '*.yaml')))
+    return paths or [DEFAULT_CONFIG_PATH]
+
+
+def resolve_config_paths():
+    """Return ``(paths, from_env)`` for the configs every consumer should read, in order."""
+    listed = os.environ.get(CONFIG_ENV, '')
+    paths = [path for path in listed.split(CONFIG_PATH_SEP) if path]
+    return (paths, True) if paths else (_default_config_paths(), False)
 
 
 def _as_domain_id(value):
@@ -134,7 +163,25 @@ def parse_domain_bridge_config(text):
     return rules, skipped
 
 
-def load_domain_bridge_rules(path):
-    """Read and parse the ``domain_bridge`` YAML at ``path``; return ``(rules, skipped)``."""
-    with open(path, encoding='utf-8') as f:
-        return parse_domain_bridge_config(f.read())
+ConfigResult = namedtuple('ConfigResult', ('path', 'rules', 'skipped', 'error'))
+
+
+def load_domain_bridge_rules(paths):
+    """Read and parse each ``domain_bridge`` YAML in ``paths``; return a ``ConfigResult`` each.
+
+    Rules from separate files accumulate, the way the external node merges several configs:
+    ``topics`` add up, while ``from_domain`` / ``to_domain`` stay local to the file setting them.
+
+    An error is carried in the result rather than raised, so one unreadable config does not
+    take the readable ones with it.
+    """
+    results = []
+    for path in paths:
+        try:
+            with open(path, encoding='utf-8') as f:
+                rules, skipped = parse_domain_bridge_config(f.read())
+        except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+            results.append(ConfigResult(path, [], [], e))
+            continue
+        results.append(ConfigResult(path, rules, skipped, None))
+    return results

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -50,6 +50,17 @@ def _default_config_paths():
     return paths or [DEFAULT_CONFIG_PATH]
 
 
+SHADOWED_DROP_INS_NOTICE = f'{CONFIG_ENV} is set, so these drop-ins are not read'
+
+
+def shadowed_drop_ins():
+    """Return the drop-ins ``CONFIG_ENV`` is suppressing, for the caller to report.
+
+    The variable replaces the default location instead of adding to it.
+    """
+    return sorted(glob.glob(os.path.join(default_config_dir(), '*.yaml')))
+
+
 def resolve_config_paths():
     """Return ``(paths, from_env)`` for the configs every consumer should read, in order."""
     listed = os.environ.get(CONFIG_ENV, '')

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -3,7 +3,7 @@
 Unsupported: the kmod cross-domain zero-copy path is incomplete; relay between ROS
 domains with the external ``domain_bridge`` node instead.
 
-Reads a ROS 2 ``domain_bridge`` YAML and registers each
+Reads one or more ROS 2 ``domain_bridge`` YAMLs and registers each
 ``(from_topic, to_topic, from_domain, to_domain)`` rule through the ioctl wrapper
 (``to_topic`` is the per-topic ``remap`` target, or the source name if absent).
 
@@ -16,8 +16,6 @@ discovery agent, which is observability-only and never registers rules.
 import argparse
 import ctypes
 import sys
-
-import yaml
 
 from . import domain_bridge_config
 
@@ -38,50 +36,57 @@ def _load_add_rule_symbol():
 
 
 def main(argv=None) -> int:
-    """Register every rule in the config; return non-zero if any is rejected."""
+    """Register every rule in the configs; return non-zero if any rule or config is rejected."""
     parser = argparse.ArgumentParser(
         description='Register Agnocast domain bridge rules with the kernel module. '
                     f'Unsupported: {UNSUPPORTED_NOTICE}.')
     parser.add_argument(
         '--config',
-        default=domain_bridge_config.resolve_config_path()[0],
-        help='path to the domain_bridge YAML '
-             f'(default: ${domain_bridge_config.CONFIG_ENV}, '
-             f'else {domain_bridge_config.DEFAULT_CONFIG_PATH})')
+        nargs='+',
+        default=domain_bridge_config.resolve_config_paths()[0],
+        help='paths to the domain_bridge YAMLs, applied in order '
+             f'(default: ${domain_bridge_config.CONFIG_ENV}, a '
+             f"'{domain_bridge_config.CONFIG_PATH_SEP}'-separated list, "
+             f'else {domain_bridge_config.DEFAULT_CONFIG_PATH} and '
+             f'{domain_bridge_config.default_config_dir()}/*.yaml)')
     args = parser.parse_args(argv)
 
-    # Before the config is read, so an operator sees it even on a run that registers nothing.
+    # Before the configs are read, so an operator sees it even on a run that registers nothing.
     print(f'warning: {UNSUPPORTED_NOTICE}', file=sys.stderr)
 
-    try:
-        rules, skipped = domain_bridge_config.load_domain_bridge_rules(args.config)
-    except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
-        print(f'error: cannot load {args.config}: {e}', file=sys.stderr)
-        return 1
-
-    for topic in skipped:
-        print(f'warning: skipping {topic}: no from_domain/to_domain resolved '
-              '(set them at the top level or on the topic)', file=sys.stderr)
-
-    add_rule = _load_add_rule_symbol()
-    failures = 0
-    for from_topic, to_topic, from_domain, to_domain in rules:
-        label = f'{from_topic}@{from_domain} -> {to_topic}@{to_domain}'
-        if add_rule(
-                from_topic.encode('utf-8'), to_topic.encode('utf-8'),
-                from_domain, to_domain) == 0:
-            print(f'registered: {label}')
+    rules = []
+    unreadable = 0
+    for result in domain_bridge_config.load_domain_bridge_rules(args.config):
+        if result.error is not None:
+            print(f'error: cannot load {result.path}: {result.error}', file=sys.stderr)
+            unreadable += 1
             continue
-        # The wrapper prints the specific errno to stderr just above; the usual
-        # cause is that an endpoint already exists, since a rule must precede
-        # every node in either domain.
-        failures += 1
-        print(f'error: failed to register {label}', file=sys.stderr)
+        rules.extend(result.rules)
+        for topic in result.skipped:
+            print(f'warning: skipping {topic}: no from_domain/to_domain resolved '
+                  '(set them at the top level or on the topic)', file=sys.stderr)
+
+    failures = 0
+    # Nothing to register: leave the wrapper unloaded so an unreadable config is what gets
+    # reported, not a missing library.
+    if rules:
+        add_rule = _load_add_rule_symbol()
+        for from_topic, to_topic, from_domain, to_domain in rules:
+            label = f'{from_topic}@{from_domain} -> {to_topic}@{to_domain}'
+            if add_rule(
+                    from_topic.encode('utf-8'), to_topic.encode('utf-8'),
+                    from_domain, to_domain) == 0:
+                print(f'registered: {label}')
+                continue
+            # The wrapper prints the specific errno to stderr just above; the usual
+            # cause is that an endpoint already exists, since a rule must precede
+            # every node in either domain.
+            failures += 1
+            print(f'error: failed to register {label}', file=sys.stderr)
 
     if failures:
         print(f'error: {failures} of {len(rules)} rule(s) rejected', file=sys.stderr)
-        return 1
-    return 0
+    return 1 if failures or unreadable else 0
 
 
 if __name__ == '__main__':

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -36,6 +36,10 @@ layout systemd and sysctl use, but not their precedence: a later file only adds,
 it never overrides an earlier one. Two files that bridge the same topic and domain
 to different places are a configuration error, which the kernel module rejects.
 
+`AGNOCAST_DOMAIN_BRIDGE_CONFIG` replaces the default location rather than adding to
+it, so setting it means the drop-in directory is **not** read. The agent warns when
+the variable is set and the directory still holds a `*.yaml`.
+
 The discovery agent reads the same files, to force the A2R bridge that a topic
 split across both an IPC namespace and a ROS domain needs (without it,
 `domain_bridge` waits for a DDS publisher while the A2R bridge waits for a DDS

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -13,8 +13,8 @@ once a domain has allocated endpoint ids. Registration is therefore a one-time
 boot step, independent of the discovery agent (which is observability-only and
 never registers rules).
 
-`register_domain_bridge` (a console script in this package) reads a ROS 2
-`domain_bridge` YAML and registers each rule:
+`register_domain_bridge` (a console script in this package) reads ROS 2
+`domain_bridge` YAMLs and registers each rule:
 
 ```bash
 ros2 run ros2agnocast_discovery_agent register_domain_bridge
@@ -22,14 +22,28 @@ ros2 run ros2agnocast_discovery_agent register_domain_bridge
 # AGNOCAST_DOMAIN_BRIDGE_CONFIG
 ```
 
-The discovery agent reads the same file, to force the A2R bridge that a topic
+Several configs can be listed, applied in the order given, the way `domain_bridge`
+itself takes several positional arguments: `--config a.yaml b.yaml`, or a
+`:`-separated `AGNOCAST_DOMAIN_BRIDGE_CONFIG`. `topics` accumulate across files,
+while `from_domain` / `to_domain` stay local to the file that sets them — the same
+merge `domain_bridge` performs. Unlike `domain_bridge`, which aborts on the first
+unreadable file, a bad file here is reported and skipped so the rest still apply.
+
+Drop-ins need no environment variable: every `*.yaml` in
+`/etc/agnocast/domain_bridge.d/` is read in name order (`10-base.yaml`,
+`20-lidar.yaml`), after `/etc/agnocast/domain_bridge.yaml` when that exists — the
+layout systemd and sysctl use, but not their precedence: a later file only adds,
+it never overrides an earlier one. Two files that bridge the same topic and domain
+to different places are a configuration error, which the kernel module rejects.
+
+The discovery agent reads the same files, to force the A2R bridge that a topic
 split across both an IPC namespace and a ROS domain needs (without it,
 `domain_bridge` waits for a DDS publisher while the A2R bridge waits for a DDS
 subscriber, and the topic never flows). The agent is `execv`'d from an
 application process, so it only ever sees the default path or an environment
 variable exported to that process — **not** a `--config` argument passed here.
 
-Keep the file at `/etc/agnocast/domain_bridge.yaml`, or export
+Keep the config at `/etc/agnocast/domain_bridge.yaml`, or export
 `AGNOCAST_DOMAIN_BRIDGE_CONFIG` to the applications as well. Registering with
 `--config` alone leaves the rules in the kmod but the forcing off, which the
 agent reports only in its own log.

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -565,6 +565,32 @@ def test_load_domain_rules_errors_and_returns_empty_on_a_broken_config(monkeypat
     logger.error.assert_called_once()
 
 
+def test_load_domain_rules_reads_the_default_drop_in_directory(monkeypatch, tmp_path):
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    monkeypatch.setattr(
+        domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(tmp_path / 'domain_bridge.yaml'))
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    (drop_in_dir / '10-base.yaml').write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    (drop_in_dir / '20-lidar.yaml').write_text('from_domain: 3\nto_domain: 4\ntopics:\n  /y:\n')
+
+    assert _load_domain_rules() == [('/x', '/x', 1, 2), ('/y', '/y', 3, 4)]
+
+
+def test_load_domain_rules_keeps_the_configs_that_load_around_a_broken_one(monkeypatch, tmp_path):
+    broken = tmp_path / 'a.yaml'
+    broken.write_text('topics: [not, a, mapping]\n')
+    good = tmp_path / 'b.yaml'
+    good.write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    monkeypatch.setenv(
+        CONFIG_ENV,
+        f'{broken}{domain_bridge_config.CONFIG_PATH_SEP}{good}')
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == [('/x', '/x', 1, 2)]
+    logger.error.assert_called_once()
+
+
 def test_exit_when_idle_enabled_via_env(monkeypatch):
     monkeypatch.setattr(sys, 'argv', ['discovery_agent'])  # no CLI flag
     monkeypatch.delenv(EXIT_WHEN_IDLE_ENV, raising=False)

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -485,6 +485,13 @@ def test_dispatch_sends_nothing_when_no_request_is_produced(monkeypatch):
     assert sent == []
 
 
+@pytest.fixture(autouse=True)
+def _default_config_in_tmp(monkeypatch, tmp_path):
+    """Keep the default path, and the drop-in directory beside it, out of /etc."""
+    monkeypatch.setattr(
+        domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(tmp_path / 'domain_bridge.yaml'))
+
+
 def test_load_domain_rules_returns_empty_when_no_config_exists(monkeypatch, tmp_path):
     monkeypatch.delenv(CONFIG_ENV, raising=False)
     monkeypatch.setattr(
@@ -575,6 +582,32 @@ def test_load_domain_rules_reads_the_default_drop_in_directory(monkeypatch, tmp_
     (drop_in_dir / '20-lidar.yaml').write_text('from_domain: 3\nto_domain: 4\ntopics:\n  /y:\n')
 
     assert _load_domain_rules() == [('/x', '/x', 1, 2), ('/y', '/y', 3, 4)]
+
+
+def test_load_domain_rules_warns_that_the_env_var_shadows_the_drop_ins(monkeypatch, tmp_path):
+    config = tmp_path / 'listed.yaml'
+    config.write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    (drop_in_dir / '10-base.yaml').write_text('from_domain: 3\nto_domain: 4\ntopics:\n  /y:\n')
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == [('/x', '/x', 1, 2)]
+    warning = logger.warn.call_args[0][0]
+    assert domain_bridge_config.SHADOWED_DROP_INS_NOTICE in warning
+    assert str(drop_in_dir / '10-base.yaml') in warning
+
+
+def test_load_domain_rules_is_quiet_when_the_drop_in_directory_is_empty(monkeypatch, tmp_path):
+    config = tmp_path / 'listed.yaml'
+    config.write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+    (tmp_path / 'domain_bridge.d').mkdir()
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == [('/x', '/x', 1, 2)]
+    logger.warn.assert_not_called()
 
 
 def test_load_domain_rules_keeps_the_configs_that_load_around_a_broken_one(monkeypatch, tmp_path):

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -1,6 +1,6 @@
-"""Unit tests for locating and parsing the domain_bridge YAML.
+"""Unit tests for locating, loading, and parsing the domain_bridge YAMLs.
 
-These exercise path resolution and the pure parser; no kmod, DDS, or file I/O
+These exercise path resolution, the loader, and the pure parser; no kmod or DDS
 is involved.
 """
 
@@ -258,12 +258,130 @@ topics:
         parse_domain_bridge_config(text)
 
 
-def test_resolve_config_path_prefers_the_env_var(monkeypatch):
+def test_resolve_config_paths_prefers_the_env_var(monkeypatch):
     monkeypatch.setenv(domain_bridge_config.CONFIG_ENV, '/somewhere/else.yaml')
-    assert domain_bridge_config.resolve_config_path() == ('/somewhere/else.yaml', True)
+    assert domain_bridge_config.resolve_config_paths() == (['/somewhere/else.yaml'], True)
 
 
-def test_resolve_config_path_falls_back_to_the_default(monkeypatch):
+def test_resolve_config_paths_splits_the_env_var_on_the_separator(monkeypatch):
+    monkeypatch.setenv(domain_bridge_config.CONFIG_ENV, '/a.yaml:/b.yaml:/c.yaml')
+    assert domain_bridge_config.resolve_config_paths() == (
+        ['/a.yaml', '/b.yaml', '/c.yaml'], True)
+
+
+def _patch_default(monkeypatch, tmp_path):
+    """Point the default path into tmp_path and return it, drop-in directory included."""
+    default = tmp_path / 'domain_bridge.yaml'
+    monkeypatch.setattr(domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(default))
+    return default
+
+
+def test_resolve_config_paths_falls_back_to_the_default(monkeypatch, tmp_path):
     monkeypatch.delenv(domain_bridge_config.CONFIG_ENV, raising=False)
-    assert domain_bridge_config.resolve_config_path() == (
-        domain_bridge_config.DEFAULT_CONFIG_PATH, False)
+    default = _patch_default(monkeypatch, tmp_path)
+    assert domain_bridge_config.resolve_config_paths() == ([str(default)], False)
+
+
+@pytest.mark.parametrize('value', [':', '::'])
+def test_resolve_config_paths_treats_an_empty_listing_as_unset(monkeypatch, tmp_path, value):
+    """A cleared or separator-only variable must not resolve to a path of ''."""
+    monkeypatch.setenv(domain_bridge_config.CONFIG_ENV, value)
+    default = _patch_default(monkeypatch, tmp_path)
+    assert domain_bridge_config.resolve_config_paths() == ([str(default)], False)
+
+
+def test_the_drop_ins_are_read_after_the_default_file(monkeypatch, tmp_path):
+    monkeypatch.delenv(domain_bridge_config.CONFIG_ENV, raising=False)
+    default = _patch_default(monkeypatch, tmp_path)
+    default.write_text('topics:\n')
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    (drop_in_dir / '10-lidar.yaml').write_text('topics:\n')
+
+    assert domain_bridge_config.resolve_config_paths() == (
+        [str(default), str(drop_in_dir / '10-lidar.yaml')], False)
+
+
+def test_the_drop_ins_are_read_in_name_order_without_the_default_file(monkeypatch, tmp_path):
+    monkeypatch.delenv(domain_bridge_config.CONFIG_ENV, raising=False)
+    _patch_default(monkeypatch, tmp_path)
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    for name in ('20-lidar.yaml', '10-base.yaml'):
+        (drop_in_dir / name).write_text('topics:\n')
+
+    paths, from_env = domain_bridge_config.resolve_config_paths()
+
+    assert paths == [str(drop_in_dir / '10-base.yaml'), str(drop_in_dir / '20-lidar.yaml')]
+    assert from_env is False
+
+
+def test_a_drop_in_that_is_not_yaml_is_ignored(monkeypatch, tmp_path):
+    monkeypatch.delenv(domain_bridge_config.CONFIG_ENV, raising=False)
+    default = _patch_default(monkeypatch, tmp_path)
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    (drop_in_dir / 'base.yaml.bak').write_text('topics:\n')
+
+    assert domain_bridge_config.resolve_config_paths() == ([str(default)], False)
+
+
+def test_the_env_var_wins_over_the_drop_in_directory(monkeypatch, tmp_path):
+    listed = tmp_path / 'listed.yaml'
+    listed.write_text('topics:\n')
+    monkeypatch.setenv(domain_bridge_config.CONFIG_ENV, str(listed))
+    _patch_default(monkeypatch, tmp_path)
+    drop_in_dir = tmp_path / 'domain_bridge.d'
+    drop_in_dir.mkdir()
+    (drop_in_dir / '10-base.yaml').write_text('topics:\n')
+
+    assert domain_bridge_config.resolve_config_paths() == ([str(listed)], True)
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+def test_load_accumulates_rules_from_every_config_in_order(tmp_path):
+    first = _write(tmp_path, 'a.yaml', 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    second = _write(tmp_path, 'b.yaml', 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n')
+
+    results = domain_bridge_config.load_domain_bridge_rules([first, second])
+
+    assert [r.path for r in results] == [first, second]
+    assert [rule for r in results for rule in r.rules] == [
+        ('/chatter', '/chatter', 1, 2), ('/image', '/image', 3, 4)]
+    assert all(r.error is None for r in results)
+
+
+def test_load_keeps_the_domain_defaults_local_to_each_config(tmp_path):
+    """Matching domain_bridge, where 'from_domain'/'to_domain' never leak between files."""
+    with_defaults = _write(
+        tmp_path, 'a.yaml', 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    without = _write(tmp_path, 'b.yaml', 'topics:\n  image:\n')
+
+    results = domain_bridge_config.load_domain_bridge_rules([with_defaults, without])
+
+    assert results[1].rules == []
+    assert results[1].skipped == ['/image']
+
+
+def test_load_reports_a_broken_config_without_dropping_the_others(tmp_path):
+    broken = _write(tmp_path, 'a.yaml', 'topics: [not, a, mapping]\n')
+    good = _write(tmp_path, 'b.yaml', 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+
+    results = domain_bridge_config.load_domain_bridge_rules([broken, good])
+
+    assert isinstance(results[0].error, ValueError)
+    assert results[0].rules == []
+    assert results[1].error is None
+    assert results[1].rules == [('/chatter', '/chatter', 1, 2)]
+
+
+def test_load_carries_a_missing_config_as_file_not_found(tmp_path):
+    """The agent logs an absent default at info and an absent listed path at warn."""
+    (result,) = domain_bridge_config.load_domain_bridge_rules([str(tmp_path / 'absent.yaml')])
+
+    assert isinstance(result.error, FileNotFoundError)

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -20,8 +20,8 @@ class FakeAddRule:
         return self._codes.get(from_name, 0)
 
 
-def _write_config(tmp_path, text):
-    path = tmp_path / 'bridge.yaml'
+def _write_config(tmp_path, text, name='bridge.yaml'):
+    path = tmp_path / name
     path.write_text(text)
     return str(path)
 
@@ -109,3 +109,27 @@ def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
     monkeypatch.setenv(CONFIG_ENV, cfg)
     assert register_domain_bridge.main([]) == 0
     assert fake.calls == [('/image', '/image', 3, 4)]
+
+
+def test_registers_the_rules_of_every_config(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    first = _write_config(
+        tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n', 'a.yaml')
+    second = _write_config(
+        tmp_path, 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n', 'b.yaml')
+
+    assert register_domain_bridge.main(['--config', first, second]) == 0
+    assert fake.calls == [('/chatter', '/chatter', 1, 2), ('/image', '/image', 3, 4)]
+
+
+def test_a_broken_config_is_reported_but_the_others_still_register(tmp_path, monkeypatch, capsys):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    broken = _write_config(tmp_path, 'topics: [not, a, mapping]\n', 'a.yaml')
+    good = _write_config(
+        tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n', 'b.yaml')
+
+    assert register_domain_bridge.main(['--config', broken, good]) == 1
+    assert fake.calls == [('/chatter', '/chatter', 1, 2)]
+    assert f'cannot load {broken}' in capsys.readouterr().err


### PR DESCRIPTION
## Description

`AGNOCAST_DOMAIN_BRIDGE_CONFIG` and `register_domain_bridge --config` now accept several `domain_bridge` YAMLs instead of one, so rules can be split per subsystem the way `domain_bridge` itself already allows (it takes several positional configs). The environment variable holds a `:`-separated list; `--config` takes several paths. Files apply in the order given: `topics` accumulate, while `from_domain` / `to_domain` stay local to the file that sets them, matching the external node's merge.

Splitting also works with no environment variable at all: every `*.yaml` in `/etc/agnocast/domain_bridge.d/` is read in name order, after `/etc/agnocast/domain_bridge.yaml` when that exists — the pairing systemd and sysctl use for a configuration file and its drop-in directory. That matters because the discovery agent is `execv`'d from an application process and so never sees a `--config` argument.

A single path keeps working unchanged, so existing deployments need no edit: the drop-in directory cannot pre-exist this change.

Unlike `domain_bridge`, which aborts the whole process on the first unreadable file, a bad config here is reported and skipped so the rest still apply: the agent cannot abort, since it is `execv`'d from an application process, and `register_domain_bridge` still exits non-zero so a boot-time misconfiguration is loud.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`colcon test` for `ros2agnocast_discovery_agent` (139 tests, all passing), covering the separator split, the empty-listing fallback, ordered accumulation across files, per-file domain defaults, and a broken config being skipped while its neighbours apply.

## Notes for reviewers

The `--config` default is still resolved from the environment, so the agent and the registration tool read the same list.

#1626 marks rule *registration* unsupported, but the discovery agent reads the same configs to force the A2R bridge the external `domain_bridge` node needs, which stays supported. That is the half this change is for.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
https://github.com/autowarefoundation/agnocast_doc/pull/58

## Version Update Label (Required)

`need-patch-update`



