### PR TITLE
fix(agnocast_kmod): retain entries for the deepest subscriber

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -9,6 +9,12 @@
 #define MAX_TOPIC_LOCAL_ID 4096  // Bitmap size for per-entry subscriber reference tracking
 #define MAX_SUBSCRIBER_NUM \
   (MAX_TOPIC_LOCAL_ID - MAX_PUBLISHER_NUM)  // Maximum number of subscribers per topic
+/* Maximum subscriber qos_depth; a deeper request is refused. A subscriber's depth decides how long
+ * its publishers must hold entries open, so it spends memory in another process's mempool. The
+ * bound is well above what exists in practice -- the deepest subscriber in Autoware is 100
+ * (autoware_pointcloud_preprocessor's twist and odom), and 1000 across the whole tree -- so a
+ * request over it is a bug worth surfacing rather than silently narrowing. */
+#define MAX_QOS_DEPTH 4096
 /* Maximum number of entries that can be received at one ioctl. This value is heuristically set to
  * balance the number of calling ioctl and the overhead of copying data between user and kernel
  * space. */

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -988,19 +988,41 @@ unlock:
   return ret;
 }
 
+// A subscriber has no cache of its own: its qos_depth is a window onto the publisher's entries, so
+// an entry released once the publisher's depth is met is gone for every subscriber that had not
+// read it yet.
+//
+// Caller holds global_htables_rwsem (read), which excludes subscriber join and leave, and
+// wrapper->topic->rwsem (write).
+static uint32_t retention_depth(
+  struct topic_wrapper * wrapper, const struct publisher_info * pub_info)
+{
+  uint32_t depth = pub_info->qos_depth;
+
+  struct subscriber_info * sub_info;
+  int bkt_sub_info;
+  hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
+  {
+    if (sub_info->qos_depth > depth) depth = sub_info->qos_depth;
+  }
+
+  return depth;
+}
+
 static int release_msgs_to_meet_depth(
   struct topic_wrapper * wrapper, struct publisher_info * pub_info,
   union ioctl_publish_msg_args * ioctl_ret)
 {
   ioctl_ret->ret_released_num = 0;
 
-  if (pub_info->entries_num <= pub_info->qos_depth) {
+  const uint32_t depth = retention_depth(wrapper, pub_info);
+
+  if (pub_info->entries_num <= depth) {
     return 0;
   }
 
-  const uint32_t leak_warn_threshold = (pub_info->qos_depth <= 100)
-                                         ? 100 + pub_info->qos_depth
-                                         : pub_info->qos_depth * 2;  // This is rough value.
+  const uint32_t leak_warn_threshold =
+    (depth <= 100) ? 100 + depth : depth * 2;  // This is rough value.
   if (pub_info->entries_num > leak_warn_threshold) {
     dev_warn(
       agnocast_device,
@@ -1020,8 +1042,8 @@ static int release_msgs_to_meet_depth(
     return -ENODATA;
   }
 
-  // Number of entries exceeding qos_depth
-  uint32_t num_search_entries = pub_info->entries_num - pub_info->qos_depth;
+  // Number of entries exceeding the retention depth
+  uint32_t num_search_entries = pub_info->entries_num - depth;
 
   // NOTE:
   //   The searched message is either deleted or, if a reference count remains, is not deleted.
@@ -1030,10 +1052,8 @@ static int release_msgs_to_meet_depth(
   //
   // HACK:
   //   The current implementation only releases a maximum of MAX_RELEASE_NUM messages at a time, and
-  //   if there are more messages to release, qos_depth is temporarily not met.
-  //   However, it is rare for more than MAX_RELEASE_NUM messages that are out of qos_depth to be
-  //   unreferenced at a specific time. If this happens, as long as the publisher's qos_depth is
-  //   greater than the subscriber's qos_depth, this has little effect on system behavior.
+  //   if there are more messages to release, the retention depth is temporarily exceeded. That
+  //   costs memory only: what a subscriber is handed is bounded by its own window either way.
   while (num_search_entries > 0 && ioctl_ret->ret_released_num < MAX_RELEASE_NUM) {
     struct entry_node * en = container_of(node, struct entry_node, node);
     node = rb_next(node);
@@ -1064,8 +1084,8 @@ static int release_msgs_to_meet_depth(
     dev_dbg(
       agnocast_device,
       "Release oldest message in the publisher_info (id=$%d) of the topic "
-      "(topic_name=%s) with qos_depth=%d. (%s)\n",
-      pub_info->id, wrapper->key, pub_info->qos_depth, __func__);
+      "(topic_name=%s) with retention depth=%d. (%s)\n",
+      pub_info->id, wrapper->key, depth, __func__);
   }
 
   return 0;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -129,6 +129,19 @@ static bool domain_delivery_allowed(
   return false;
 }
 
+// Whether pub_info's publications reach sub_info at all. What a publish retains and whom it
+// signals both have to agree with what receive and take will hand over, so the three ask it here
+// rather than each spelling out the same pair of conditions.
+static bool sub_can_receive_from(
+  const struct topic_struct * topic, const struct publisher_info * pub_info,
+  const struct subscriber_info * sub_info)
+{
+  if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) return false;
+
+  return domain_delivery_allowed(
+    topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id, sub_info->is_bridge);
+}
+
 static int add_topic(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id,
   struct topic_wrapper ** wrapper)
@@ -285,11 +298,7 @@ static void rebuild_notify_list(struct topic_wrapper * wrapper, struct publisher
   {
     // NULL exactly for take subs, which poll instead of being woken.
     if (!sub_info->notify_ctx) continue;
-    if (!domain_delivery_allowed(
-          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
-          sub_info->is_bridge))
-      continue;
-    if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
+    if (!sub_can_receive_from(wrapper->topic, pub_info, sub_info)) continue;
 
     if (WARN_ON_ONCE(notify_num == pub_info->notify_capacity)) break;
     pub_info->notify_ctxs[notify_num++] = sub_info->notify_ctx;
@@ -335,6 +344,16 @@ static int insert_subscriber_info(
 {
   // rebuild_notify_list() skips take subs by testing notify_ctx alone, so the two must agree.
   WARN_ON_ONCE(is_take_sub != (notify_ctx == NULL));
+
+  if (qos_depth > MAX_QOS_DEPTH) {
+    dev_warn(
+      agnocast_device,
+      "Subscriber qos_depth (%u) for the topic (topic_name=%s) exceeds the upper "
+      "bound (MAX_QOS_DEPTH=%d), so no new subscriber can be "
+      "added. (%s)\n",
+      qos_depth, wrapper->key, MAX_QOS_DEPTH, __func__);
+    return -EINVAL;
+  }
 
   int count = agnocast_get_size_sub_info_htable(wrapper);
   if (count == MAX_SUBSCRIBER_NUM) {
@@ -988,22 +1007,33 @@ unlock:
   return ret;
 }
 
-// A subscriber has no cache of its own: its qos_depth is a window onto the publisher's entries, so
-// an entry released once the publisher's depth is met is gone for every subscriber that had not
-// read it yet.
+// sub_info_htable is shared by the two domains a bridge rule pairs, so only a subscriber this
+// publisher can reach counts. And what one needs is its lag, not its declared depth: nothing at or
+// below latest_received_entry_id is handed over again, since receive_msg_core() starts one past it
+// and take_msg breaks below it. The lag counts the topic's entries while the depth bounds this
+// publisher's, so it over-estimates on a multi-publisher topic -- the safe direction.
 //
 // Caller holds global_htables_rwsem (read), which excludes subscriber join and leave, and
-// wrapper->topic->rwsem (write).
+// wrapper->topic->rwsem (write), which excludes the receive and take that advance
+// latest_received_entry_id.
 static uint32_t retention_depth(
   struct topic_wrapper * wrapper, const struct publisher_info * pub_info)
 {
   uint32_t depth = pub_info->qos_depth;
+  const int64_t newest_entry_id = wrapper->topic->current_entry_id - 1;
 
   struct subscriber_info * sub_info;
   int bkt_sub_info;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
-    if (sub_info->qos_depth > depth) depth = sub_info->qos_depth;
+    if (!sub_can_receive_from(wrapper->topic, pub_info, sub_info)) continue;
+
+    const int64_t lag = newest_entry_id - sub_info->latest_received_entry_id;
+    if (lag <= 0) continue;
+
+    const uint32_t wanted =
+      (lag < (int64_t)sub_info->qos_depth) ? (uint32_t)lag : sub_info->qos_depth;
+    if (wanted > depth) depth = wanted;
   }
 
   return depth;
@@ -1189,13 +1219,7 @@ static int is_entry_deliverable(
     return 0;
   }
 
-  if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
-    return 0;
-  }
-
-  return domain_delivery_allowed(
-    wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
-    sub_info->is_bridge);
+  return sub_can_receive_from(wrapper->topic, pub_info, sub_info);
 }
 
 static int receive_msg_core(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -98,3 +98,39 @@ void test_case_error_subscriber_not_found(struct kunit * test)
 
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
 }
+
+// Refused rather than narrowed: agnocastlib turns the failure into an RCLCPP_ERROR and exits, so
+// the depth the subscriber asked for is never silently different from the one it gets.
+void test_case_qos_depth_above_max_is_rejected(struct kunit * test)
+{
+  union ioctl_add_subscriber_args add_sub_args;
+
+  setup_process(test, SUBSCRIBER_PID);
+
+  int ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, MAX_QOS_DEPTH + 1, false, true,
+    false, false, IS_BRIDGE, -1, &add_sub_args);
+
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+// The bound itself is honored as asked, so the check cannot be off by one.
+void test_case_qos_depth_at_max_is_kept(struct kunit * test)
+{
+  union ioctl_add_subscriber_args add_sub_args;
+  struct ioctl_get_subscriber_qos_args get_qos_args;
+  int ret;
+
+  setup_process(test, SUBSCRIBER_PID);
+
+  ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, MAX_QOS_DEPTH, false, true,
+    false, false, IS_BRIDGE, -1, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  ret = agnocast_ioctl_get_subscriber_qos(
+    TOPIC_NAME, current->nsproxy->ipc_ns, add_sub_args.ret_id, &get_qos_args);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, get_qos_args.ret_depth, MAX_QOS_DEPTH);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.h
@@ -6,7 +6,9 @@
   KUNIT_CASE(test_case_qos_volatile_best_effort), KUNIT_CASE(test_case_qos_volatile_reliable),     \
     KUNIT_CASE(test_case_qos_transient_best_effort), KUNIT_CASE(test_case_qos_transient_reliable), \
     KUNIT_CASE(test_case_sub_error_topic_not_found),                                               \
-    KUNIT_CASE(test_case_error_subscriber_not_found)
+    KUNIT_CASE(test_case_error_subscriber_not_found),                                              \
+    KUNIT_CASE(test_case_qos_depth_above_max_is_rejected),                                         \
+    KUNIT_CASE(test_case_qos_depth_at_max_is_kept)
 
 void test_case_qos_volatile_best_effort(struct kunit * test);
 void test_case_qos_volatile_reliable(struct kunit * test);
@@ -15,3 +17,6 @@ void test_case_qos_transient_reliable(struct kunit * test);
 
 void test_case_sub_error_topic_not_found(struct kunit * test);
 void test_case_error_subscriber_not_found(struct kunit * test);
+
+void test_case_qos_depth_above_max_is_rejected(struct kunit * test);
+void test_case_qos_depth_at_max_is_kept(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -8,6 +8,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+#define KUNIT_PUB_SHM_BUF_SIZE 4
+
 static char * topic_name = "/kunit_test_topic";
 static char * node_name = "/kunit_test_node";
 static uint32_t qos_depth = 1;
@@ -69,8 +71,25 @@ static topic_local_id_t setup_one_subscriber_with_eventfd(
     test, 0, is_bridge, eventfd, ignore_local_publications);
 }
 
-static topic_local_id_t setup_one_subscriber_with_qos_depth(
-  struct kunit * test, const uint32_t sub_qos_depth)
+// Joins an already registered process, so that a case can put the subscriber in the publisher's.
+static topic_local_id_t add_subscriber_with_qos_depth(
+  struct kunit * test, const pid_t pid, const uint32_t sub_qos_depth,
+  const bool ignore_local_publications, const bool sub_is_bridge)
+{
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      topic_name, current->nsproxy->ipc_ns, node_name, pid, sub_qos_depth, qos_is_transient_local,
+      qos_is_reliable, is_take_sub, ignore_local_publications, sub_is_bridge, -1,
+      &add_subscriber_args),
+    0);
+  return add_subscriber_args.ret_id;
+}
+
+static topic_local_id_t setup_subscriber_with_qos_depth_in_domain(
+  struct kunit * test, const uint32_t domain_id, const bool sub_is_bridge,
+  const uint32_t sub_qos_depth)
 {
   subscriber_pid++;
 
@@ -78,18 +97,16 @@ static topic_local_id_t setup_one_subscriber_with_qos_depth(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, domain_id,
+      &add_process_args),
     0);
+  return add_subscriber_with_qos_depth(test, subscriber_pid, sub_qos_depth, false, sub_is_bridge);
+}
 
-  union ioctl_add_subscriber_args add_subscriber_args;
-  KUNIT_ASSERT_EQ(
-    test,
-    agnocast_ioctl_add_subscriber(
-      topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, sub_qos_depth,
-      qos_is_transient_local, qos_is_reliable, is_take_sub, false, is_bridge, -1,
-      &add_subscriber_args),
-    0);
-  return add_subscriber_args.ret_id;
+static topic_local_id_t setup_one_subscriber_with_qos_depth(
+  struct kunit * test, const uint32_t sub_qos_depth)
+{
+  return setup_subscriber_with_qos_depth_in_domain(test, 0, is_bridge, sub_qos_depth);
 }
 
 static void publish_n(
@@ -912,4 +929,126 @@ void test_case_publish_msg_deepest_subscriber_sets_retention(struct kunit * test
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 4);
+}
+
+// The two cases below are the reason retention_depth() filters: sub_info_htable holds subscribers
+// this publisher can never reach, and their depth must not hold its entries open.
+void test_case_publish_msg_ignores_depth_of_ignore_local_subscriber(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1, and the depth-3 subscriber sits in its process and
+  // ignores it, so retention stays at 1.
+  common_pid++;
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, common_pid, 0, is_bridge, &publisher_id, &ret_addr);
+  add_subscriber_with_qos_depth(test, common_pid, 3, true, is_bridge);
+  publish_n(test, publisher_id, ret_addr, 2);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 2, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 1);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
+}
+
+void test_case_publish_msg_ignores_depth_of_other_domain_subscriber(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1. The two cells share one sub_info_htable, but a bridge
+  // endpoint never crosses domains, so the depth-3 subscriber in domain 2 is unreachable from it.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, current->tgid, 1, is_bridge, &publisher_id, &ret_addr);
+  setup_subscriber_with_qos_depth_in_domain(test, 2, true, 3);
+  publish_n(test, publisher_id, ret_addr, 2);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 2, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 1);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
+}
+
+// The depth a subscriber declares is what it may fall behind by, not a standing reservation: a
+// subscriber that keeps up costs the publisher nothing however deep it is declared.
+void test_case_publish_msg_caught_up_deep_subscriber_keeps_no_entries(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1, the subscriber's is 100.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  const topic_local_id_t subscriber_id = setup_one_subscriber_with_qos_depth(test, 100);
+
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+  for (int i = 0; i < 5; i++) {
+    union ioctl_publish_msg_args ioctl_publish_msg_ret;
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_publish_msg(
+        topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret),
+      0);
+
+    // Drain, so the subscriber never lags by more than the one entry just published.
+    union ioctl_receive_msg_args ioctl_receive_msg_ret;
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_receive_msg(
+        topic_name, current->nsproxy->ipc_ns, subscriber_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+        &ioctl_receive_msg_ret),
+      0);
+    KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
+
+    // Standing in for the userland free: a still-referenced entry is skipped by the release loop
+    // whatever the retention depth says, which would mask the assert below.
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_release_message_entry_reference(
+        topic_name, current->nsproxy->ipc_ns, subscriber_id,
+        ioctl_receive_msg_ret.ret_entry_ids[0]),
+      0);
+  }
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 5, &ioctl_publish_msg_ret);
+
+  // Assert: retention fell back to the publisher's own depth, not the subscriber's 100.
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
+}
+
+// The same subscriber, not draining, is the case the deeper retention exists for.
+void test_case_publish_msg_lagging_deep_subscriber_keeps_entries(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1, the subscriber's is 100, and it never receives.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  setup_one_subscriber_with_qos_depth(test, 100);
+  publish_n(test, publisher_id, ret_addr, 5);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 5, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 6);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -69,6 +69,42 @@ static topic_local_id_t setup_one_subscriber_with_eventfd(
     test, 0, is_bridge, eventfd, ignore_local_publications);
 }
 
+static topic_local_id_t setup_one_subscriber_with_qos_depth(
+  struct kunit * test, const uint32_t sub_qos_depth)
+{
+  subscriber_pid++;
+
+  union ioctl_add_process_args add_process_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      subscriber_pid, current->nsproxy->ipc_ns, PROCESS_ROLE_APPLICATION, 0, &add_process_args),
+    0);
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, sub_qos_depth,
+      qos_is_transient_local, qos_is_reliable, is_take_sub, false, is_bridge, -1,
+      &add_subscriber_args),
+    0);
+  return add_subscriber_args.ret_id;
+}
+
+static void publish_n(
+  struct kunit * test, const topic_local_id_t publisher_id, const uint64_t ret_addr, const int n)
+{
+  for (int i = 0; i < n; i++) {
+    union ioctl_publish_msg_args ioctl_publish_msg_ret;
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_publish_msg(
+        topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret),
+      0);
+  }
+}
+
 static void setup_publisher_in_domain(
   struct kunit * test, const pid_t pid, const uint32_t domain_id, const bool pub_is_bridge,
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
@@ -787,4 +823,93 @@ void test_case_publish_msg_bridge_subscriber_in_own_domain_notified(struct kunit
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+}
+
+void test_case_publish_msg_deeper_subscriber_keeps_entries(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  setup_one_subscriber_with_qos_depth(test, 3);
+  publish_n(test, publisher_id, ret_addr, 2);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 2, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 3);
+}
+
+void test_case_publish_msg_releases_beyond_deepest_subscriber(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  setup_one_subscriber_with_qos_depth(test, 3);
+  publish_n(test, publisher_id, ret_addr, 3);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 3, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 1);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_addrs[0], ret_addr);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 3);
+}
+
+void test_case_publish_msg_falls_back_to_publisher_depth_after_subscriber_leaves(
+  struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  const topic_local_id_t subscriber_id = setup_one_subscriber_with_qos_depth(test, 3);
+  publish_n(test, publisher_id, ret_addr, 3);
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_subscriber(topic_name, current->nsproxy->ipc_ns, subscriber_id), 0);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 3, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 3);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
+}
+
+void test_case_publish_msg_deepest_subscriber_sets_retention(struct kunit * test)
+{
+  // Arrange: the publisher qos_depth is 1.
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+  setup_one_subscriber_with_qos_depth(test, 2);
+  setup_one_subscriber_with_qos_depth(test, 4);
+  publish_n(test, publisher_id, ret_addr, 3);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 3, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 4);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -28,7 +28,11 @@
     KUNIT_CASE(test_case_publish_msg_deeper_subscriber_keeps_entries),                        \
     KUNIT_CASE(test_case_publish_msg_releases_beyond_deepest_subscriber),                     \
     KUNIT_CASE(test_case_publish_msg_falls_back_to_publisher_depth_after_subscriber_leaves),  \
-    KUNIT_CASE(test_case_publish_msg_deepest_subscriber_sets_retention)
+    KUNIT_CASE(test_case_publish_msg_deepest_subscriber_sets_retention),                      \
+    KUNIT_CASE(test_case_publish_msg_ignores_depth_of_ignore_local_subscriber),               \
+    KUNIT_CASE(test_case_publish_msg_ignores_depth_of_other_domain_subscriber),               \
+    KUNIT_CASE(test_case_publish_msg_caught_up_deep_subscriber_keeps_no_entries),             \
+    KUNIT_CASE(test_case_publish_msg_lagging_deep_subscriber_keeps_entries)
 
 void test_case_publish_msg_no_topic(struct kunit * test);
 void test_case_publish_msg_no_publisher(struct kunit * test);
@@ -58,3 +62,7 @@ void test_case_publish_msg_releases_beyond_deepest_subscriber(struct kunit * tes
 void test_case_publish_msg_falls_back_to_publisher_depth_after_subscriber_leaves(
   struct kunit * test);
 void test_case_publish_msg_deepest_subscriber_sets_retention(struct kunit * test);
+void test_case_publish_msg_ignores_depth_of_ignore_local_subscriber(struct kunit * test);
+void test_case_publish_msg_ignores_depth_of_other_domain_subscriber(struct kunit * test);
+void test_case_publish_msg_caught_up_deep_subscriber_keeps_no_entries(struct kunit * test);
+void test_case_publish_msg_lagging_deep_subscriber_keeps_entries(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -24,7 +24,11 @@
     KUNIT_CASE(test_case_publish_msg_no_process),                                             \
     KUNIT_CASE(test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified),         \
     KUNIT_CASE(test_case_publish_msg_bridge_publisher_does_not_notify_other_domain),          \
-    KUNIT_CASE(test_case_publish_msg_bridge_subscriber_in_own_domain_notified)
+    KUNIT_CASE(test_case_publish_msg_bridge_subscriber_in_own_domain_notified),               \
+    KUNIT_CASE(test_case_publish_msg_deeper_subscriber_keeps_entries),                        \
+    KUNIT_CASE(test_case_publish_msg_releases_beyond_deepest_subscriber),                     \
+    KUNIT_CASE(test_case_publish_msg_falls_back_to_publisher_depth_after_subscriber_leaves),  \
+    KUNIT_CASE(test_case_publish_msg_deepest_subscriber_sets_retention)
 
 void test_case_publish_msg_no_topic(struct kunit * test);
 void test_case_publish_msg_no_publisher(struct kunit * test);
@@ -49,3 +53,8 @@ void test_case_publish_msg_no_process(struct kunit * test);
 void test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified(struct kunit * test);
 void test_case_publish_msg_bridge_publisher_does_not_notify_other_domain(struct kunit * test);
 void test_case_publish_msg_bridge_subscriber_in_own_domain_notified(struct kunit * test);
+void test_case_publish_msg_deeper_subscriber_keeps_entries(struct kunit * test);
+void test_case_publish_msg_releases_beyond_deepest_subscriber(struct kunit * test);
+void test_case_publish_msg_falls_back_to_publisher_depth_after_subscriber_leaves(
+  struct kunit * test);
+void test_case_publish_msg_deepest_subscriber_sets_retention(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -1188,3 +1188,52 @@ void test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing(struct
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_num, 0);
 }
+
+void test_case_take_msg_drains_every_entry_when_sub_qos_depth_exceeds_pub_qos_depth(
+  struct kunit * test)
+{
+  // Arrange
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  const pid_t publisher_pid = 1000;
+  setup_one_publisher(test, publisher_pid, 1, false, &publisher_id, &ret_addr);
+  topic_local_id_t subscriber_id;
+  const pid_t subscriber_pid = 2000;
+  setup_one_subscriber(test, subscriber_pid, 3, false, &subscriber_id);
+
+  int64_t entry_ids[3];
+  for (int i = 0; i < 3; i++) {
+    union ioctl_publish_msg_args ioctl_publish_msg_ret;
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_publish_msg(
+        TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret),
+      0);
+    entry_ids[i] = ioctl_publish_msg_ret.ret_entry_id;
+  }
+
+  const bool allow_same_message = false;
+
+  // Act & Assert
+  for (int i = 0; i < 3; i++) {
+    union ioctl_take_msg_args ioctl_take_msg_ret;
+    struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+    KUNIT_EXPECT_EQ(
+      test,
+      agnocast_ioctl_take_msg(
+        TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, allow_same_message, pub_shm_infos,
+        KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret),
+      0);
+    KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, entry_ids[i]);
+  }
+
+  union ioctl_take_msg_args ioctl_take_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_ioctl_take_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, allow_same_message, pub_shm_infos,
+      KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret),
+    0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -32,7 +32,8 @@
     KUNIT_CASE(test_case_take_msg_ignore_local_same_pid_enabled),                                 \
     KUNIT_CASE(test_case_take_msg_ignore_local_same_pid_disabled),                                \
     KUNIT_CASE(test_case_take_msg_bridge_subscriber_in_other_domain_takes_nothing),               \
-    KUNIT_CASE(test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing)
+    KUNIT_CASE(test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing),             \
+    KUNIT_CASE(test_case_take_msg_drains_every_entry_when_sub_qos_depth_exceeds_pub_qos_depth)
 
 void test_case_take_msg_no_topic(struct kunit * test);
 void test_case_take_msg_no_subscriber(struct kunit * test);
@@ -66,3 +67,5 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test);
 void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test);
 void test_case_take_msg_bridge_subscriber_in_other_domain_takes_nothing(struct kunit * test);
 void test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing(struct kunit * test);
+void test_case_take_msg_drains_every_entry_when_sub_qos_depth_exceeds_pub_qos_depth(
+  struct kunit * test);


### PR DESCRIPTION
## Description

`release_msgs_to_meet_depth()` bounded retention by the publisher's `qos_depth` alone, making the effective queue `min(pub depth, sub depth)`. DDS holds the two separately and History is not an RxO policy, so `pub 10 / sub 100` is intended: with 30 messages published, ROS 2 hands back 30 and Agnocast 10. `autoware_pointcloud_preprocessor` needs exactly this, taking twist and odom at depth 100 against publishers at 10. The take side already walks back `sub_info->qos_depth`, so only retention changed.

Retention now covers the deepest subscriber, under two bounds:

- **Reachability.** `sub_info_htable` is shared by the two domain cells a bridge rule pairs, so it holds subscribers a publisher can never deliver to. `sub_can_receive_from()` extracts the conditions `rebuild_notify_list()` and `is_entry_deliverable()` already shared, and `retention_depth()` asks it too.
- **Lag, not declared depth.** Nothing at or below `latest_received_entry_id` is handed over again, so a subscriber that keeps up costs nothing however deep it is declared.

`MAX_QOS_DEPTH` (4096) clamps the stored subscriber depth, which now spends memory in another process's mempool. The deepest subscriber in Autoware is 100, and 1000 across the whole tree.

## Related links

- <https://github.com/autowarefoundation/autoware_core/pull/1443>

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`make all` and `make test` build clean under `-Wall -Werror`, and the KUnit suite passes.

New cases: the deepest subscriber sets retention (5), the lag bound (2), reachability (2), the clamp (2).

## Notes for reviewers

`retention_depth()` scans `sub_info_htable` on every publish, safe under the `global_htables_rwsem` read that publish holds. Caching the maximum was the alternative, but the lag bound moves it on every receive.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` -- no ioctl command, struct, or shared data structure changes, so kmod/agnocastlib compatibility is unaffected.
