### PR TITLE
refactor(agnocast_cie_thread_configurator): hold scheduling attributes in a SchedAttrs value type

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast_cie_thread_configurator/sched_policy.hpp"
 #include "yaml-cpp/yaml.h"
 
 #include <cstdint>
@@ -12,6 +13,26 @@
 namespace agnocast_cie_thread_configurator
 {
 
+struct DeadlineParams
+{
+  uint64_t runtime = 0;  // nsec
+  uint64_t period = 0;
+  uint64_t deadline = 0;
+};
+
+// Only the knobs of the policy's class are meaningful, namely nice for
+// OTHER/BATCH/IDLE, rt_priority for FIFO/RR and deadline for DEADLINE; the
+// parser leaves the others at their defaults. affinity is independent of the
+// policy.
+struct SchedAttrs
+{
+  std::optional<SchedPolicy> policy;  // nullopt only for an affinity-only kernel_threads entry
+  int nice = 0;                       // -20..19
+  int rt_priority = 0;                // 1..99
+  DeadlineParams deadline;
+  std::vector<int> affinity;  // sorted, deduplicated; empty = do not manage
+};
+
 // A single thread's scheduling configuration as parsed from the YAML and
 // observed at runtime. Owned by ThreadConfiguratorNode in two vectors.
 struct ThreadConfig
@@ -19,15 +40,7 @@ struct ThreadConfig
   std::string thread_str;  // callback_group_id or thread_name
   size_t domain_id = 0;
   int64_t thread_id = -1;  // -1 until announced by the target application
-  std::vector<int> affinity;
-  std::string policy;
-  int nice = 0;      // SCHED_OTHER/BATCH/IDLE only (-20..19)
-  int priority = 0;  // rt_priority; SCHED_FIFO/RR only (1..99)
-
-  // SCHED_DEADLINE only
-  unsigned int runtime = 0;
-  unsigned int period = 0;
-  unsigned int deadline = 0;
+  SchedAttrs attrs;        // attrs.policy is always set since the parser requires 'policy'
 
   // Full incoming callback_group_id -> last announced tid; wildcard
   // ("<node name>/*") entries only. For such entries `applied` means "at least
@@ -53,20 +66,12 @@ std::string extract_node_part(const std::string & callback_group_id);
 inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
 
 // Desired attributes for every kernel thread whose comm matches at apply
-// time (comms are not unique, e.g. an nfsd pool). Unset fields (YAML null,
-// absent key, or UNMANAGEABLE) are never applied.
+// time (comms are not unique, e.g. an nfsd pool). Unset attributes (YAML
+// null, absent key, or UNMANAGEABLE) are never applied.
 struct KernelThreadConfig
 {
   std::string comm;
-  std::optional<std::string> policy;
-  int nice = 0;               // SCHED_OTHER/BATCH/IDLE only (-20..19)
-  int priority = 0;           // rt_priority; SCHED_FIFO/RR only (1..99)
-  std::vector<int> affinity;  // empty = leave alone
-
-  // SCHED_DEADLINE only
-  unsigned int runtime = 0;
-  unsigned int period = 0;
-  unsigned int deadline = 0;
+  SchedAttrs attrs;
 
   bool is_managed() const noexcept;
 };

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -22,6 +22,7 @@ class ThreadConfiguratorNode : public rclcpp::Node
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
   using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
   using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
+  using SchedAttrs = agnocast_cie_thread_configurator::SchedAttrs;
   using SchedPolicy = agnocast_cie_thread_configurator::SchedPolicy;
 
   // Concurrency:
@@ -61,8 +62,8 @@ private:
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
   // thread_id is passed explicitly because a wildcard entry applies to many
-  // threads (one per matched_tids element), not just config.thread_id.
-  bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
+  // threads (one per matched_tids element). attrs.policy must be set.
+  bool issue_syscalls(const std::string & thread_str, const SchedAttrs & attrs, int64_t thread_id);
   // Only Deadline takes the cgroup-based affinity path; any other value,
   // including nullopt (an observed policy with no YAML name), uses
   // sched_setaffinity.

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -47,13 +47,13 @@ constexpr int k_rt_priority_max = 99;
 // parse_rt_priority is the mirror image for SCHED_FIFO/SCHED_RR. `entry_desc`
 // is the "id=..."/"name=..." fragment used in messages.
 int parse_nice(
-  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc,
+  const YAML::Node & entry, SchedPolicy policy, const std::string & entry_desc,
   bool allow_unmanageable)
 {
   const YAML::Node nice = entry["nice"];
   if (is_unset(nice, allow_unmanageable)) {
     throw std::runtime_error(
-      "Policy '" + policy + "' requires 'nice' for " + entry_desc +
+      "Policy '" + std::string(to_string(policy)) + "' requires 'nice' for " + entry_desc +
       (is_unmanageable_sentinel(nice) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
   int value = 0;
@@ -73,13 +73,13 @@ int parse_nice(
 }
 
 int parse_rt_priority(
-  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc,
+  const YAML::Node & entry, SchedPolicy policy, const std::string & entry_desc,
   bool allow_unmanageable)
 {
   const YAML::Node priority = entry["priority"];
   if (is_unset(priority, allow_unmanageable)) {
     throw std::runtime_error(
-      "Policy '" + policy + "' requires 'priority' for " + entry_desc +
+      "Policy '" + std::string(to_string(policy)) + "' requires 'priority' for " + entry_desc +
       (is_unmanageable_sentinel(priority) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
   int value = 0;
@@ -120,10 +120,10 @@ std::optional<T> as_base10(const YAML::Node & node)
   return value;
 }
 
-unsigned int parse_deadline_field(
+uint64_t parse_deadline_field(
   const YAML::Node & entry, const char * key, const std::string & entry_desc)
 {
-  const auto value = as_base10<unsigned int>(entry[key]);
+  const auto value = as_base10<uint64_t>(entry[key]);
   if (!value) {
     throw std::runtime_error(
       "'" + std::string(key) + "' must be a non-negative decimal integer for " + entry_desc);
@@ -242,19 +242,19 @@ void parse_yaml(
       }
     }
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
-    cfg.affinity = parse_affinity(cg, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
-    cfg.policy = cg["policy"].as<std::string>();
-    const SchedPolicy policy = parse_policy_or_throw(cfg.policy, "id=" + cfg.thread_str);
+    cfg.attrs.affinity = parse_affinity(cg, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+    const SchedPolicy policy =
+      parse_policy_or_throw(cg["policy"].as<std::string>(), "id=" + cfg.thread_str);
+    cfg.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      cfg.runtime = cg["runtime"].as<unsigned int>();
-      cfg.period = cg["period"].as<unsigned int>();
-      cfg.deadline = cg["deadline"].as<unsigned int>();
+      cfg.attrs.deadline = DeadlineParams{
+        cg["runtime"].as<uint64_t>(), cg["period"].as<uint64_t>(), cg["deadline"].as<uint64_t>()};
     } else if (is_cfs(policy)) {
-      cfg.nice = parse_nice(cg, cfg.policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      cfg.attrs.nice = parse_nice(cg, policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
-      cfg.priority =
-        parse_rt_priority(cg, cfg.policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      cfg.attrs.rt_priority =
+        parse_rt_priority(cg, policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     }
   }
 
@@ -263,20 +263,22 @@ void parse_yaml(
     auto & cfg = non_ros_threads_out[i];
 
     cfg.thread_str = nrt["name"].as<std::string>();
-    cfg.affinity = parse_affinity(nrt, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
-    cfg.policy = nrt["policy"].as<std::string>();
-    const SchedPolicy policy = parse_policy_or_throw(cfg.policy, "name=" + cfg.thread_str);
+    cfg.attrs.affinity =
+      parse_affinity(nrt, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+    const SchedPolicy policy =
+      parse_policy_or_throw(nrt["policy"].as<std::string>(), "name=" + cfg.thread_str);
+    cfg.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      cfg.runtime = nrt["runtime"].as<unsigned int>();
-      cfg.period = nrt["period"].as<unsigned int>();
-      cfg.deadline = nrt["deadline"].as<unsigned int>();
+      cfg.attrs.deadline = DeadlineParams{
+        nrt["runtime"].as<uint64_t>(), nrt["period"].as<uint64_t>(),
+        nrt["deadline"].as<uint64_t>()};
     } else if (is_cfs(policy)) {
-      cfg.nice =
-        parse_nice(nrt, cfg.policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      cfg.attrs.nice =
+        parse_nice(nrt, policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
-      cfg.priority =
-        parse_rt_priority(nrt, cfg.policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      cfg.attrs.rt_priority =
+        parse_rt_priority(nrt, policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     }
   }
 
@@ -304,7 +306,7 @@ void parse_yaml(
 
 bool KernelThreadConfig::is_managed() const noexcept
 {
-  return policy.has_value() || !affinity.empty();
+  return attrs.policy.has_value() || !attrs.affinity.empty();
 }
 
 bool IrqConfig::is_managed() const noexcept
@@ -349,7 +351,7 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
         "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
         "be matched reliably");
     }
-    cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
+    cfg.attrs.affinity = parse_affinity(kt, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
 
     if (is_unset(kt["policy"], /*allow_unmanageable=*/true)) {
       // Any policy-dependent field without 'policy' would otherwise be
@@ -364,12 +366,14 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
       continue;
     }
 
+    std::string policy_str;
     try {
-      cfg.policy = kt["policy"].as<std::string>();
+      policy_str = kt["policy"].as<std::string>();
     } catch (const YAML::Exception &) {
       throw std::runtime_error("'policy' must be a string for comm=" + cfg.comm);
     }
-    const SchedPolicy policy = parse_policy_or_throw(*cfg.policy, "comm=" + cfg.comm);
+    const SchedPolicy policy = parse_policy_or_throw(policy_str, "comm=" + cfg.comm);
+    cfg.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
       // Explicit check for a clear message: these fields are always
@@ -381,14 +385,15 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
         throw std::runtime_error(
           "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
       }
-      cfg.runtime = parse_deadline_field(kt, "runtime", "comm=" + cfg.comm);
-      cfg.period = parse_deadline_field(kt, "period", "comm=" + cfg.comm);
-      cfg.deadline = parse_deadline_field(kt, "deadline", "comm=" + cfg.comm);
+      cfg.attrs.deadline = DeadlineParams{
+        parse_deadline_field(kt, "runtime", "comm=" + cfg.comm),
+        parse_deadline_field(kt, "period", "comm=" + cfg.comm),
+        parse_deadline_field(kt, "deadline", "comm=" + cfg.comm)};
     } else if (is_cfs(policy)) {
-      cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
+      cfg.attrs.nice = parse_nice(kt, policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
     } else {
-      cfg.priority =
-        parse_rt_priority(kt, *cfg.policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
+      cfg.attrs.rt_priority =
+        parse_rt_priority(kt, policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
     }
   }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -57,25 +57,22 @@ bool kernel_thread_in_sync(
   const agnocast_cie_thread_configurator::KernelThreadConfig & config,
   const agnocast_cie_thread_configurator::KernelThreadInfo & info)
 {
-  if (config.policy.has_value()) {
-    const auto policy = parse_sched_policy(*config.policy);
-    if (!policy || *policy == SchedPolicy::Deadline) {
-      return false;
-    }
-    if (*config.policy != info.policy) {
+  const auto & attrs = config.attrs;
+  if (attrs.policy.has_value()) {
+    if (*attrs.policy == SchedPolicy::Deadline || parse_sched_policy(info.policy) != attrs.policy) {
       return false;
     }
     // The policy classes tune different knobs: nice for CFS, rt_priority for
     // FIFO/RR (the emitter and parser agree on this split).
     const bool tunable_in_sync =
-      is_cfs(*policy) ? config.nice == info.nice : config.priority == info.rt_priority;
+      is_cfs(*attrs.policy) ? attrs.nice == info.nice : attrs.rt_priority == info.rt_priority;
     if (!tunable_in_sync) {
       return false;
     }
   }
-  if (!config.affinity.empty()) {
+  if (!attrs.affinity.empty()) {
     if (!same_cpu_set(
-          config.affinity,
+          attrs.affinity,
           agnocast_cie_thread_configurator::parse_manageable_cpu_list(info.affinity))) {
       return false;
     }
@@ -348,38 +345,39 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
   return true;
 }
 
-bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t thread_id)
+bool ThreadConfiguratorNode::issue_syscalls(
+  const std::string & thread_str, const SchedAttrs & attrs, int64_t thread_id)
 {
-  const auto policy = parse_sched_policy(config.policy);
-  if (!policy) {
+  if (!attrs.policy.has_value()) {
     RCLCPP_ERROR(
-      this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%" PRId64 ")",
-      config.policy.c_str(), config.thread_str.c_str(), thread_id);
+      this->get_logger(), "No scheduling policy to apply (thread=%s, tid=%" PRId64 ")",
+      thread_str.c_str(), thread_id);
     return false;
   }
+  const SchedPolicy policy = *attrs.policy;
 
   // No default: -Werror=switch must reject an unhandled SchedPolicy, since an
   // unhandled case would fall through to the affinity syscalls.
-  switch (*policy) {
+  switch (policy) {
     case SchedPolicy::Other:
     case SchedPolicy::Batch:
     case SchedPolicy::Idle:
     case SchedPolicy::Fifo:
     case SchedPolicy::Rr: {
       struct sched_param param;
-      param.sched_priority = is_cfs(*policy) ? 0 : config.priority;
+      param.sched_priority = is_cfs(policy) ? 0 : attrs.rt_priority;
 
-      if (sched_setscheduler(thread_id, to_kernel_policy(*policy), &param) == -1) {
+      if (sched_setscheduler(thread_id, to_kernel_policy(policy), &param) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
 
-      if (is_cfs(*policy) && setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
+      if (is_cfs(policy) && setpriority(PRIO_PROCESS, thread_id, attrs.nice) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure nice value (thread=%s, tid=%" PRId64 "): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
       break;
@@ -397,21 +395,21 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
       attr.sched_priority = 0;
 
       attr.sched_policy = SCHED_DEADLINE;
-      attr.sched_runtime = config.runtime;
-      attr.sched_period = config.period;
-      attr.sched_deadline = config.deadline;
+      attr.sched_runtime = attrs.deadline.runtime;
+      attr.sched_period = attrs.deadline.period;
+      attr.sched_deadline = attrs.deadline.deadline;
 
       if (sched_setattr(thread_id, &attr, 0) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure policy (thread=%s, tid=%" PRId64 "): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
       break;
     }
   }
 
-  return issue_affinity_syscalls(config.thread_str, policy, config.affinity, thread_id);
+  return issue_affinity_syscalls(thread_str, policy, attrs.affinity, thread_id);
 }
 
 bool ThreadConfiguratorNode::issue_affinity_syscalls(
@@ -473,23 +471,8 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
       continue;
     }
 
-    // Reuse the announcement-path syscall code (and its error wording)
-    // verbatim by shaping the entry as a ThreadConfig: one desired state,
-    // applied to every matched tid.
-    std::optional<ThreadConfig> shaped;
-    if (config.policy.has_value()) {
-      ThreadConfig tmp;
-      tmp.thread_str = config.comm;
-      tmp.policy = *config.policy;
-      tmp.nice = config.nice;
-      tmp.priority = config.priority;
-      tmp.affinity = config.affinity;
-      tmp.runtime = config.runtime;
-      tmp.period = config.period;
-      tmp.deadline = config.deadline;
-      shaped = std::move(tmp);
-    }
-
+    // One desired state, applied to every matched tid.
+    const SchedAttrs & attrs = config.attrs;
     for (const auto * info : matches) {
       std::string key = config.comm + ":" + std::to_string(info->tid);
       if (kernel_thread_in_sync(config, *info)) {
@@ -498,11 +481,11 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
       }
       // A per-CPU kthread's affinity is kernel-fixed, but a request equal to
       // that fixed value needs no change; only a different one is impossible.
-      const bool affinity_on_fixed = !config.affinity.empty() && info->no_setaffinity;
+      const bool affinity_on_fixed = !attrs.affinity.empty() && info->no_setaffinity;
       if (
         affinity_on_fixed &&
         !same_cpu_set(
-          config.affinity,
+          attrs.affinity,
           agnocast_cie_thread_configurator::parse_manageable_cpu_list(info->affinity))) {
         RCLCPP_ERROR(
           this->get_logger(),
@@ -517,21 +500,21 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
       }
 
       bool ok = false;
-      if (shaped.has_value()) {
+      if (attrs.policy.has_value()) {
         if (affinity_on_fixed) {
           // sched_setaffinity returns EINVAL for such a thread even with the
           // identical set, so issue only the policy part.
-          ThreadConfig policy_only = *shaped;
+          SchedAttrs policy_only = attrs;
           policy_only.affinity.clear();
-          ok = issue_syscalls(policy_only, info->tid);
+          ok = issue_syscalls(config.comm, policy_only, info->tid);
         } else {
-          ok = issue_syscalls(*shaped, info->tid);
+          ok = issue_syscalls(config.comm, attrs, info->tid);
         }
       } else {
         // Branch on the observed policy: an affinity-only entry matching a
         // thread currently under SCHED_DEADLINE needs the cgroup path.
         ok = issue_affinity_syscalls(
-          config.comm, parse_sched_policy(info->policy), config.affinity, info->tid);
+          config.comm, parse_sched_policy(info->policy), attrs.affinity, info->tid);
       }
 
       if (ok) {
@@ -752,7 +735,7 @@ void ThreadConfiguratorNode::callback_group_callback(
     config->thread_id = msg->thread_id;
   }
 
-  if (!issue_syscalls(*config, msg->thread_id)) {
+  if (!issue_syscalls(config->thread_str, config->attrs, msg->thread_id)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for callback group (domain=%zu, id=%s, tid=%" PRId64
@@ -803,7 +786,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     info.name.c_str());
   config->thread_id = info.tid;
 
-  if (!issue_syscalls(*config, info.tid)) {
+  if (!issue_syscalls(config->thread_str, config->attrs, info.tid)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for non-ROS thread (name=%s, tid=%" PRId64
@@ -925,7 +908,7 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       bool any_applied = false;
       for (const auto & [full_id, tid] : cfg.matched_tids) {
         std::string key = std::to_string(cfg.domain_id) + ":" + full_id;
-        if (issue_syscalls(cfg, tid)) {
+        if (issue_syscalls(cfg.thread_str, cfg.attrs, tid)) {
           response->applied_callback_groups.push_back(std::move(key));
           any_applied = true;
         } else {
@@ -944,7 +927,7 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       response->skipped_callback_groups.push_back(std::move(key));
       continue;
     }
-    if (issue_syscalls(cfg, cfg.thread_id)) {
+    if (issue_syscalls(cfg.thread_str, cfg.attrs, cfg.thread_id)) {
       response->applied_callback_groups.push_back(std::move(key));
       cfg.applied = true;
       unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
@@ -960,7 +943,7 @@ void ThreadConfiguratorNode::on_reapply_config_request(
         response->skipped_non_ros_threads.push_back(cfg.thread_str);
         continue;
       }
-      if (issue_syscalls(cfg, cfg.thread_id)) {
+      if (issue_syscalls(cfg.thread_str, cfg.attrs, cfg.thread_id)) {
         response->applied_non_ros_threads.push_back(cfg.thread_str);
         if (!cfg.applied) {
           cfg.applied = true;

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -72,9 +72,9 @@ non_ros_threads: []
   ASSERT_EQ(cb.size(), 1u);
   EXPECT_EQ(cb[0].thread_str, "my_cbg");
   EXPECT_EQ(cb[0].domain_id, 3u);
-  EXPECT_EQ(cb[0].policy, "SCHED_FIFO");
-  EXPECT_EQ(cb[0].priority, 50);
-  EXPECT_EQ(cb[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(cb[0].attrs.policy, acie::SchedPolicy::Fifo);
+  EXPECT_EQ(cb[0].attrs.rt_priority, 50);
+  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{0, 1}));
   EXPECT_EQ(cb[0].thread_id, -1);
   EXPECT_FALSE(cb[0].applied);
   EXPECT_FALSE(cb[0].is_wildcard());
@@ -96,8 +96,8 @@ TEST(ParseYaml, ParsesNiceForCfsPolicies)
     std::vector<acie::ThreadConfig> cb, nrt;
     ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt)) << policy;
     ASSERT_EQ(cb.size(), 1u);
-    EXPECT_EQ(cb[0].nice, -10) << policy;
-    EXPECT_EQ(cb[0].priority, 0) << policy;
+    EXPECT_EQ(cb[0].attrs.nice, -10) << policy;
+    EXPECT_EQ(cb[0].attrs.rt_priority, 0) << policy;
   }
 }
 
@@ -122,10 +122,10 @@ non_ros_threads: []
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 2u);
-  EXPECT_EQ(cb[0].nice, -5);
-  EXPECT_EQ(cb[0].priority, 0);
-  EXPECT_EQ(cb[1].priority, 50);
-  EXPECT_EQ(cb[1].nice, 0);
+  EXPECT_EQ(cb[0].attrs.nice, -5);
+  EXPECT_EQ(cb[0].attrs.rt_priority, 0);
+  EXPECT_EQ(cb[1].attrs.rt_priority, 50);
+  EXPECT_EQ(cb[1].attrs.nice, 0);
 }
 
 TEST(ParseYaml, RejectsMissingNiceOnSchedOther)
@@ -290,10 +290,31 @@ non_ros_threads: []
   std::vector<acie::ThreadConfig> cb, nrt;
   acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
   ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].policy, "SCHED_DEADLINE");
-  EXPECT_EQ(cb[0].runtime, 1000000u);
-  EXPECT_EQ(cb[0].period, 5000000u);
-  EXPECT_EQ(cb[0].deadline, 5000000u);
+  EXPECT_EQ(cb[0].attrs.policy, acie::SchedPolicy::Deadline);
+  EXPECT_EQ(cb[0].attrs.deadline.runtime, 1000000u);
+  EXPECT_EQ(cb[0].attrs.deadline.period, 5000000u);
+  EXPECT_EQ(cb[0].attrs.deadline.deadline, 5000000u);
+}
+
+TEST(ParseYaml, AcceptsDeadlineParamsBeyond32Bits)
+{
+  // sched_attr carries nanoseconds in 64-bit fields; a 5 s period exceeds
+  // 2^32 ns.
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: dl_cbg
+    domain_id: 0
+    policy: SCHED_DEADLINE
+    runtime: 1000000000
+    period: 5000000000
+    deadline: 5000000000
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].attrs.deadline.period, 5000000000u);
 }
 
 TEST(ParseYaml, RejectsUnknownPolicyOnCallbackGroup)
@@ -358,8 +379,8 @@ non_ros_threads:
   acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
   ASSERT_EQ(nrt.size(), 1u);
   EXPECT_EQ(nrt[0].thread_str, "worker");
-  EXPECT_EQ(nrt[0].policy, "SCHED_RR");
-  EXPECT_EQ(nrt[0].priority, 30);
+  EXPECT_EQ(nrt[0].attrs.policy, acie::SchedPolicy::Rr);
+  EXPECT_EQ(nrt[0].attrs.rt_priority, 30);
 }
 
 TEST(ParseYaml, ClearsOutputVectorsOnReparse)
@@ -627,9 +648,9 @@ non_ros_threads:
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{0, 1}));
   ASSERT_EQ(nrt.size(), 1u);
-  EXPECT_EQ(nrt[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(nrt[0].attrs.affinity, (std::vector<int>{0, 1}));
 }
 
 TEST(ParseYaml, TreatsAbsentOrNullAffinityAsUnmanaged)
@@ -650,8 +671,8 @@ non_ros_threads: []
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 2u);
-  EXPECT_TRUE(cb[0].affinity.empty());
-  EXPECT_TRUE(cb[1].affinity.empty());
+  EXPECT_TRUE(cb[0].attrs.affinity.empty());
+  EXPECT_TRUE(cb[1].attrs.affinity.empty());
 }
 
 TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
@@ -697,7 +718,7 @@ TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].affinity, (std::vector<int>{max_cpu}));
+  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{max_cpu}));
 }
 
 TEST(ParseYaml, RejectsScalarAffinity)
@@ -774,10 +795,9 @@ kernel_threads:
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].comm, "agnocast_exit_w");
-  ASSERT_TRUE(result[0].policy.has_value());
-  EXPECT_EQ(*result[0].policy, "SCHED_FIFO");
-  EXPECT_EQ(result[0].priority, 10);
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Fifo);
+  EXPECT_EQ(result[0].attrs.rt_priority, 10);
+  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{0, 1}));
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -792,9 +812,8 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  ASSERT_TRUE(result[0].policy.has_value());
-  EXPECT_EQ(*result[0].policy, "SCHED_OTHER");
-  EXPECT_EQ(result[0].nice, -10);
+  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Other);
+  EXPECT_EQ(result[0].attrs.nice, -10);
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -810,8 +829,8 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].policy.has_value());
-  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].attrs.policy.has_value());
+  EXPECT_TRUE(result[0].attrs.affinity.empty());
   EXPECT_FALSE(result[0].is_managed());
 }
 
@@ -827,8 +846,8 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].policy.has_value());
-  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].attrs.policy.has_value());
+  EXPECT_TRUE(result[0].attrs.affinity.empty());
   EXPECT_FALSE(result[0].is_managed());
 }
 
@@ -843,8 +862,8 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].policy.has_value());
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{1}));
+  EXPECT_FALSE(result[0].attrs.policy.has_value());
+  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{1}));
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -859,7 +878,7 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{0, 1}));
 }
 
 TEST(ParseKernelThreads, RejectsScalarAndOutOfRangeAffinity)
@@ -897,8 +916,8 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  ASSERT_TRUE(result[0].policy.has_value());
-  EXPECT_TRUE(result[0].affinity.empty());
+  ASSERT_TRUE(result[0].attrs.policy.has_value());
+  EXPECT_TRUE(result[0].attrs.affinity.empty());
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -915,11 +934,26 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  ASSERT_TRUE(result[0].policy.has_value());
-  EXPECT_EQ(*result[0].policy, "SCHED_DEADLINE");
-  EXPECT_EQ(result[0].runtime, 1000000u);
-  EXPECT_EQ(result[0].period, 5000000u);
-  EXPECT_EQ(result[0].deadline, 5000000u);
+  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Deadline);
+  EXPECT_EQ(result[0].attrs.deadline.runtime, 1000000u);
+  EXPECT_EQ(result[0].attrs.deadline.period, 5000000u);
+  EXPECT_EQ(result[0].attrs.deadline.deadline, 5000000u);
+}
+
+TEST(ParseKernelThreads, AcceptsDeadlineParamsBeyond32Bits)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000000
+    period: 5000000000
+    deadline: 5000000000
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].attrs.deadline.period, 5000000000u);
 }
 
 TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
@@ -1204,7 +1238,7 @@ kernel_threads:
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].runtime, 500000u);
+  EXPECT_EQ(result[0].attrs.deadline.runtime, 500000u);
 }
 
 TEST(ParseKernelThreads, RejectsNonListSection)


### PR DESCRIPTION
## Description

`ThreadConfig` and `KernelThreadConfig` each carried the same seven scheduling fields (string `policy`, `nice`, `priority`, `runtime`, `period`, `deadline`, `affinity`), and `apply_kernel_thread_configs()` copied them one by one into a "shaped" `ThreadConfig` so it could reuse `issue_syscalls()`.

Both structs now hold one `SchedAttrs` (`std::optional<SchedPolicy>`, `nice`, `rt_priority`, `DeadlineParams`, `affinity`). The policy is stored as the enum the parser already validated, so the node no longer re-parses a string, and the unreachable "Unknown scheduling policy" branch in `issue_syscalls()` becomes a "no policy" guard. `issue_syscalls()` takes `(thread_str, SchedAttrs, tid)`, which lets the kernel-thread path pass its entry's `attrs` directly and drops the shaping code.

`DeadlineParams` are `uint64_t`, matching `sched_attr`'s nanosecond fields, so periods beyond 2^32 ns are now accepted (the previous `unsigned int` conversion rejected them). No other behavior changes; parser messages and the YAML schema are untouched.

This is the first of seven stacked PRs implementing P2 (config model redesign) of `docs/cie_thread_configurator_refactoring_proposal.md`. The follow-ups split desired state from runtime state, align the per-section validation and unify the three attribute parsers, then align integer, section-shape and entry-key validation across sections.

Verified by building with `-DBUILD_TESTING=ON` and running the five gtests (test_thread_config: 79 tests, two new ones for the 64-bit deadline parameters). cppcheck with the CI flags reports nothing new; clang-tidy findings are unchanged from `main`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
