### PR TITLE
refactor(agnocast_cie_thread_configurator): split the YAML model into desired entries and tracked runtime state

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -4,7 +4,6 @@
 #include "yaml-cpp/yaml.h"
 
 #include <cstdint>
-#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -12,6 +11,10 @@
 
 namespace agnocast_cie_thread_configurator
 {
+
+// The desired state of one schedulable entity as written in the YAML. What
+// is observed at runtime (announced tids, applied flags) lives with the
+// owner, not here, so re-parsing yields a plain value to swap in.
 
 struct DeadlineParams
 {
@@ -33,26 +36,56 @@ struct SchedAttrs
   std::vector<int> affinity;  // sorted, deduplicated; empty = do not manage
 };
 
-// A single thread's scheduling configuration as parsed from the YAML and
-// observed at runtime. Owned by ThreadConfiguratorNode in two vectors.
-struct ThreadConfig
+// A callback-group id ending in "/*" is a wildcard matching every callback
+// group whose node part (before the first '@') equals the prefix, within the
+// same domain; exact entries take precedence over wildcards.
+struct CallbackGroupEntry
 {
-  std::string thread_str;  // callback_group_id or thread_name
   size_t domain_id = 0;
-  int64_t thread_id = -1;  // -1 until announced by the target application
-  SchedAttrs attrs;        // attrs.policy is always set since the parser requires 'policy'
-
-  // Full incoming callback_group_id -> last announced tid; wildcard
-  // ("<node name>/*") entries only. For such entries `applied` means "at least
-  // one matched instance has been configured" and thread_id stays -1. std::map
-  // for deterministic iteration order in the reapply response arrays.
-  std::map<std::string, int64_t> matched_tids;
-
-  bool applied = false;  // true once issue_syscalls() has succeeded
+  std::string id;
+  SchedAttrs attrs;
 
   bool is_wildcard() const noexcept;
-  // thread_str minus the trailing "/*"; only meaningful when is_wildcard().
+  // id minus the trailing "/*"; only meaningful when is_wildcard().
   std::string wildcard_prefix() const;
+};
+
+// Names are opaque and matched exactly (no wildcards).
+struct NonRosThreadEntry
+{
+  std::string name;
+  SchedAttrs attrs;
+};
+
+// Applies to every kernel thread whose comm matches at apply time (comms are
+// not unique, e.g. an nfsd pool). Unset attributes are never applied.
+struct KernelThreadEntry
+{
+  std::string comm;
+  SchedAttrs attrs;
+
+  bool is_managed() const noexcept;
+};
+
+// Affinity is a hard IRQ's only schedulable attribute (threaded-IRQ handler
+// threads are plain kernel threads).
+struct IrqEntry
+{
+  int irq = -1;
+  // Expected /sys/kernel/irq/<irq>/actions content, verified before applying
+  // (guards against IRQ renumbering across boots). Empty = skip the check.
+  std::string name;
+  std::vector<int> affinity;  // empty = leave alone
+
+  bool is_managed() const noexcept;
+};
+
+struct ParsedConfig
+{
+  std::vector<CallbackGroupEntry> callback_groups;
+  std::vector<NonRosThreadEntry> non_ros_threads;
+  std::vector<KernelThreadEntry> kernel_threads;
+  std::vector<IrqEntry> irqs;
 };
 
 // Node-name part of an incoming callback_group_id: the substring before the
@@ -65,48 +98,12 @@ std::string extract_node_part(const std::string & callback_group_id);
 // to "not applied". Case-sensitive, exact match.
 inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
 
-// Desired attributes for every kernel thread whose comm matches at apply
-// time (comms are not unique, e.g. an nfsd pool). Unset attributes (YAML
-// null, absent key, or UNMANAGEABLE) are never applied.
-struct KernelThreadConfig
-{
-  std::string comm;
-  SchedAttrs attrs;
-
-  bool is_managed() const noexcept;
-};
-
-// Desired affinity for one IRQ, a hard IRQ's only schedulable attribute
-// (threaded-IRQ handler threads are plain kernel threads).
-struct IrqConfig
-{
-  int irq = -1;
-  // Expected /sys/kernel/irq/<irq>/actions content, verified before applying
-  // (guards against IRQ renumbering across boots). Empty = skip the check.
-  std::string name;
-  std::vector<int> affinity;  // empty = leave alone
-
-  bool is_managed() const noexcept;
-};
-
-// Parse the optional kernel_threads / irqs sections. Missing/null sections
-// yield empty vectors (pre-existing YAMLs keep working). Throws
-// std::runtime_error on validation error.
-std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml);
-std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml);
-
-// Parse the given YAML document and populate the two output vectors.
-// Throws std::runtime_error on per-entry validation error. Output ThreadConfigs
-// have thread_id=-1 and applied=false; callers that re-parse must carry
-// thread_id over from their existing index manually.
-// A callback-group id ending in "/*" is a wildcard entry matching every
-// callback group whose node part (before the first '@') equals the prefix,
-// within the same domain; exact entries take precedence over wildcards.
-// non_ros_threads names are always matched exactly.
-// hardware_info / rt_throttling are validated only at startup, not here, and
-// the kernel_threads / irqs sections have their own parsers (see above).
-void parse_yaml(
-  const YAML::Node & yaml, size_t default_domain_id,
-  std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out);
+// Parse the four entry sections. A missing or null section yields an empty
+// vector. callback_groups and non_ros_threads require 'policy' and treat
+// UNMANAGEABLE as an ordinary invalid value; callback_groups take an optional
+// 'domain_id' (default_domain_id otherwise). kernel_threads and irqs accept
+// UNMANAGEABLE as unset. Throws std::runtime_error on validation error.
+// hardware_info / rt_throttling are validated only at startup, not here.
+ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id);
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -19,11 +19,32 @@
 
 class ThreadConfiguratorNode : public rclcpp::Node
 {
-  using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
-  using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
-  using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
+  using CallbackGroupEntry = agnocast_cie_thread_configurator::CallbackGroupEntry;
+  using NonRosThreadEntry = agnocast_cie_thread_configurator::NonRosThreadEntry;
+  using KernelThreadEntry = agnocast_cie_thread_configurator::KernelThreadEntry;
+  using IrqEntry = agnocast_cie_thread_configurator::IrqEntry;
   using SchedAttrs = agnocast_cie_thread_configurator::SchedAttrs;
   using SchedPolicy = agnocast_cie_thread_configurator::SchedPolicy;
+
+  // A YAML entry plus what has been observed at runtime for it. Owned in the
+  // two vectors below, which the id_to_*/node_to_* maps index into.
+  struct TrackedCallbackGroup
+  {
+    CallbackGroupEntry entry;
+    int64_t thread_id = -1;  // -1 until announced; stays -1 for wildcard entries
+    // Full incoming callback_group_id -> last announced tid; wildcard
+    // ("<node name>/*") entries only. For such entries `applied` means "at
+    // least one matched instance has been configured". std::map for
+    // deterministic iteration order in the reapply response arrays.
+    std::map<std::string, int64_t> matched_tids;
+    bool applied = false;  // true once issue_syscalls() has succeeded
+  };
+  struct TrackedNonRosThread
+  {
+    NonRosThreadEntry entry;
+    int64_t thread_id = -1;  // -1 until announced
+    bool applied = false;    // true once issue_syscalls() has succeeded
+  };
 
   // Concurrency:
   // - callback_group_configs_ / id_to_callback_group_config_ /
@@ -74,7 +95,7 @@ private:
   SectionApplyOutcome apply_irq_configs() const;
   // Sole logging point for the write path: emits errno-specific guidance on
   // any open/write/short-write failure (returning false) and the success line.
-  bool write_irq_affinity_file(const IrqConfig & config) const;
+  bool write_irq_affinity_file(const IrqEntry & config) const;
   void callback_group_callback(
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
@@ -85,18 +106,18 @@ private:
 
   rclcpp::Service<agnocast_cie_config_msgs::srv::ReapplyConfig>::SharedPtr reapply_service_;
 
-  std::vector<ThreadConfig> callback_group_configs_;
-  // (domain_id, callback_group_id) -> ThreadConfig*, exact entries only
-  std::map<std::pair<size_t, std::string>, ThreadConfig *> id_to_callback_group_config_;
-  // (domain_id, wildcard_prefix) -> ThreadConfig*, wildcard ("<node>/*") entries only
-  std::map<std::pair<size_t, std::string>, ThreadConfig *> node_to_wildcard_config_;
+  std::vector<TrackedCallbackGroup> callback_group_configs_;
+  // (domain_id, callback_group_id) -> exact entries only
+  std::map<std::pair<size_t, std::string>, TrackedCallbackGroup *> id_to_callback_group_config_;
+  // (domain_id, wildcard_prefix) -> wildcard ("<node>/*") entries only
+  std::map<std::pair<size_t, std::string>, TrackedCallbackGroup *> node_to_wildcard_config_;
 
-  std::vector<ThreadConfig> non_ros_thread_configs_;
-  // thread_name -> ThreadConfig*
-  std::map<std::string, ThreadConfig *> id_to_non_ros_thread_config_;
+  std::vector<TrackedNonRosThread> non_ros_thread_configs_;
+  // thread_name -> entry
+  std::map<std::string, TrackedNonRosThread *> id_to_non_ros_thread_config_;
 
-  std::vector<KernelThreadConfig> kernel_thread_configs_;
-  std::vector<IrqConfig> irq_configs_;
+  std::vector<KernelThreadEntry> kernel_thread_configs_;
+  std::vector<IrqEntry> irq_configs_;
 
   std::atomic<int> unapplied_num_{0};
   std::atomic<int> cgroup_num_{0};

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -184,18 +184,70 @@ SchedPolicy parse_policy_or_throw(const std::string & policy, const std::string 
   return *parsed;
 }
 
-}  // namespace
-
-bool ThreadConfig::is_wildcard() const noexcept
+// A typo'd pattern silently treated as an exact id would never match, so any
+// id containing '*' must be a well-formed "<node name>/*".
+void validate_callback_group_id(const CallbackGroupEntry & entry)
 {
-  static constexpr std::string_view suffix = "/*";
-  return thread_str.size() >= suffix.size() &&
-         thread_str.compare(thread_str.size() - suffix.size(), suffix.size(), suffix) == 0;
+  if (entry.id.find('*') == std::string::npos) {
+    return;
+  }
+  if (!entry.is_wildcard()) {
+    throw std::runtime_error(
+      "Invalid id '" + entry.id +
+      "': '*' is only allowed as a trailing \"/*\" wildcard (e.g. /my_node/*)");
+  }
+  const std::string prefix = entry.wildcard_prefix();
+  if (prefix.empty() || prefix.find('*') != std::string::npos) {
+    throw std::runtime_error(
+      "Invalid wildcard id '" + entry.id +
+      "': the part before \"/*\" must be a non-empty node name without '*'");
+  }
+  if (prefix.find('@') != std::string::npos) {
+    throw std::runtime_error(
+      "Invalid wildcard id '" + entry.id +
+      "': the part before \"/*\" must be a plain node name, not a full callback-group id "
+      "containing '@'");
+  }
 }
 
-std::string ThreadConfig::wildcard_prefix() const
+// Duplicates would otherwise collapse to the last-inserted entry in the
+// owner's index, dropping earlier YAML lines without warning. `describe`
+// doubles as the identity, so entries with the same description are
+// duplicates.
+template <typename Entries, typename Describe>
+void reject_duplicates(const Entries & entries, const char * what, Describe describe)
 {
-  return thread_str.substr(0, thread_str.size() - 2);
+  std::unordered_set<std::string> seen;
+  for (const auto & entry : entries) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen.insert(describe(entry)).second) {
+      throw std::runtime_error(std::string("Duplicate ") + what + " entry: " + describe(entry));
+    }
+  }
+}
+
+}  // namespace
+
+bool CallbackGroupEntry::is_wildcard() const noexcept
+{
+  static constexpr std::string_view suffix = "/*";
+  return id.size() >= suffix.size() &&
+         id.compare(id.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string CallbackGroupEntry::wildcard_prefix() const
+{
+  return id.substr(0, id.size() - 2);
+}
+
+bool KernelThreadEntry::is_managed() const noexcept
+{
+  return attrs.policy.has_value() || !attrs.affinity.empty();
+}
+
+bool IrqEntry::is_managed() const noexcept
+{
+  return !affinity.empty();
 }
 
 std::string extract_node_part(const std::string & callback_group_id)
@@ -203,260 +255,192 @@ std::string extract_node_part(const std::string & callback_group_id)
   return callback_group_id.substr(0, callback_group_id.find('@'));
 }
 
-void parse_yaml(
-  const YAML::Node & yaml, size_t default_domain_id,
-  std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out)
+ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
 {
-  YAML::Node callback_groups = yaml["callback_groups"];
-  YAML::Node non_ros_threads = yaml["non_ros_threads"];
+  ParsedConfig config;
 
-  callback_groups_out.clear();
-  non_ros_threads_out.clear();
-  callback_groups_out.resize(callback_groups.size());
-  non_ros_threads_out.resize(non_ros_threads.size());
-
-  for (size_t i = 0; i < callback_groups.size(); ++i) {
-    const auto & cg = callback_groups[i];
-    auto & cfg = callback_groups_out[i];
-
-    cfg.thread_str = cg["id"].as<std::string>();
-    if (cfg.thread_str.find('*') != std::string::npos) {
-      // A typo'd pattern silently treated as an exact id would never match,
-      // so any id containing '*' must be a well-formed "<node name>/*".
-      if (!cfg.is_wildcard()) {
-        throw std::runtime_error(
-          "Invalid id '" + cfg.thread_str +
-          "': '*' is only allowed as a trailing \"/*\" wildcard (e.g. /my_node/*)");
-      }
-      const std::string prefix = cfg.wildcard_prefix();
-      if (prefix.empty() || prefix.find('*') != std::string::npos) {
-        throw std::runtime_error(
-          "Invalid wildcard id '" + cfg.thread_str +
-          "': the part before \"/*\" must be a non-empty node name without '*'");
-      }
-      if (prefix.find('@') != std::string::npos) {
-        throw std::runtime_error(
-          "Invalid wildcard id '" + cfg.thread_str +
-          "': the part before \"/*\" must be a plain node name, not a full callback-group id "
-          "containing '@'");
-      }
-    }
-    cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
-    cfg.attrs.affinity = parse_affinity(cg, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+  // A missing or null section has no entries, like kernel_threads / irqs.
+  const YAML::Node callback_groups = yaml["callback_groups"];
+  const size_t callback_group_count =
+    (callback_groups && !callback_groups.IsNull()) ? callback_groups.size() : 0;
+  for (size_t i = 0; i < callback_group_count; ++i) {
+    const YAML::Node cg = callback_groups[i];
+    CallbackGroupEntry entry;
+    entry.id = cg["id"].as<std::string>();
+    validate_callback_group_id(entry);
+    entry.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
+    entry.attrs.affinity = parse_affinity(cg, "id=" + entry.id, /*allow_unmanageable=*/false);
     const SchedPolicy policy =
-      parse_policy_or_throw(cg["policy"].as<std::string>(), "id=" + cfg.thread_str);
-    cfg.attrs.policy = policy;
+      parse_policy_or_throw(cg["policy"].as<std::string>(), "id=" + entry.id);
+    entry.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      cfg.attrs.deadline = DeadlineParams{
+      entry.attrs.deadline = DeadlineParams{
         cg["runtime"].as<uint64_t>(), cg["period"].as<uint64_t>(), cg["deadline"].as<uint64_t>()};
     } else if (is_cfs(policy)) {
-      cfg.attrs.nice = parse_nice(cg, policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      entry.attrs.nice = parse_nice(cg, policy, "id=" + entry.id, /*allow_unmanageable=*/false);
     } else {
-      cfg.attrs.rt_priority =
-        parse_rt_priority(cg, policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      entry.attrs.rt_priority =
+        parse_rt_priority(cg, policy, "id=" + entry.id, /*allow_unmanageable=*/false);
     }
+    config.callback_groups.push_back(std::move(entry));
   }
+  reject_duplicates(config.callback_groups, "callback_group", [](const CallbackGroupEntry & e) {
+    return "domain_id=" + std::to_string(e.domain_id) + ", id=" + e.id;
+  });
 
-  for (size_t i = 0; i < non_ros_threads.size(); ++i) {
-    const auto & nrt = non_ros_threads[i];
-    auto & cfg = non_ros_threads_out[i];
-
-    cfg.thread_str = nrt["name"].as<std::string>();
-    cfg.attrs.affinity =
-      parse_affinity(nrt, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+  const YAML::Node non_ros_threads = yaml["non_ros_threads"];
+  const size_t non_ros_thread_count =
+    (non_ros_threads && !non_ros_threads.IsNull()) ? non_ros_threads.size() : 0;
+  for (size_t i = 0; i < non_ros_thread_count; ++i) {
+    const YAML::Node nrt = non_ros_threads[i];
+    NonRosThreadEntry entry;
+    entry.name = nrt["name"].as<std::string>();
+    entry.attrs.affinity = parse_affinity(nrt, "name=" + entry.name, /*allow_unmanageable=*/false);
     const SchedPolicy policy =
-      parse_policy_or_throw(nrt["policy"].as<std::string>(), "name=" + cfg.thread_str);
-    cfg.attrs.policy = policy;
+      parse_policy_or_throw(nrt["policy"].as<std::string>(), "name=" + entry.name);
+    entry.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      cfg.attrs.deadline = DeadlineParams{
+      entry.attrs.deadline = DeadlineParams{
         nrt["runtime"].as<uint64_t>(), nrt["period"].as<uint64_t>(),
         nrt["deadline"].as<uint64_t>()};
     } else if (is_cfs(policy)) {
-      cfg.attrs.nice =
-        parse_nice(nrt, policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      entry.attrs.nice =
+        parse_nice(nrt, policy, "name=" + entry.name, /*allow_unmanageable=*/false);
     } else {
-      cfg.attrs.rt_priority =
-        parse_rt_priority(nrt, policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
+      entry.attrs.rt_priority =
+        parse_rt_priority(nrt, policy, "name=" + entry.name, /*allow_unmanageable=*/false);
     }
+    config.non_ros_threads.push_back(std::move(entry));
   }
+  reject_duplicates(config.non_ros_threads, "non_ros_thread", [](const NonRosThreadEntry & e) {
+    return "name=" + e.name;
+  });
 
-  // Reject duplicates: id_to_*_config_ would silently collapse them to the
-  // last-inserted entry, dropping earlier YAML lines without warning.
-  // The std::find_if rewrite cppcheck suggests would hide a side-effecting
-  // predicate inside the algorithm; a plain loop is clearer here.
-  std::unordered_set<std::string> seen_cb;
-  for (const auto & c : callback_groups_out) {
-    // cppcheck-suppress useStlAlgorithm
-    if (!seen_cb.insert(std::to_string(c.domain_id) + ":" + c.thread_str).second) {
-      throw std::runtime_error(
-        "Duplicate callback_group entry: domain_id=" + std::to_string(c.domain_id) +
-        ", id=" + c.thread_str);
+  const YAML::Node kernel_threads = yaml["kernel_threads"];
+  if (kernel_threads && !kernel_threads.IsNull()) {
+    if (!kernel_threads.IsSequence()) {
+      throw std::runtime_error("'kernel_threads' must be a list");
     }
-  }
-  std::unordered_set<std::string> seen_nrt;
-  for (const auto & c : non_ros_threads_out) {
-    // cppcheck-suppress useStlAlgorithm
-    if (!seen_nrt.insert(c.thread_str).second) {
-      throw std::runtime_error("Duplicate non_ros_thread entry: name=" + c.thread_str);
-    }
-  }
-}
+    for (size_t i = 0; i < kernel_threads.size(); ++i) {
+      const YAML::Node kt = kernel_threads[i];
+      KernelThreadEntry entry;
+      const std::string entry_pos = "kernel_threads entry #" + std::to_string(i);
 
-bool KernelThreadConfig::is_managed() const noexcept
-{
-  return attrs.policy.has_value() || !attrs.affinity.empty();
-}
+      if (!kt.IsMap()) {
+        throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- comm: ...')");
+      }
+      if (!kt["comm"] || kt["comm"].IsNull()) {
+        throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
+      }
+      try {
+        entry.comm = kt["comm"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        throw std::runtime_error(entry_pos + ": 'comm' must be a string");
+      }
+      if (entry.comm.empty()) {
+        throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
+      }
+      if (is_kworker_comm(entry.comm)) {
+        throw std::runtime_error(
+          "kernel_threads entry '" + entry.comm +
+          "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
+          "be matched reliably");
+      }
+      entry.attrs.affinity = parse_affinity(kt, "comm=" + entry.comm, /*allow_unmanageable=*/true);
 
-bool IrqConfig::is_managed() const noexcept
-{
-  return !affinity.empty();
-}
+      if (is_unset(kt["policy"], /*allow_unmanageable=*/true)) {
+        // Any policy-dependent field without 'policy' would otherwise be
+        // silently dead configuration (is_managed() == false).
+        for (const char * key : {"nice", "priority", "runtime", "period", "deadline"}) {
+          if (!is_unset(kt[key], /*allow_unmanageable=*/true)) {
+            throw std::runtime_error(
+              "'" + std::string(key) + "' requires 'policy' for comm=" + entry.comm +
+              ": set both or leave both unset");
+          }
+        }
+        config.kernel_threads.push_back(std::move(entry));
+        continue;
+      }
 
-std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
-{
-  YAML::Node section = yaml["kernel_threads"];
-  std::vector<KernelThreadConfig> result;
-  if (!section || section.IsNull()) {
-    return result;
-  }
-  if (!section.IsSequence()) {
-    throw std::runtime_error("'kernel_threads' must be a list");
-  }
-  result.resize(section.size());
+      std::string policy_str;
+      try {
+        policy_str = kt["policy"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        throw std::runtime_error("'policy' must be a string for comm=" + entry.comm);
+      }
+      const SchedPolicy policy = parse_policy_or_throw(policy_str, "comm=" + entry.comm);
+      entry.attrs.policy = policy;
 
-  for (size_t i = 0; i < section.size(); ++i) {
-    const auto & kt = section[i];
-    auto & cfg = result[i];
-    const std::string entry_pos = "kernel_threads entry #" + std::to_string(i);
-
-    if (!kt.IsMap()) {
-      throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- comm: ...')");
-    }
-    if (!kt["comm"] || kt["comm"].IsNull()) {
-      throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
-    }
-    try {
-      cfg.comm = kt["comm"].as<std::string>();
-    } catch (const YAML::Exception &) {
-      throw std::runtime_error(entry_pos + ": 'comm' must be a string");
-    }
-    if (cfg.comm.empty()) {
-      throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
-    }
-    if (is_kworker_comm(cfg.comm)) {
-      throw std::runtime_error(
-        "kernel_threads entry '" + cfg.comm +
-        "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
-        "be matched reliably");
-    }
-    cfg.attrs.affinity = parse_affinity(kt, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
-
-    if (is_unset(kt["policy"], /*allow_unmanageable=*/true)) {
-      // Any policy-dependent field without 'policy' would otherwise be
-      // silently dead configuration (is_managed() == false).
-      for (const char * key : {"nice", "priority", "runtime", "period", "deadline"}) {
-        if (!is_unset(kt[key], /*allow_unmanageable=*/true)) {
+      if (policy == SchedPolicy::Deadline) {
+        // Explicit check for a clear message: these fields are always
+        // hand-written (prerun never emits DEADLINE) and easy to forget.
+        if (
+          is_unset(kt["runtime"], /*allow_unmanageable=*/true) ||
+          is_unset(kt["period"], /*allow_unmanageable=*/true) ||
+          is_unset(kt["deadline"], /*allow_unmanageable=*/true)) {
           throw std::runtime_error(
-            "'" + std::string(key) + "' requires 'policy' for comm=" + cfg.comm +
-            ": set both or leave both unset");
+            "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + entry.comm);
+        }
+        entry.attrs.deadline = DeadlineParams{
+          parse_deadline_field(kt, "runtime", "comm=" + entry.comm),
+          parse_deadline_field(kt, "period", "comm=" + entry.comm),
+          parse_deadline_field(kt, "deadline", "comm=" + entry.comm)};
+      } else if (is_cfs(policy)) {
+        entry.attrs.nice =
+          parse_nice(kt, policy, "comm=" + entry.comm, /*allow_unmanageable=*/true);
+      } else {
+        entry.attrs.rt_priority =
+          parse_rt_priority(kt, policy, "comm=" + entry.comm, /*allow_unmanageable=*/true);
+      }
+      config.kernel_threads.push_back(std::move(entry));
+    }
+  }
+  reject_duplicates(config.kernel_threads, "kernel_thread", [](const KernelThreadEntry & e) {
+    return "comm=" + e.comm;
+  });
+
+  const YAML::Node irqs = yaml["irqs"];
+  if (irqs && !irqs.IsNull()) {
+    if (!irqs.IsSequence()) {
+      throw std::runtime_error("'irqs' must be a list");
+    }
+    for (size_t i = 0; i < irqs.size(); ++i) {
+      const YAML::Node iq = irqs[i];
+      IrqEntry entry;
+      const std::string entry_pos = "irqs entry #" + std::to_string(i);
+
+      if (!iq.IsMap()) {
+        throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- irq: ...')");
+      }
+      if (!iq["irq"] || iq["irq"].IsNull()) {
+        throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
+      }
+      const auto irq = as_base10<int>(iq["irq"]);
+      if (!irq) {
+        throw std::runtime_error(
+          entry_pos + ": 'irq' must be a non-negative decimal integer, got '" +
+          (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
+      }
+      entry.irq = *irq;
+
+      if (iq["name"] && !iq["name"].IsNull()) {
+        try {
+          entry.name = iq["name"].as<std::string>();
+        } catch (const YAML::Exception &) {
+          throw std::runtime_error("'name' must be a string for irq=" + std::to_string(entry.irq));
         }
       }
-      continue;
-    }
-
-    std::string policy_str;
-    try {
-      policy_str = kt["policy"].as<std::string>();
-    } catch (const YAML::Exception &) {
-      throw std::runtime_error("'policy' must be a string for comm=" + cfg.comm);
-    }
-    const SchedPolicy policy = parse_policy_or_throw(policy_str, "comm=" + cfg.comm);
-    cfg.attrs.policy = policy;
-
-    if (policy == SchedPolicy::Deadline) {
-      // Explicit check for a clear message: these fields are always
-      // hand-written (prerun never emits DEADLINE) and easy to forget.
-      if (
-        is_unset(kt["runtime"], /*allow_unmanageable=*/true) ||
-        is_unset(kt["period"], /*allow_unmanageable=*/true) ||
-        is_unset(kt["deadline"], /*allow_unmanageable=*/true)) {
-        throw std::runtime_error(
-          "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
-      }
-      cfg.attrs.deadline = DeadlineParams{
-        parse_deadline_field(kt, "runtime", "comm=" + cfg.comm),
-        parse_deadline_field(kt, "period", "comm=" + cfg.comm),
-        parse_deadline_field(kt, "deadline", "comm=" + cfg.comm)};
-    } else if (is_cfs(policy)) {
-      cfg.attrs.nice = parse_nice(kt, policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
-    } else {
-      cfg.attrs.rt_priority =
-        parse_rt_priority(kt, policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
+      entry.affinity =
+        parse_affinity(iq, "irq=" + std::to_string(entry.irq), /*allow_unmanageable=*/true);
+      config.irqs.push_back(std::move(entry));
     }
   }
+  reject_duplicates(
+    config.irqs, "irq", [](const IrqEntry & e) { return "irq=" + std::to_string(e.irq); });
 
-  std::unordered_set<std::string> seen;
-  for (const auto & c : result) {
-    // cppcheck-suppress useStlAlgorithm
-    if (!seen.insert(c.comm).second) {
-      throw std::runtime_error("Duplicate kernel_thread entry: comm=" + c.comm);
-    }
-  }
-  return result;
-}
-
-std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
-{
-  YAML::Node section = yaml["irqs"];
-  std::vector<IrqConfig> result;
-  if (!section || section.IsNull()) {
-    return result;
-  }
-  if (!section.IsSequence()) {
-    throw std::runtime_error("'irqs' must be a list");
-  }
-  result.resize(section.size());
-
-  for (size_t i = 0; i < section.size(); ++i) {
-    const auto & iq = section[i];
-    auto & cfg = result[i];
-    const std::string entry_pos = "irqs entry #" + std::to_string(i);
-
-    if (!iq.IsMap()) {
-      throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- irq: ...')");
-    }
-    if (!iq["irq"] || iq["irq"].IsNull()) {
-      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
-    }
-    const auto irq = as_base10<int>(iq["irq"]);
-    if (!irq) {
-      throw std::runtime_error(
-        entry_pos + ": 'irq' must be a non-negative decimal integer, got '" +
-        (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
-    }
-    cfg.irq = *irq;
-
-    if (iq["name"] && !iq["name"].IsNull()) {
-      try {
-        cfg.name = iq["name"].as<std::string>();
-      } catch (const YAML::Exception &) {
-        throw std::runtime_error("'name' must be a string for irq=" + std::to_string(cfg.irq));
-      }
-    }
-    cfg.affinity =
-      parse_affinity(iq, "irq=" + std::to_string(cfg.irq), /*allow_unmanageable=*/true);
-  }
-
-  std::unordered_set<int> seen;
-  for (const auto & c : result) {
-    // cppcheck-suppress useStlAlgorithm
-    if (!seen.insert(c.irq).second) {
-      throw std::runtime_error("Duplicate irq entry: irq=" + std::to_string(c.irq));
-    }
-  }
-  return result;
+  return config;
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -54,7 +54,7 @@ bool same_cpu_set(const std::vector<int> & desired, const std::optional<std::vec
 // cannot be read back from stat, so a DEADLINE request always takes the
 // syscall path (never counted in-sync; it can still end up in failed).
 bool kernel_thread_in_sync(
-  const agnocast_cie_thread_configurator::KernelThreadConfig & config,
+  const agnocast_cie_thread_configurator::KernelThreadEntry & config,
   const agnocast_cie_thread_configurator::KernelThreadInfo & info)
 {
   const auto & attrs = config.attrs;
@@ -91,13 +91,27 @@ constexpr const char * k_cap_guidance =
 // optional (empty skips the identity check), so an unset one is labeled
 // instead of being printed as ''.
 void log_irq_vanished(
-  const rclcpp::Logger & logger, const agnocast_cie_thread_configurator::IrqConfig & config)
+  const rclcpp::Logger & logger, const agnocast_cie_thread_configurator::IrqEntry & config)
 {
   RCLCPP_ERROR(
     logger,
     "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
     "change across boots or device changes; re-run prerun_node and update the config.",
     config.irq, config.name.empty() ? "<not recorded>" : config.name.c_str());
+}
+
+// Wraps freshly parsed entries with their (empty) runtime state.
+template <typename Tracked, typename Entry>
+std::vector<Tracked> track(std::vector<Entry> entries)
+{
+  std::vector<Tracked> tracked;
+  tracked.reserve(entries.size());
+  for (auto & entry : entries) {
+    Tracked t;
+    t.entry = std::move(entry);
+    tracked.push_back(std::move(t));
+  }
+  return tracked;
 }
 
 }  // namespace
@@ -128,10 +142,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   RCLCPP_INFO(this->get_logger(), "Loaded config from: %s", config_file_.c_str());
 
-  agnocast_cie_thread_configurator::parse_yaml(
-    yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
-  kernel_thread_configs_ = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
-  irq_configs_ = agnocast_cie_thread_configurator::parse_irqs(yaml);
+  auto parsed = agnocast_cie_thread_configurator::parse_config(yaml, default_domain_id_);
+  callback_group_configs_ = track<TrackedCallbackGroup>(std::move(parsed.callback_groups));
+  non_ros_thread_configs_ = track<TrackedNonRosThread>(std::move(parsed.non_ros_threads));
+  kernel_thread_configs_ = std::move(parsed.kernel_threads);
+  irq_configs_ = std::move(parsed.irqs);
 
   // Kernel threads and IRQs never announce themselves: configure them here
   // from a /proc scan, outside the announcement-driven accounting below.
@@ -151,15 +166,16 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   std::set<size_t> domain_ids;
   for (auto & cfg : callback_group_configs_) {
-    domain_ids.insert(cfg.domain_id);
-    if (cfg.is_wildcard()) {
-      node_to_wildcard_config_[std::make_pair(cfg.domain_id, cfg.wildcard_prefix())] = &cfg;
+    const auto & entry = cfg.entry;
+    domain_ids.insert(entry.domain_id);
+    if (entry.is_wildcard()) {
+      node_to_wildcard_config_[std::make_pair(entry.domain_id, entry.wildcard_prefix())] = &cfg;
     } else {
-      id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+      id_to_callback_group_config_[std::make_pair(entry.domain_id, entry.id)] = &cfg;
     }
   }
   for (auto & cfg : non_ros_thread_configs_) {
-    id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
+    id_to_non_ros_thread_config_[cfg.entry.name] = &cfg;
   }
 
   sources_ = std::make_unique<agnocast_cie_thread_configurator::AnnouncementSources>(
@@ -278,7 +294,7 @@ void ThreadConfiguratorNode::print_all_unapplied()
 
   for (auto & config : callback_group_configs_) {
     if (!config.applied) {
-      RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
+      RCLCPP_WARN(this->get_logger(), "  - %s", config.entry.id.c_str());
     }
   }
 
@@ -286,7 +302,7 @@ void ThreadConfiguratorNode::print_all_unapplied()
 
   for (auto & config : non_ros_thread_configs_) {
     if (!config.applied) {
-      RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
+      RCLCPP_WARN(this->get_logger(), "  - %s", config.entry.name.c_str());
     }
   }
 }
@@ -449,7 +465,7 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel
   SectionApplyOutcome outcome;
   const bool any_managed = std::any_of(
     kernel_thread_configs_.begin(), kernel_thread_configs_.end(),
-    [](const KernelThreadConfig & config) { return config.is_managed(); });
+    [](const KernelThreadEntry & config) { return config.is_managed(); });
   if (!any_managed) {
     return outcome;
   }
@@ -535,7 +551,7 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_co
   SectionApplyOutcome outcome;
   const bool any_managed = std::any_of(
     irq_configs_.begin(), irq_configs_.end(),
-    [](const IrqConfig & config) { return config.is_managed(); });
+    [](const IrqEntry & config) { return config.is_managed(); });
   if (!any_managed) {
     return outcome;
   }
@@ -613,7 +629,7 @@ ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_co
   return outcome;
 }
 
-bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqConfig & config) const
+bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqEntry & config) const
 {
   const std::string path = "/proc/irq/" + std::to_string(config.irq) + "/smp_affinity_list";
   const std::string value = agnocast_cie_thread_configurator::format_cpu_list(config.affinity);
@@ -681,7 +697,7 @@ const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_
 void ThreadConfiguratorNode::callback_group_callback(
   size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg)
 {
-  ThreadConfig * config = nullptr;
+  TrackedCallbackGroup * config = nullptr;
   bool already_seen = false;
 
   // Exact entries take precedence over wildcard ("<node>/*") entries.
@@ -711,7 +727,7 @@ void ThreadConfiguratorNode::callback_group_callback(
     already_seen = config->matched_tids.count(msg->callback_group_id) > 0;
     RCLCPP_INFO(
       this->get_logger(), "Callback group (domain=%zu, id=%s) matched wildcard entry '%s'",
-      domain_id, msg->callback_group_id.c_str(), config->thread_str.c_str());
+      domain_id, msg->callback_group_id.c_str(), config->entry.id.c_str());
   }
 
   if (already_seen) {
@@ -729,13 +745,13 @@ void ThreadConfiguratorNode::callback_group_callback(
     this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%" PRId64 " | %s", domain_id,
     msg->thread_id, msg->callback_group_id.c_str());
   // Record the tid before the syscall so a failed attempt can be retried via reapply.
-  if (config->is_wildcard()) {
+  if (config->entry.is_wildcard()) {
     config->matched_tids[msg->callback_group_id] = msg->thread_id;
   } else {
     config->thread_id = msg->thread_id;
   }
 
-  if (!issue_syscalls(config->thread_str, config->attrs, msg->thread_id)) {
+  if (!issue_syscalls(config->entry.id, config->entry.attrs, msg->thread_id)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for callback group (domain=%zu, id=%s, tid=%" PRId64
@@ -771,7 +787,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     return;
   }
 
-  ThreadConfig * config = it->second;
+  TrackedNonRosThread * config = it->second;
   if (config->applied) {
     // Always re-apply: the OS may reuse the same thread IDs after an application
     // restarts, so we cannot use thread_id equality to skip reconfiguration.
@@ -786,7 +802,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     info.name.c_str());
   config->thread_id = info.tid;
 
-  if (!issue_syscalls(config->thread_str, config->attrs, info.tid)) {
+  if (!issue_syscalls(config->entry.name, config->entry.attrs, info.tid)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for non-ROS thread (name=%s, tid=%" PRId64
@@ -823,14 +839,9 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     return;
   }
 
-  std::vector<ThreadConfig> new_cb;
-  std::vector<ThreadConfig> new_nrt;
-  std::vector<KernelThreadConfig> new_kernel_threads;
-  std::vector<IrqConfig> new_irqs;
+  agnocast_cie_thread_configurator::ParsedConfig parsed;
   try {
-    agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
-    new_kernel_threads = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
-    new_irqs = agnocast_cie_thread_configurator::parse_irqs(yaml);
+    parsed = agnocast_cie_thread_configurator::parse_config(yaml, default_domain_id_);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();
@@ -844,14 +855,17 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   // picked up at the next announcement (see ReapplyConfig.srv). 'applied' is
   // intentionally NOT carried: a syscall failure below must leave
   // applied=false, not the stale 'true' that a verbatim carry-over would imply.
+  auto new_cb = track<TrackedCallbackGroup>(std::move(parsed.callback_groups));
   for (auto & cfg : new_cb) {
-    if (cfg.is_wildcard()) {
-      auto it = node_to_wildcard_config_.find(std::make_pair(cfg.domain_id, cfg.wildcard_prefix()));
+    const auto & entry = cfg.entry;
+    if (entry.is_wildcard()) {
+      auto it =
+        node_to_wildcard_config_.find(std::make_pair(entry.domain_id, entry.wildcard_prefix()));
       if (it != node_to_wildcard_config_.end()) {
         cfg.matched_tids = it->second->matched_tids;
       }
     } else {
-      auto it = id_to_callback_group_config_.find(std::make_pair(cfg.domain_id, cfg.thread_str));
+      auto it = id_to_callback_group_config_.find(std::make_pair(entry.domain_id, entry.id));
       if (it != id_to_callback_group_config_.end()) {
         cfg.thread_id = it->second->thread_id;
       }
@@ -862,10 +876,11 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   id_to_callback_group_config_.clear();
   node_to_wildcard_config_.clear();
   for (auto & cfg : callback_group_configs_) {
-    if (cfg.is_wildcard()) {
-      node_to_wildcard_config_[std::make_pair(cfg.domain_id, cfg.wildcard_prefix())] = &cfg;
+    const auto & entry = cfg.entry;
+    if (entry.is_wildcard()) {
+      node_to_wildcard_config_[std::make_pair(entry.domain_id, entry.wildcard_prefix())] = &cfg;
     } else {
-      id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+      id_to_callback_group_config_[std::make_pair(entry.domain_id, entry.id)] = &cfg;
     }
   }
 
@@ -874,8 +889,9 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   // update would be dropped by move-assign) nor race the counter store.
   {
     std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
+    auto new_nrt = track<TrackedNonRosThread>(std::move(parsed.non_ros_threads));
     for (auto & cfg : new_nrt) {
-      auto it = id_to_non_ros_thread_config_.find(cfg.thread_str);
+      auto it = id_to_non_ros_thread_config_.find(cfg.entry.name);
       if (it != id_to_non_ros_thread_config_.end()) {
         cfg.thread_id = it->second->thread_id;
       }
@@ -883,7 +899,7 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     non_ros_thread_configs_ = std::move(new_nrt);
     id_to_non_ros_thread_config_.clear();
     for (auto & cfg : non_ros_thread_configs_) {
-      id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
+      id_to_non_ros_thread_config_[cfg.entry.name] = &cfg;
     }
 
     unapplied_num_.store(
@@ -893,22 +909,23 @@ void ThreadConfiguratorNode::on_reapply_config_request(
 
   // No carry-over: kernel threads and IRQs are matched against a fresh /proc
   // scan on every apply pass.
-  kernel_thread_configs_ = std::move(new_kernel_threads);
-  irq_configs_ = std::move(new_irqs);
+  kernel_thread_configs_ = std::move(parsed.kernel_threads);
+  irq_configs_ = std::move(parsed.irqs);
 
   for (auto & cfg : callback_group_configs_) {
-    if (cfg.is_wildcard()) {
+    const auto & entry = cfg.entry;
+    if (entry.is_wildcard()) {
       // One applied/failed key per known instance; the pattern itself is
       // reported as skipped only while no instance has been announced yet.
       if (cfg.matched_tids.empty()) {
         response->skipped_callback_groups.push_back(
-          std::to_string(cfg.domain_id) + ":" + cfg.thread_str);
+          std::to_string(entry.domain_id) + ":" + entry.id);
         continue;
       }
       bool any_applied = false;
       for (const auto & [full_id, tid] : cfg.matched_tids) {
-        std::string key = std::to_string(cfg.domain_id) + ":" + full_id;
-        if (issue_syscalls(cfg.thread_str, cfg.attrs, tid)) {
+        std::string key = std::to_string(entry.domain_id) + ":" + full_id;
+        if (issue_syscalls(entry.id, entry.attrs, tid)) {
           response->applied_callback_groups.push_back(std::move(key));
           any_applied = true;
         } else {
@@ -922,12 +939,12 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       continue;
     }
 
-    std::string key = std::to_string(cfg.domain_id) + ":" + cfg.thread_str;
+    std::string key = std::to_string(entry.domain_id) + ":" + entry.id;
     if (cfg.thread_id == -1) {
       response->skipped_callback_groups.push_back(std::move(key));
       continue;
     }
-    if (issue_syscalls(cfg.thread_str, cfg.attrs, cfg.thread_id)) {
+    if (issue_syscalls(entry.id, entry.attrs, cfg.thread_id)) {
       response->applied_callback_groups.push_back(std::move(key));
       cfg.applied = true;
       unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
@@ -939,18 +956,19 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   {
     std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
     for (auto & cfg : non_ros_thread_configs_) {
+      const auto & entry = cfg.entry;
       if (cfg.thread_id == -1) {
-        response->skipped_non_ros_threads.push_back(cfg.thread_str);
+        response->skipped_non_ros_threads.push_back(entry.name);
         continue;
       }
-      if (issue_syscalls(cfg.thread_str, cfg.attrs, cfg.thread_id)) {
-        response->applied_non_ros_threads.push_back(cfg.thread_str);
+      if (issue_syscalls(entry.name, entry.attrs, cfg.thread_id)) {
+        response->applied_non_ros_threads.push_back(entry.name);
         if (!cfg.applied) {
           cfg.applied = true;
           unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
         }
       } else {
-        response->failed_non_ros_threads.push_back(cfg.thread_str);
+        response->failed_non_ros_threads.push_back(entry.name);
       }
     }
   }

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -21,23 +21,18 @@ YAML::Node yaml_from_str(const char * s)
   return YAML::Load(s);
 }
 
+acie::ParsedConfig parse(const YAML::Node & yaml)
+{
+  return acie::parse_config(yaml, kTestDefaultDomain);
+}
+
 // EXPECT_THROW alone cannot tell WHICH validation fired (every failure path
 // derives from std::runtime_error), so the negative tests also match a
 // distinguishing fragment of the message.
-void expect_kernel_threads_error(const char * yaml, const std::string & fragment)
+void expect_error(const char * yaml, const std::string & fragment)
 {
   try {
-    acie::parse_kernel_threads(yaml_from_str(yaml));
-    FAIL() << "expected std::runtime_error";
-  } catch (const std::runtime_error & e) {
-    EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos) << e.what();
-  }
-}
-
-void expect_irqs_error(const char * yaml, const std::string & fragment)
-{
-  try {
-    acie::parse_irqs(yaml_from_str(yaml));
+    parse(yaml_from_str(yaml));
     FAIL() << "expected std::runtime_error";
   } catch (const std::runtime_error & e) {
     EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos) << e.what();
@@ -45,18 +40,17 @@ void expect_irqs_error(const char * yaml, const std::string & fragment)
 }
 }  // namespace
 
-// ---------- parse_yaml ----------
+// ---------- callback_groups / non_ros_threads ----------
 
-TEST(ParseYaml, ParsesEmptyConfig)
+TEST(ParseConfig, ParsesEmptyConfig)
 {
   auto y = yaml_from_str("callback_groups: []\nnon_ros_threads: []\n");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  EXPECT_TRUE(cb.empty());
-  EXPECT_TRUE(nrt.empty());
+  const auto config = parse(y);
+  EXPECT_TRUE(config.callback_groups.empty());
+  EXPECT_TRUE(config.non_ros_threads.empty());
 }
 
-TEST(ParseYaml, ParsesCallbackGroupSchedFifo)
+TEST(ParseConfig, ParsesCallbackGroupSchedFifo)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -67,20 +61,17 @@ callback_groups:
     affinity: [0, 1]
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].thread_str, "my_cbg");
-  EXPECT_EQ(cb[0].domain_id, 3u);
-  EXPECT_EQ(cb[0].attrs.policy, acie::SchedPolicy::Fifo);
-  EXPECT_EQ(cb[0].attrs.rt_priority, 50);
-  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{0, 1}));
-  EXPECT_EQ(cb[0].thread_id, -1);
-  EXPECT_FALSE(cb[0].applied);
-  EXPECT_FALSE(cb[0].is_wildcard());
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].id, "my_cbg");
+  EXPECT_EQ(config.callback_groups[0].domain_id, 3u);
+  EXPECT_EQ(config.callback_groups[0].attrs.policy, acie::SchedPolicy::Fifo);
+  EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 50);
+  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{0, 1}));
+  EXPECT_FALSE(config.callback_groups[0].is_wildcard());
 }
 
-TEST(ParseYaml, ParsesNiceForCfsPolicies)
+TEST(ParseConfig, ParsesNiceForCfsPolicies)
 {
   for (const char * policy : {"SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"}) {
     auto y = yaml_from_str(("callback_groups:\n"
@@ -93,15 +84,14 @@ TEST(ParseYaml, ParsesNiceForCfsPolicies)
                             "    affinity: []\n"
                             "non_ros_threads: []\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt)) << policy;
-    ASSERT_EQ(cb.size(), 1u);
-    EXPECT_EQ(cb[0].attrs.nice, -10) << policy;
-    EXPECT_EQ(cb[0].attrs.rt_priority, 0) << policy;
+    const auto config = parse(y);
+    ASSERT_EQ(config.callback_groups.size(), 1u);
+    EXPECT_EQ(config.callback_groups[0].attrs.nice, -10) << policy;
+    EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 0) << policy;
   }
 }
 
-TEST(ParseYaml, IgnoresStrayKeyOfTheOtherPolicyClass)
+TEST(ParseConfig, IgnoresStrayKeyOfTheOtherPolicyClass)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -119,16 +109,15 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 2u);
-  EXPECT_EQ(cb[0].attrs.nice, -5);
-  EXPECT_EQ(cb[0].attrs.rt_priority, 0);
-  EXPECT_EQ(cb[1].attrs.rt_priority, 50);
-  EXPECT_EQ(cb[1].attrs.nice, 0);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 2u);
+  EXPECT_EQ(config.callback_groups[0].attrs.nice, -5);
+  EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 0);
+  EXPECT_EQ(config.callback_groups[1].attrs.rt_priority, 50);
+  EXPECT_EQ(config.callback_groups[1].attrs.nice, 0);
 }
 
-TEST(ParseYaml, RejectsMissingNiceOnSchedOther)
+TEST(ParseConfig, RejectsMissingNiceOnSchedOther)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -138,11 +127,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsNiceOutOfRange)
+TEST(ParseConfig, RejectsNiceOutOfRange)
 {
   for (const char * bad_nice : {"-21", "20", "50"}) {
     auto y = yaml_from_str(("callback_groups:\n"
@@ -155,13 +143,11 @@ TEST(ParseYaml, RejectsNiceOutOfRange)
                             "    affinity: []\n"
                             "non_ros_threads: []\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
-      << "nice=" << bad_nice;
+    EXPECT_THROW(parse(y), std::runtime_error) << "nice=" << bad_nice;
   }
 }
 
-TEST(ParseYaml, TreatsNullNiceAsMissing)
+TEST(ParseConfig, TreatsNullNiceAsMissing)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -172,16 +158,15 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
   try {
-    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    parse(y);
     FAIL() << "expected std::runtime_error";
   } catch (const std::runtime_error & e) {
     EXPECT_NE(std::string(e.what()).find("requires 'nice'"), std::string::npos) << e.what();
   }
 }
 
-TEST(ParseYaml, ReportsEntryOnNonIntegerNice)
+TEST(ParseConfig, ReportsEntryOnNonIntegerNice)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -192,9 +177,8 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
   try {
-    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    parse(y);
     FAIL() << "expected std::runtime_error";
   } catch (const std::runtime_error & e) {
     const std::string what = e.what();
@@ -203,7 +187,7 @@ non_ros_threads: []
   }
 }
 
-TEST(ParseYaml, ReportsEntryOnNonIntegerRtPriority)
+TEST(ParseConfig, ReportsEntryOnNonIntegerRtPriority)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -214,9 +198,8 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
   try {
-    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    parse(y);
     FAIL() << "expected std::runtime_error";
   } catch (const std::runtime_error & e) {
     const std::string what = e.what();
@@ -225,7 +208,7 @@ non_ros_threads: []
   }
 }
 
-TEST(ParseYaml, RejectsMissingPriorityOnRtPolicy)
+TEST(ParseConfig, RejectsMissingPriorityOnRtPolicy)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -235,11 +218,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsRtPriorityOutOfRange)
+TEST(ParseConfig, RejectsRtPriorityOutOfRange)
 {
   for (const char * bad_priority : {"0", "100", "-1"}) {
     auto y = yaml_from_str(("callback_groups:\n"
@@ -252,13 +234,11 @@ TEST(ParseYaml, RejectsRtPriorityOutOfRange)
                             "    affinity: []\n"
                             "non_ros_threads: []\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
-      << "priority=" << bad_priority;
+    EXPECT_THROW(parse(y), std::runtime_error) << "priority=" << bad_priority;
   }
 }
 
-TEST(ParseYaml, FallsBackToDefaultDomainId)
+TEST(ParseConfig, FallsBackToDefaultDomainId)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -268,13 +248,12 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].domain_id, kTestDefaultDomain);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].domain_id, kTestDefaultDomain);
 }
 
-TEST(ParseYaml, ParsesSchedDeadline)
+TEST(ParseConfig, ParsesSchedDeadline)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -287,16 +266,15 @@ callback_groups:
     affinity: [0]
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].attrs.policy, acie::SchedPolicy::Deadline);
-  EXPECT_EQ(cb[0].attrs.deadline.runtime, 1000000u);
-  EXPECT_EQ(cb[0].attrs.deadline.period, 5000000u);
-  EXPECT_EQ(cb[0].attrs.deadline.deadline, 5000000u);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].attrs.policy, acie::SchedPolicy::Deadline);
+  EXPECT_EQ(config.callback_groups[0].attrs.deadline.runtime, 1000000u);
+  EXPECT_EQ(config.callback_groups[0].attrs.deadline.period, 5000000u);
+  EXPECT_EQ(config.callback_groups[0].attrs.deadline.deadline, 5000000u);
 }
 
-TEST(ParseYaml, AcceptsDeadlineParamsBeyond32Bits)
+TEST(ParseConfig, AcceptsDeadlineParamsBeyond32Bits)
 {
   // sched_attr carries nanoseconds in 64-bit fields; a 5 s period exceeds
   // 2^32 ns.
@@ -311,13 +289,12 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].attrs.deadline.period, 5000000000u);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].attrs.deadline.period, 5000000000u);
 }
 
-TEST(ParseYaml, RejectsUnknownPolicyOnCallbackGroup)
+TEST(ParseConfig, RejectsUnknownPolicyOnCallbackGroup)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -328,11 +305,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsUnknownPolicyOnNonRosThread)
+TEST(ParseConfig, RejectsUnknownPolicyOnNonRosThread)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups: []
@@ -342,14 +318,13 @@ non_ros_threads:
     priority: 0
     affinity: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsSchedDeadlineMissingRuntimeField)
+TEST(ParseConfig, RejectsSchedDeadlineMissingRuntimeField)
 {
-  // SCHED_DEADLINE requires runtime/period/deadline. parse_yaml calls
-  // .as<unsigned int>() on a missing node, which makes yaml-cpp throw
+  // SCHED_DEADLINE requires runtime/period/deadline. parse_config calls
+  // .as<uint64_t>() on a missing node, which makes yaml-cpp throw
   // YAML::TypedBadConversion (a subclass of YAML::Exception, which is
   // a subclass of std::runtime_error). The test catches the most general
   // shape so it does not couple to the precise yaml-cpp exception type.
@@ -361,11 +336,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, ParsesNonRosThread)
+TEST(ParseConfig, ParsesNonRosThread)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups: []
@@ -375,44 +349,14 @@ non_ros_threads:
     priority: 30
     affinity: [0]
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(nrt.size(), 1u);
-  EXPECT_EQ(nrt[0].thread_str, "worker");
-  EXPECT_EQ(nrt[0].attrs.policy, acie::SchedPolicy::Rr);
-  EXPECT_EQ(nrt[0].attrs.rt_priority, 30);
+  const auto config = parse(y);
+  ASSERT_EQ(config.non_ros_threads.size(), 1u);
+  EXPECT_EQ(config.non_ros_threads[0].name, "worker");
+  EXPECT_EQ(config.non_ros_threads[0].attrs.policy, acie::SchedPolicy::Rr);
+  EXPECT_EQ(config.non_ros_threads[0].attrs.rt_priority, 30);
 }
 
-TEST(ParseYaml, ClearsOutputVectorsOnReparse)
-{
-  auto y1 = yaml_from_str(R"YAML(
-callback_groups:
-  - id: alpha
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y1, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-
-  auto y2 = yaml_from_str(R"YAML(
-callback_groups:
-  - id: beta
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  acie::parse_yaml(y2, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].thread_str, "beta");
-}
-
-TEST(ParseYaml, RejectsDuplicateCallbackGroupKey)
+TEST(ParseConfig, RejectsDuplicateCallbackGroupKey)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -428,11 +372,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, AllowsSameIdInDifferentDomains)
+TEST(ParseConfig, AllowsSameIdInDifferentDomains)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -448,12 +391,11 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 2u);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 2u);
 }
 
-TEST(ParseYaml, RejectsDuplicateNonRosThreadName)
+TEST(ParseConfig, RejectsDuplicateNonRosThreadName)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups: []
@@ -467,13 +409,12 @@ non_ros_threads:
     nice: 0
     affinity: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
 // ---------- wildcard ("<node name>/*") callback-group ids ----------
 
-TEST(ParseYaml, ParsesWildcardCallbackGroupId)
+TEST(ParseConfig, ParsesWildcardCallbackGroupId)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -484,16 +425,14 @@ callback_groups:
     affinity: [0]
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_TRUE(cb[0].is_wildcard());
-  EXPECT_EQ(cb[0].wildcard_prefix(), "/perception/lidar_node");
-  EXPECT_EQ(cb[0].thread_str, "/perception/lidar_node/*");  // kept as written
-  EXPECT_TRUE(cb[0].matched_tids.empty());
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_TRUE(config.callback_groups[0].is_wildcard());
+  EXPECT_EQ(config.callback_groups[0].wildcard_prefix(), "/perception/lidar_node");
+  EXPECT_EQ(config.callback_groups[0].id, "/perception/lidar_node/*");  // kept as written
 }
 
-TEST(ParseYaml, RejectsWildcardWithEmptyNodePart)
+TEST(ParseConfig, RejectsWildcardWithEmptyNodePart)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -504,11 +443,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsStrayAsteriskInId)
+TEST(ParseConfig, RejectsStrayAsteriskInId)
 {
   for (const char * bad_id :
        {"/node*", "/node/**", "/node/*x", "/a/*/b", "*", "/node/*@Waitable"}) {
@@ -522,13 +460,11 @@ TEST(ParseYaml, RejectsStrayAsteriskInId)
                             "    affinity: []\n"
                             "non_ros_threads: []\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
-      << "id=" << bad_id;
+    EXPECT_THROW(parse(y), std::runtime_error) << "id=" << bad_id;
   }
 }
 
-TEST(ParseYaml, RejectsAtSignInWildcardPrefix)
+TEST(ParseConfig, RejectsAtSignInWildcardPrefix)
 {
   // A full callback-group id copied from the template with "/*" appended.
   auto y = yaml_from_str(R"YAML(
@@ -540,11 +476,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, RejectsDuplicateWildcardKey)
+TEST(ParseConfig, RejectsDuplicateWildcardKey)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -560,11 +495,10 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseYaml, AllowsSameWildcardInDifferentDomains)
+TEST(ParseConfig, AllowsSameWildcardInDifferentDomains)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -580,12 +514,11 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 2u);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 2u);
 }
 
-TEST(ParseYaml, AllowsExactAndWildcardForSameNode)
+TEST(ParseConfig, AllowsExactAndWildcardForSameNode)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -601,14 +534,13 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 2u);
-  EXPECT_TRUE(cb[0].is_wildcard());
-  EXPECT_FALSE(cb[1].is_wildcard());
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 2u);
+  EXPECT_TRUE(config.callback_groups[0].is_wildcard());
+  EXPECT_FALSE(config.callback_groups[1].is_wildcard());
 }
 
-TEST(ParseYaml, NonRosThreadNameEndingInSlashStarStaysExact)
+TEST(ParseConfig, NonRosThreadNameEndingInSlashStarStaysExact)
 {
   // Wildcards are a callback_groups-only feature; non_ros_threads names are
   // opaque strings matched exactly, even when they happen to end in "/*".
@@ -620,15 +552,14 @@ non_ros_threads:
     nice: 0
     affinity: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(nrt.size(), 1u);
-  EXPECT_EQ(nrt[0].thread_str, "worker/*");
+  const auto config = parse(y);
+  ASSERT_EQ(config.non_ros_threads.size(), 1u);
+  EXPECT_EQ(config.non_ros_threads[0].name, "worker/*");
 }
 
 // ---------- affinity validation ----------
 
-TEST(ParseYaml, NormalizesAffinityToSortedUnique)
+TEST(ParseConfig, NormalizesAffinityToSortedUnique)
 {
   // parse_affinity bounds values by the machine CPU count, so only CPUs 0
   // and 1 are used to keep this test valid on small CI machines.
@@ -645,15 +576,14 @@ non_ros_threads:
     nice: 0
     affinity: [1, 1, 0]
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{0, 1}));
-  ASSERT_EQ(nrt.size(), 1u);
-  EXPECT_EQ(nrt[0].attrs.affinity, (std::vector<int>{0, 1}));
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{0, 1}));
+  ASSERT_EQ(config.non_ros_threads.size(), 1u);
+  EXPECT_EQ(config.non_ros_threads[0].attrs.affinity, (std::vector<int>{0, 1}));
 }
 
-TEST(ParseYaml, TreatsAbsentOrNullAffinityAsUnmanaged)
+TEST(ParseConfig, TreatsAbsentOrNullAffinityAsUnmanaged)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -668,14 +598,13 @@ callback_groups:
     affinity: ~
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 2u);
-  EXPECT_TRUE(cb[0].attrs.affinity.empty());
-  EXPECT_TRUE(cb[1].attrs.affinity.empty());
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 2u);
+  EXPECT_TRUE(config.callback_groups[0].attrs.affinity.empty());
+  EXPECT_TRUE(config.callback_groups[1].attrs.affinity.empty());
 }
 
-TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
+TEST(ParseConfig, RejectsAffinityCpuOutOfRange)
 {
   // CPU_SET(3) / sched_setaffinity(2) would silently ignore all of these,
   // shrinking the mask without any error report. The valid CPU 0 in front
@@ -694,13 +623,11 @@ TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
                             "\n"
                             "non_ros_threads: []\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
-      << "affinity=" << bad_affinity;
+    EXPECT_THROW(parse(y), std::runtime_error) << "affinity=" << bad_affinity;
   }
 }
 
-TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
+TEST(ParseConfig, AcceptsHighestValidAffinityCpu)
 {
   // Pins the accept side of the [0, min(CPU_SETSIZE, num_cpus)) boundary.
   const int max_cpu =
@@ -715,13 +642,12 @@ TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
                           "]\n"
                           "non_ros_threads: []\n")
                            .c_str());
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].attrs.affinity, (std::vector<int>{max_cpu}));
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{max_cpu}));
 }
 
-TEST(ParseYaml, RejectsScalarAffinity)
+TEST(ParseConfig, RejectsScalarAffinity)
 {
   // A scalar iterates zero times and would otherwise silently mean
   // "no affinity".
@@ -734,13 +660,11 @@ TEST(ParseYaml, RejectsScalarAffinity)
                             "    affinity: " +
                             std::string(bad_affinity) + "\n")
                              .c_str());
-    std::vector<acie::ThreadConfig> cb, nrt;
-    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
-      << "affinity=" << bad_affinity;
+    EXPECT_THROW(parse(y), std::runtime_error) << "affinity=" << bad_affinity;
   }
 }
 
-TEST(ParseYaml, ReportsEntryOnNonIntegerAffinityElement)
+TEST(ParseConfig, ReportsEntryOnNonIntegerAffinityElement)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -751,9 +675,8 @@ callback_groups:
     affinity: [0, all]
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
   try {
-    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    parse(y);
     FAIL() << "expected std::runtime_error";
   } catch (const std::runtime_error & e) {
     const std::string what = e.what();
@@ -773,13 +696,13 @@ TEST(ExtractNodePart, SplitsAtFirstAtSign)
   EXPECT_EQ(acie::extract_node_part(""), "");
 }
 
-// ---------- parse_kernel_threads ----------
+// ---------- kernel_threads ----------
 
 TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
 {
-  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("callback_groups: []\n")).empty());
-  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: ~\n")).empty());
-  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: []\n")).empty());
+  EXPECT_TRUE(parse(yaml_from_str("callback_groups: []\n")).kernel_threads.empty());
+  EXPECT_TRUE(parse(yaml_from_str("kernel_threads: ~\n")).kernel_threads.empty());
+  EXPECT_TRUE(parse(yaml_from_str("kernel_threads: []\n")).kernel_threads.empty());
 }
 
 TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
@@ -792,7 +715,7 @@ kernel_threads:
     priority: 10
     affinity: [0, 1]
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].comm, "agnocast_exit_w");
   EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Fifo);
@@ -810,7 +733,7 @@ kernel_threads:
     nice: -10
     affinity: ~
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Other);
   EXPECT_EQ(result[0].attrs.nice, -10);
@@ -827,7 +750,7 @@ kernel_threads:
     priority: ~
     affinity: ~
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_FALSE(result[0].attrs.policy.has_value());
   EXPECT_TRUE(result[0].attrs.affinity.empty());
@@ -844,7 +767,7 @@ kernel_threads:
     priority: UNMANAGEABLE
     affinity: UNMANAGEABLE
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_FALSE(result[0].attrs.policy.has_value());
   EXPECT_TRUE(result[0].attrs.affinity.empty());
@@ -860,7 +783,7 @@ kernel_threads:
     priority: ~
     affinity: [1]
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_FALSE(result[0].attrs.policy.has_value());
   EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{1}));
@@ -876,7 +799,7 @@ kernel_threads:
     priority: ~
     affinity: [1, 0, 1]
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{0, 1}));
 }
@@ -885,7 +808,7 @@ TEST(ParseKernelThreads, RejectsScalarAndOutOfRangeAffinity)
 {
   // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
   // silently mean "leave alone".
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: nfsd
@@ -894,7 +817,7 @@ kernel_threads:
     affinity: 0-3
 )YAML",
     "'affinity' must be a list");
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: nfsd
@@ -914,7 +837,7 @@ kernel_threads:
     priority: 5
     affinity: UNMANAGEABLE
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   ASSERT_TRUE(result[0].attrs.policy.has_value());
   EXPECT_TRUE(result[0].attrs.affinity.empty());
@@ -932,7 +855,7 @@ kernel_threads:
     deadline: 5000000
     affinity: ~
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Deadline);
   EXPECT_EQ(result[0].attrs.deadline.runtime, 1000000u);
@@ -951,7 +874,7 @@ kernel_threads:
     deadline: 5000000000
     affinity: ~
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].attrs.deadline.period, 5000000000u);
 }
@@ -962,7 +885,7 @@ TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
   // must fall through to the normal validation (here: unknown policy). No
   // other attribute key is set, so a case-insensitive sentinel match would
   // parse cleanly and fail the test.
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -974,7 +897,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsMissingOrEmptyComm)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - policy: ~
@@ -982,7 +905,7 @@ kernel_threads:
     affinity: ~
 )YAML",
     "is missing a non-empty 'comm'");
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: ""
@@ -995,7 +918,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsNonStringComm)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: [a, b]
@@ -1008,7 +931,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsKworkerComm)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: kworker/0:0H-events_highpri
@@ -1031,7 +954,7 @@ kernel_threads:
     priority: ~
     affinity: [0]
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
   EXPECT_TRUE(result[0].is_managed());
@@ -1039,7 +962,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsDuplicateComm)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: nfsd
@@ -1056,7 +979,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsUnknownPolicy)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1069,7 +992,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsPriorityWithoutPolicy)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1082,7 +1005,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsNiceWithoutPolicy)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1097,7 +1020,7 @@ TEST(ParseKernelThreads, RejectsCfsPolicyWithoutNice)
 {
   // As in callback_groups, a CFS policy takes 'nice'; 'priority' does not
   // satisfy the requirement.
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1110,7 +1033,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsOutOfRangeNiceAndRtPriority)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: nfsd
@@ -1119,7 +1042,7 @@ kernel_threads:
     affinity: ~
 )YAML",
     "'nice' must be in [-20, 19]");
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: nfsd
@@ -1132,7 +1055,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1143,7 +1066,7 @@ kernel_threads:
     "requires 'priority'");
   // The sentinel counts as unset exactly like null does, and the message
   // says so because the key is visibly present.
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: rcu_preempt
@@ -1159,7 +1082,7 @@ TEST(ParseKernelThreads, RejectsDeadlineFieldsWithoutPolicy)
   // The full SCHED_DEADLINE triple with 'policy' forgotten would otherwise
   // parse cleanly as unmanaged, the same silently dead configuration the
   // nice/priority guard rejects.
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: dl_thread
@@ -1174,7 +1097,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: dl_thread
@@ -1187,7 +1110,7 @@ kernel_threads:
 
 TEST(ParseKernelThreads, RejectsMalformedSchedDeadlineFields)
 {
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: dl_thread
@@ -1198,7 +1121,7 @@ kernel_threads:
     affinity: ~
 )YAML",
     "'runtime' must be a non-negative decimal integer for comm=dl_thread");
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: dl_thread
@@ -1210,7 +1133,7 @@ kernel_threads:
 )YAML",
     "'period' must be a non-negative decimal integer for comm=dl_thread");
   // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
-  expect_kernel_threads_error(
+  expect_error(
     R"YAML(
 kernel_threads:
   - comm: dl_thread
@@ -1236,7 +1159,7 @@ kernel_threads:
     deadline: 5000000
     affinity: ~
 )YAML");
-  const auto result = acie::parse_kernel_threads(y);
+  const auto result = parse(y).kernel_threads;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].attrs.deadline.runtime, 500000u);
 }
@@ -1244,24 +1167,24 @@ kernel_threads:
 TEST(ParseKernelThreads, RejectsNonListSection)
 {
   // A scalar or map section would otherwise silently parse as empty.
-  expect_kernel_threads_error("kernel_threads: oops\n", "'kernel_threads' must be a list");
-  expect_kernel_threads_error("kernel_threads:\n  comm: nfsd\n", "'kernel_threads' must be a list");
+  expect_error("kernel_threads: oops\n", "'kernel_threads' must be a list");
+  expect_error("kernel_threads:\n  comm: nfsd\n", "'kernel_threads' must be a list");
 }
 
 TEST(ParseKernelThreads, RejectsScalarListEntry)
 {
   // A plausible shorthand (a list of bare comms) must fail with the entry
   // diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_kernel_threads_error("kernel_threads: [nfsd]\n", "entry #0 must be a mapping");
+  expect_error("kernel_threads: [nfsd]\n", "entry #0 must be a mapping");
 }
 
-// ---------- parse_irqs ----------
+// ---------- irqs ----------
 
 TEST(ParseIrqs, MissingOrNullSectionYieldsEmpty)
 {
-  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("callback_groups: []\n")).empty());
-  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: ~\n")).empty());
-  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: []\n")).empty());
+  EXPECT_TRUE(parse(yaml_from_str("callback_groups: []\n")).irqs.empty());
+  EXPECT_TRUE(parse(yaml_from_str("irqs: ~\n")).irqs.empty());
+  EXPECT_TRUE(parse(yaml_from_str("irqs: []\n")).irqs.empty());
 }
 
 TEST(ParseIrqs, ParsesFilledAffinityAndName)
@@ -1272,7 +1195,7 @@ irqs:
     name: nvidia
     affinity: [1, 0]
 )YAML");
-  const auto result = acie::parse_irqs(y);
+  const auto result = parse(y).irqs;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].irq, 103);
   EXPECT_EQ(result[0].name, "nvidia");
@@ -1291,7 +1214,7 @@ irqs:
     name: i8042
     affinity: ~
 )YAML");
-  const auto result = acie::parse_irqs(y);
+  const auto result = parse(y).irqs;
   ASSERT_EQ(result.size(), 2u);
   EXPECT_FALSE(result[0].is_managed());
   EXPECT_FALSE(result[1].is_managed());
@@ -1304,7 +1227,7 @@ irqs:
   - irq: 42
     affinity: [1]
 )YAML");
-  const auto result = acie::parse_irqs(y);
+  const auto result = parse(y).irqs;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_TRUE(result[0].name.empty());
   EXPECT_TRUE(result[0].is_managed());
@@ -1312,21 +1235,21 @@ irqs:
 
 TEST(ParseIrqs, RejectsMissingOrNegativeOrNonIntIrq)
 {
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - name: orphan
     affinity: ~
 )YAML",
     "is missing a non-negative integer 'irq'");
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: -1
     affinity: ~
 )YAML",
     "'irq' must be a non-negative decimal integer, got '-1'");
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: not_a_number
@@ -1344,7 +1267,7 @@ irqs:
   - irq: 010
     affinity: ~
 )YAML");
-  const auto result = acie::parse_irqs(y);
+  const auto result = parse(y).irqs;
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].irq, 10);
 }
@@ -1352,7 +1275,7 @@ irqs:
 TEST(ParseIrqs, RejectsHexIrq)
 {
   // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: 0x10
@@ -1363,7 +1286,7 @@ irqs:
 
 TEST(ParseIrqs, RejectsDuplicateIrq)
 {
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: 5
@@ -1378,14 +1301,14 @@ TEST(ParseIrqs, RejectsScalarAndOutOfRangeAffinity)
 {
   // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
   // silently mean "leave alone".
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: 10
     affinity: 0-3
 )YAML",
     "'affinity' must be a list");
-  expect_irqs_error(
+  expect_error(
     R"YAML(
 irqs:
   - irq: 10
@@ -1396,20 +1319,20 @@ irqs:
 
 TEST(ParseIrqs, RejectsNonListSection)
 {
-  expect_irqs_error("irqs: oops\n", "'irqs' must be a list");
-  expect_irqs_error("irqs:\n  irq: 5\n", "'irqs' must be a list");
+  expect_error("irqs: oops\n", "'irqs' must be a list");
+  expect_error("irqs:\n  irq: 5\n", "'irqs' must be a list");
 }
 
 TEST(ParseIrqs, RejectsScalarListEntry)
 {
   // A plausible shorthand (a list of bare IRQ numbers) must fail with the
   // entry diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_irqs_error("irqs: [42]\n", "entry #0 must be a mapping");
+  expect_error("irqs: [42]\n", "entry #0 must be a mapping");
 }
 
-// ---------- new sections vs parse_yaml ----------
+// ---------- all sections ----------
 
-TEST(ParseYaml, IgnoresKernelThreadsAndIrqsSections)
+TEST(ParseConfig, ParsesAllFourSectionsIntoTheirVectors)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
@@ -1418,7 +1341,11 @@ callback_groups:
     policy: SCHED_OTHER
     nice: 0
     affinity: []
-non_ros_threads: []
+non_ros_threads:
+  - name: worker
+    policy: SCHED_RR
+    priority: 30
+    affinity: [0]
 kernel_threads:
   - comm: agnocast_exit_w
     policy: SCHED_FIFO
@@ -1429,14 +1356,32 @@ irqs:
     name: nvidia
     affinity: [0, 1]
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].thread_str, "my_cbg");
-  EXPECT_TRUE(nrt.empty());
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].id, "my_cbg");
+  ASSERT_EQ(config.non_ros_threads.size(), 1u);
+  EXPECT_EQ(config.non_ros_threads[0].name, "worker");
+  EXPECT_EQ(config.non_ros_threads[0].attrs.policy, acie::SchedPolicy::Rr);
+  EXPECT_EQ(config.non_ros_threads[0].attrs.rt_priority, 30);
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_EQ(config.kernel_threads[0].comm, "agnocast_exit_w");
+  ASSERT_EQ(config.irqs.size(), 1u);
+  EXPECT_EQ(config.irqs[0].irq, 103);
 }
 
-TEST(ParseYaml, UnmanageableSentinelIsNotRecognized)
+TEST(ParseConfig, MissingOrNullSectionsYieldEmpty)
+{
+  for (const char * yaml :
+       {"{}\n", "callback_groups: ~\nnon_ros_threads: ~\nkernel_threads: ~\nirqs: ~\n"}) {
+    const auto config = parse(yaml_from_str(yaml));
+    EXPECT_TRUE(config.callback_groups.empty()) << yaml;
+    EXPECT_TRUE(config.non_ros_threads.empty()) << yaml;
+    EXPECT_TRUE(config.kernel_threads.empty()) << yaml;
+    EXPECT_TRUE(config.irqs.empty()) << yaml;
+  }
+}
+
+TEST(ParseConfig, UnmanageableSentinelIsNotRecognized)
 {
   // The sentinel is scoped to kernel_threads/irqs (the tool writes it there);
   // in the hand-written sections it must fail like any other invalid value,
@@ -1449,8 +1394,7 @@ callback_groups:
     affinity: UNMANAGEABLE
 non_ros_threads: []
 )YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y), std::runtime_error);
 
   auto y2 = yaml_from_str(R"YAML(
 callback_groups: []
@@ -1460,5 +1404,5 @@ non_ros_threads:
     nice: UNMANAGEABLE
     affinity: ~
 )YAML");
-  EXPECT_THROW(acie::parse_yaml(y2, kTestDefaultDomain, cb, nrt), std::runtime_error);
+  EXPECT_THROW(parse(y2), std::runtime_error);
 }


### PR DESCRIPTION
## Description

`ThreadConfig` mixed what the YAML asks for (id, domain, scheduling attributes) with what the daemon observes (`thread_id`, `matched_tids`, `applied`). That mix is why reapply needed a hand-written carry-over that copies tids but deliberately not the `applied` flag. `parse_yaml()` also filled two output parameters, while the `kernel_threads` / `irqs` sections had separate parsers.

The model now holds only desired state: `CallbackGroupEntry`, `NonRosThreadEntry`, `KernelThreadEntry` and `IrqEntry`, returned together as `ParsedConfig` by `parse_config(yaml, default_domain_id)`. The runtime fields move to node-private `TrackedCallbackGroup` / `TrackedNonRosThread` wrappers; `track<>()` wraps freshly parsed entries with empty runtime state on startup and on reapply. This is an interim home for them until the `ConfigRegistry` of P3 owns them. The wildcard-id checks and the four duplicate checks become `validate_callback_group_id()` and `reject_duplicates()`.

One behavior change: a missing or null `callback_groups` / `non_ros_threads` section now yields no entries, matching `kernel_threads` / `irqs`, instead of failing with a raw yaml-cpp "invalid node" error. The per-section attribute parsing is otherwise unchanged and still duplicated; the next PR folds it into one function.

`test_thread_config.cpp` is rewritten against `parse_config()`. The runtime-state expectations (`thread_id == -1`, `applied == false`) and the output-parameter reuse test are dropped since the model no longer carries that state.

Second of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1627; the base branch is `refactor/cie-tc-sched-attrs`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
