### PR TITLE
refactor(agnocast_cie_thread_configurator): parse every section's scheduling attributes with one function

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -99,10 +99,12 @@ std::string extract_node_part(const std::string & callback_group_id);
 inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
 
 // Parse the four entry sections. A missing or null section yields an empty
-// vector. callback_groups and non_ros_threads require 'policy' and treat
-// UNMANAGEABLE as an ordinary invalid value; callback_groups take an optional
-// 'domain_id' (default_domain_id otherwise). kernel_threads and irqs accept
-// UNMANAGEABLE as unset. Throws std::runtime_error on validation error.
+// vector. Every section shares one attribute parser, so a given entry body
+// is validated identically wherever it appears; the differences are the
+// entry key (id / name / comm / irq), that callback_groups and
+// non_ros_threads require 'policy' and reject UNMANAGEABLE, and that
+// callback_groups take an optional 'domain_id' (default_domain_id otherwise).
+// Throws std::runtime_error on validation error.
 // hardware_info / rt_throttling are validated only at startup, not here.
 ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id);
 

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -21,10 +21,19 @@ namespace agnocast_cie_thread_configurator
 namespace
 {
 
+struct EntryContext
+{
+  std::string desc;  // "id=..." / "name=..." / "comm=..." fragment for messages
+  // kernel_threads/irqs are emitted from a scan, so UNMANAGEABLE counts as
+  // unset and 'policy' may be absent. The hand-written callback_groups /
+  // non_ros_threads require 'policy' and treat the sentinel as an ordinary
+  // invalid value.
+  bool scanned = false;
+};
+
 // Unset = the attribute must not be applied: YAML null / absent key (the
 // user's opt-out) or, when `allow_unmanageable` is set, the UNMANAGEABLE
-// sentinel (a kernel/tool constraint). The sentinel is scoped to the
-// kernel_threads/irqs sections; elsewhere it is an ordinary invalid value.
+// sentinel (a kernel/tool constraint).
 bool is_unset(const YAML::Node & node, bool allow_unmanageable)
 {
   if (!node || node.IsNull()) {
@@ -42,58 +51,6 @@ constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
 constexpr int k_rt_priority_max = 99;
-
-// 'nice' is required for the CFS policies (SCHED_OTHER/BATCH/IDLE);
-// parse_rt_priority is the mirror image for SCHED_FIFO/SCHED_RR. `entry_desc`
-// is the "id=..."/"name=..." fragment used in messages.
-int parse_nice(
-  const YAML::Node & entry, SchedPolicy policy, const std::string & entry_desc,
-  bool allow_unmanageable)
-{
-  const YAML::Node nice = entry["nice"];
-  if (is_unset(nice, allow_unmanageable)) {
-    throw std::runtime_error(
-      "Policy '" + std::string(to_string(policy)) + "' requires 'nice' for " + entry_desc +
-      (is_unmanageable_sentinel(nice) ? " (UNMANAGEABLE counts as unset)" : ""));
-  }
-  int value = 0;
-  try {
-    value = nice.as<int>();
-  } catch (const YAML::Exception &) {
-    throw std::runtime_error("'nice' must be an integer for " + entry_desc);
-  }
-  if (value < k_nice_min || value > k_nice_max) {
-    // setpriority(2) would silently clamp an out-of-range value to
-    // [-20, 19]; reject it here so a misunderstanding of the scale
-    // (e.g. an rt_priority-style 50) fails loudly instead.
-    throw std::runtime_error(
-      "'nice' must be in [-20, 19] for " + entry_desc + ", got " + std::to_string(value));
-  }
-  return value;
-}
-
-int parse_rt_priority(
-  const YAML::Node & entry, SchedPolicy policy, const std::string & entry_desc,
-  bool allow_unmanageable)
-{
-  const YAML::Node priority = entry["priority"];
-  if (is_unset(priority, allow_unmanageable)) {
-    throw std::runtime_error(
-      "Policy '" + std::string(to_string(policy)) + "' requires 'priority' for " + entry_desc +
-      (is_unmanageable_sentinel(priority) ? " (UNMANAGEABLE counts as unset)" : ""));
-  }
-  int value = 0;
-  try {
-    value = priority.as<int>();
-  } catch (const YAML::Exception &) {
-    throw std::runtime_error("'priority' must be an integer for " + entry_desc);
-  }
-  if (value < k_rt_priority_min || value > k_rt_priority_max) {
-    throw std::runtime_error(
-      "'priority' must be in [1, 99] for " + entry_desc + ", got " + std::to_string(value));
-  }
-  return value;
-}
 
 // yaml-cpp's as<T>() auto-detects the numeric base (YAML 1.1), so a
 // zero-padded "010" would parse as octal 8 and "0x10" as hex 16. IRQ numbers
@@ -120,53 +77,54 @@ std::optional<T> as_base10(const YAML::Node & node)
   return value;
 }
 
-SchedPolicy parse_policy_or_throw(const std::string & policy, const std::string & entry_desc)
+// The policy's tunable ('nice' for CFS, 'priority' for FIFO/RR) is mandatory
+// once 'policy' is set. setpriority(2) would silently clamp an out-of-range
+// nice to [-20, 19], so both ranges are enforced here and a misunderstanding
+// of the scale (e.g. an rt_priority-style 50 as nice) fails loudly.
+int parse_tunable(
+  const YAML::Node & entry, const char * key, int min, int max, SchedPolicy policy,
+  const EntryContext & ctx)
 {
-  const auto parsed = parse_sched_policy(policy);
-  if (!parsed) {
+  const YAML::Node node = entry[key];
+  if (is_unset(node, ctx.scanned)) {
     throw std::runtime_error(
-      "Unknown scheduling policy '" + policy + "' for " + entry_desc +
-      ". Valid policies: " + sched_policy_names());
+      "Policy '" + std::string(to_string(policy)) + "' requires '" + key + "' for " + ctx.desc +
+      (is_unmanageable_sentinel(node) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
-  return *parsed;
+  int value = 0;
+  try {
+    value = node.as<int>();
+  } catch (const YAML::Exception &) {
+    throw std::runtime_error("'" + std::string(key) + "' must be an integer for " + ctx.desc);
+  }
+  if (value < min || value > max) {
+    throw std::runtime_error(
+      "'" + std::string(key) + "' must be in [" + std::to_string(min) + ", " + std::to_string(max) +
+      "] for " + ctx.desc + ", got " + std::to_string(value));
+  }
+  return value;
 }
 
-DeadlineParams parse_deadline_params(
-  const YAML::Node & entry, const std::string & entry_desc, bool allow_unmanageable)
+DeadlineParams parse_deadline_params(const YAML::Node & entry, const EntryContext & ctx)
 {
   // Explicit check for a clear message: these fields are always hand-written
   // (prerun never emits DEADLINE) and easy to forget.
   for (const char * key : {"runtime", "period", "deadline"}) {
     // cppcheck-suppress useStlAlgorithm
-    if (is_unset(entry[key], allow_unmanageable)) {
+    if (is_unset(entry[key], ctx.scanned)) {
       throw std::runtime_error(
-        "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for " + entry_desc);
+        "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for " + ctx.desc);
     }
   }
   const auto field = [&](const char * key) {
     const auto value = as_base10<uint64_t>(entry[key]);
     if (!value) {
       throw std::runtime_error(
-        "'" + std::string(key) + "' must be a non-negative decimal integer for " + entry_desc);
+        "'" + std::string(key) + "' must be a non-negative decimal integer for " + ctx.desc);
     }
     return *value;
   };
   return DeadlineParams{field("runtime"), field("period"), field("deadline")};
-}
-
-// callback_groups / non_ros_threads describe threads that announce
-// themselves, so 'policy' has no "leave it alone" meaning there and is
-// mandatory. kernel_threads handles an unset policy itself.
-SchedPolicy parse_required_policy(const YAML::Node & entry, const std::string & entry_desc)
-{
-  const YAML::Node policy_node = entry["policy"];
-  if (is_unset(policy_node, /*allow_unmanageable=*/false)) {
-    throw std::runtime_error("'policy' is required for " + entry_desc);
-  }
-  if (!policy_node.IsScalar()) {
-    throw std::runtime_error("'policy' must be a string for " + entry_desc);
-  }
-  return parse_policy_or_throw(policy_node.Scalar(), entry_desc);
 }
 
 // CPU_SET(3) and sched_setaffinity(2) silently drop out-of-range or
@@ -174,19 +132,16 @@ SchedPolicy parse_required_policy(const YAML::Node & entry, const std::string & 
 // machine CPU count is a valid bound because the config is always parsed on
 // the machine that applies it. The result is sorted and deduplicated so
 // downstream consumers see a canonical form.
-std::vector<int> parse_affinity(
-  const YAML::Node & entry, const std::string & entry_desc, bool allow_unmanageable)
+std::vector<int> parse_affinity(const YAML::Node & entry, const EntryContext & ctx)
 {
   const YAML::Node affinity = entry["affinity"];
   std::vector<int> cpus;
-  // Unset (absent, null, or the allowed UNMANAGEABLE sentinel) means
-  // "do not manage affinity".
-  if (is_unset(affinity, allow_unmanageable)) {
+  if (is_unset(affinity, ctx.scanned)) {
     return cpus;
   }
   if (!affinity.IsSequence()) {
     throw std::runtime_error(
-      "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + entry_desc);
+      "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + ctx.desc);
   }
   const int max_cpu = manageable_cpu_bound();
   for (const auto & cpu_node : affinity) {
@@ -195,20 +150,66 @@ std::vector<int> parse_affinity(
       cpu = cpu_node.as<int>();
     } catch (const YAML::Exception &) {
       throw std::runtime_error(
-        "'affinity' must contain only integers for " + entry_desc + ", got '" +
+        "'affinity' must contain only integers for " + ctx.desc + ", got '" +
         (cpu_node.IsScalar() ? cpu_node.Scalar() : std::string("<non-scalar>")) + "'");
     }
     if (cpu < 0 || cpu > max_cpu) {
       throw std::runtime_error(
         "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " + std::to_string(max_cpu) +
         "] (this machine has " + std::to_string(sysconf(_SC_NPROCESSORS_CONF)) + " CPUs) for " +
-        entry_desc);
+        ctx.desc);
     }
     cpus.push_back(cpu);
   }
   std::sort(cpus.begin(), cpus.end());
   cpus.erase(std::unique(cpus.begin(), cpus.end()), cpus.end());
   return cpus;
+}
+
+// The one attribute parser behind every section, so an entry body is
+// validated the same way wherever it appears.
+SchedAttrs parse_sched_attrs(const YAML::Node & entry, const EntryContext & ctx)
+{
+  SchedAttrs attrs;
+  attrs.affinity = parse_affinity(entry, ctx);
+
+  const YAML::Node policy_node = entry["policy"];
+  if (is_unset(policy_node, ctx.scanned)) {
+    if (!ctx.scanned) {
+      throw std::runtime_error("'policy' is required for " + ctx.desc);
+    }
+    // Any policy-dependent field without 'policy' would otherwise be
+    // silently dead configuration (is_managed() == false).
+    for (const char * key : {"nice", "priority", "runtime", "period", "deadline"}) {
+      // cppcheck-suppress useStlAlgorithm
+      if (!is_unset(entry[key], ctx.scanned)) {
+        throw std::runtime_error(
+          "'" + std::string(key) + "' requires 'policy' for " + ctx.desc +
+          ": set both or leave both unset");
+      }
+    }
+    return attrs;
+  }
+  if (!policy_node.IsScalar()) {
+    throw std::runtime_error("'policy' must be a string for " + ctx.desc);
+  }
+  const auto policy = parse_sched_policy(policy_node.Scalar());
+  if (!policy) {
+    throw std::runtime_error(
+      "Unknown scheduling policy '" + policy_node.Scalar() + "' for " + ctx.desc +
+      ". Valid policies: " + sched_policy_names());
+  }
+  attrs.policy = policy;
+
+  if (*policy == SchedPolicy::Deadline) {
+    attrs.deadline = parse_deadline_params(entry, ctx);
+  } else if (is_cfs(*policy)) {
+    attrs.nice = parse_tunable(entry, "nice", k_nice_min, k_nice_max, *policy, ctx);
+  } else {
+    attrs.rt_priority =
+      parse_tunable(entry, "priority", k_rt_priority_min, k_rt_priority_max, *policy, ctx);
+  }
+  return attrs;
 }
 
 // A typo'd pattern silently treated as an exact id would never match, so any
@@ -296,19 +297,7 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     entry.id = cg["id"].as<std::string>();
     validate_callback_group_id(entry);
     entry.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
-    entry.attrs.affinity = parse_affinity(cg, "id=" + entry.id, /*allow_unmanageable=*/false);
-    const SchedPolicy policy = parse_required_policy(cg, "id=" + entry.id);
-    entry.attrs.policy = policy;
-
-    if (policy == SchedPolicy::Deadline) {
-      entry.attrs.deadline =
-        parse_deadline_params(cg, "id=" + entry.id, /*allow_unmanageable=*/false);
-    } else if (is_cfs(policy)) {
-      entry.attrs.nice = parse_nice(cg, policy, "id=" + entry.id, /*allow_unmanageable=*/false);
-    } else {
-      entry.attrs.rt_priority =
-        parse_rt_priority(cg, policy, "id=" + entry.id, /*allow_unmanageable=*/false);
-    }
+    entry.attrs = parse_sched_attrs(cg, EntryContext{"id=" + entry.id, /*scanned=*/false});
     config.callback_groups.push_back(std::move(entry));
   }
   reject_duplicates(config.callback_groups, "callback_group", [](const CallbackGroupEntry & e) {
@@ -322,20 +311,7 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     const YAML::Node nrt = non_ros_threads[i];
     NonRosThreadEntry entry;
     entry.name = nrt["name"].as<std::string>();
-    entry.attrs.affinity = parse_affinity(nrt, "name=" + entry.name, /*allow_unmanageable=*/false);
-    const SchedPolicy policy = parse_required_policy(nrt, "name=" + entry.name);
-    entry.attrs.policy = policy;
-
-    if (policy == SchedPolicy::Deadline) {
-      entry.attrs.deadline =
-        parse_deadline_params(nrt, "name=" + entry.name, /*allow_unmanageable=*/false);
-    } else if (is_cfs(policy)) {
-      entry.attrs.nice =
-        parse_nice(nrt, policy, "name=" + entry.name, /*allow_unmanageable=*/false);
-    } else {
-      entry.attrs.rt_priority =
-        parse_rt_priority(nrt, policy, "name=" + entry.name, /*allow_unmanageable=*/false);
-    }
+    entry.attrs = parse_sched_attrs(nrt, EntryContext{"name=" + entry.name, /*scanned=*/false});
     config.non_ros_threads.push_back(std::move(entry));
   }
   reject_duplicates(config.non_ros_threads, "non_ros_thread", [](const NonRosThreadEntry & e) {
@@ -372,41 +348,7 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
           "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
           "be matched reliably");
       }
-      entry.attrs.affinity = parse_affinity(kt, "comm=" + entry.comm, /*allow_unmanageable=*/true);
-
-      if (is_unset(kt["policy"], /*allow_unmanageable=*/true)) {
-        // Any policy-dependent field without 'policy' would otherwise be
-        // silently dead configuration (is_managed() == false).
-        for (const char * key : {"nice", "priority", "runtime", "period", "deadline"}) {
-          if (!is_unset(kt[key], /*allow_unmanageable=*/true)) {
-            throw std::runtime_error(
-              "'" + std::string(key) + "' requires 'policy' for comm=" + entry.comm +
-              ": set both or leave both unset");
-          }
-        }
-        config.kernel_threads.push_back(std::move(entry));
-        continue;
-      }
-
-      std::string policy_str;
-      try {
-        policy_str = kt["policy"].as<std::string>();
-      } catch (const YAML::Exception &) {
-        throw std::runtime_error("'policy' must be a string for comm=" + entry.comm);
-      }
-      const SchedPolicy policy = parse_policy_or_throw(policy_str, "comm=" + entry.comm);
-      entry.attrs.policy = policy;
-
-      if (policy == SchedPolicy::Deadline) {
-        entry.attrs.deadline =
-          parse_deadline_params(kt, "comm=" + entry.comm, /*allow_unmanageable=*/true);
-      } else if (is_cfs(policy)) {
-        entry.attrs.nice =
-          parse_nice(kt, policy, "comm=" + entry.comm, /*allow_unmanageable=*/true);
-      } else {
-        entry.attrs.rt_priority =
-          parse_rt_priority(kt, policy, "comm=" + entry.comm, /*allow_unmanageable=*/true);
-      }
+      entry.attrs = parse_sched_attrs(kt, EntryContext{"comm=" + entry.comm, /*scanned=*/true});
       config.kernel_threads.push_back(std::move(entry));
     }
   }
@@ -437,16 +379,16 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
           (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
       }
       entry.irq = *irq;
+      const std::string desc = "irq=" + std::to_string(entry.irq);
 
       if (iq["name"] && !iq["name"].IsNull()) {
         try {
           entry.name = iq["name"].as<std::string>();
         } catch (const YAML::Exception &) {
-          throw std::runtime_error("'name' must be a string for irq=" + std::to_string(entry.irq));
+          throw std::runtime_error("'name' must be a string for " + desc);
         }
       }
-      entry.affinity =
-        parse_affinity(iq, "irq=" + std::to_string(entry.irq), /*allow_unmanageable=*/true);
+      entry.affinity = parse_affinity(iq, EntryContext{desc, /*scanned=*/true});
       config.irqs.push_back(std::move(entry));
     }
   }

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -16,376 +16,418 @@ namespace
 {
 constexpr size_t kTestDefaultDomain = 7;
 
-YAML::Node yaml_from_str(const char * s)
+acie::ParsedConfig parse(const std::string & yaml)
 {
-  return YAML::Load(s);
-}
-
-acie::ParsedConfig parse(const YAML::Node & yaml)
-{
-  return acie::parse_config(yaml, kTestDefaultDomain);
+  return acie::parse_config(YAML::Load(yaml), kTestDefaultDomain);
 }
 
 // EXPECT_THROW alone cannot tell WHICH validation fired (every failure path
 // derives from std::runtime_error), so the negative tests also match a
 // distinguishing fragment of the message.
-void expect_error(const char * yaml, const std::string & fragment)
+void expect_error(const std::string & yaml, const std::string & fragment)
 {
   try {
-    parse(yaml_from_str(yaml));
-    FAIL() << "expected std::runtime_error";
+    parse(yaml);
+    FAIL() << "expected std::runtime_error for:\n" << yaml;
   } catch (const std::runtime_error & e) {
-    EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos) << e.what();
+    EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos)
+      << "message: " << e.what() << "\nexpected fragment: " << fragment;
   }
 }
-}  // namespace
 
-// ---------- callback_groups / non_ros_threads ----------
-
-TEST(ParseConfig, ParsesEmptyConfig)
+// The three sections whose entries go through the shared attribute parser.
+// A body placed under each header must be accepted or rejected identically;
+// only the entry description in the message differs.
+struct ThreadSection
 {
-  auto y = yaml_from_str("callback_groups: []\nnon_ros_threads: []\n");
-  const auto config = parse(y);
-  EXPECT_TRUE(config.callback_groups.empty());
-  EXPECT_TRUE(config.non_ros_threads.empty());
+  const char * header;
+  const char * desc;
+  const acie::SchedAttrs & (*attrs)(const acie::ParsedConfig &);
+};
+
+const ThreadSection kThreadSections[] = {
+  {"callback_groups:\n  - id: x\n", "id=x",
+   [](const acie::ParsedConfig & c) -> const acie::SchedAttrs & {
+     return c.callback_groups.at(0).attrs;
+   }},
+  {"non_ros_threads:\n  - name: x\n", "name=x",
+   [](const acie::ParsedConfig & c) -> const acie::SchedAttrs & {
+     return c.non_ros_threads.at(0).attrs;
+   }},
+  {"kernel_threads:\n  - comm: x\n", "comm=x",
+   [](const acie::ParsedConfig & c) -> const acie::SchedAttrs & {
+     return c.kernel_threads.at(0).attrs;
+   }},
+};
+
+// `body` is the entry's attribute lines, indented four spaces.
+acie::SchedAttrs attrs_of(const ThreadSection & section, const std::string & body)
+{
+  return section.attrs(parse(section.header + body));
 }
 
-TEST(ParseConfig, ParsesCallbackGroupSchedFifo)
+}  // namespace
+
+// ---------- sections ----------
+
+TEST(ParseConfig, MissingOrNullOrEmptySectionsYieldEmpty)
 {
-  auto y = yaml_from_str(R"YAML(
+  for (const char * yaml :
+       {"{}\n", "callback_groups: ~\nnon_ros_threads: ~\nkernel_threads: ~\nirqs: ~\n",
+        "callback_groups: []\nnon_ros_threads: []\nkernel_threads: []\nirqs: []\n"}) {
+    const auto config = parse(yaml);
+    EXPECT_TRUE(config.callback_groups.empty()) << yaml;
+    EXPECT_TRUE(config.non_ros_threads.empty()) << yaml;
+    EXPECT_TRUE(config.kernel_threads.empty()) << yaml;
+    EXPECT_TRUE(config.irqs.empty()) << yaml;
+  }
+}
+
+TEST(ParseConfig, ParsesAllFourSectionsIntoTheirVectors)
+{
+  const auto config = parse(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    nice: 0
+    affinity: []
+non_ros_threads:
+  - name: worker
+    policy: SCHED_RR
+    priority: 30
+    affinity: [0]
+kernel_threads:
+  - comm: agnocast_exit_w
+    policy: SCHED_FIFO
+    priority: 10
+    affinity: [0]
+irqs:
+  - irq: 103
+    name: nvidia
+    affinity: [0, 1]
+)YAML");
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].id, "my_cbg");
+  ASSERT_EQ(config.non_ros_threads.size(), 1u);
+  EXPECT_EQ(config.non_ros_threads[0].name, "worker");
+  EXPECT_EQ(config.non_ros_threads[0].attrs.policy, acie::SchedPolicy::Rr);
+  EXPECT_EQ(config.non_ros_threads[0].attrs.rt_priority, 30);
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_EQ(config.kernel_threads[0].comm, "agnocast_exit_w");
+  ASSERT_EQ(config.irqs.size(), 1u);
+  EXPECT_EQ(config.irqs[0].irq, 103);
+}
+
+// ---------- shared attribute parsing (callback_groups / non_ros_threads / kernel_threads)
+// ----------
+
+TEST(ParseSchedAttrs, ParsesFifoPriorityAndAffinity)
+{
+  for (const auto & section : kThreadSections) {
+    const auto attrs =
+      attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n    affinity: [0, 1]\n");
+    EXPECT_EQ(attrs.policy, acie::SchedPolicy::Fifo) << section.desc;
+    EXPECT_EQ(attrs.rt_priority, 50) << section.desc;
+    EXPECT_EQ(attrs.nice, 0) << section.desc;
+    EXPECT_EQ(attrs.affinity, (std::vector<int>{0, 1})) << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, ParsesNiceForCfsPolicies)
+{
+  const std::pair<const char *, acie::SchedPolicy> policies[] = {
+    {"SCHED_OTHER", acie::SchedPolicy::Other},
+    {"SCHED_BATCH", acie::SchedPolicy::Batch},
+    {"SCHED_IDLE", acie::SchedPolicy::Idle},
+  };
+  for (const auto & section : kThreadSections) {
+    for (const auto & [name, policy] : policies) {
+      const auto attrs = attrs_of(
+        section, "    policy: " + std::string(name) + "\n    nice: -10\n    affinity: []\n");
+      EXPECT_EQ(attrs.policy, policy) << section.desc << " " << name;
+      EXPECT_EQ(attrs.nice, -10) << section.desc << " " << name;
+      EXPECT_EQ(attrs.rt_priority, 0) << section.desc << " " << name;
+    }
+  }
+}
+
+TEST(ParseSchedAttrs, IgnoresStrayKeyOfTheOtherPolicyClass)
+{
+  for (const auto & section : kThreadSections) {
+    const auto cfs = attrs_of(section, "    policy: SCHED_OTHER\n    nice: -5\n    priority: 50\n");
+    EXPECT_EQ(cfs.nice, -5) << section.desc;
+    EXPECT_EQ(cfs.rt_priority, 0) << section.desc;
+    const auto rt = attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n    nice: 10\n");
+    EXPECT_EQ(rt.rt_priority, 50) << section.desc;
+    EXPECT_EQ(rt.nice, 0) << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsMissingOrNullNiceOnCfsPolicy)
+{
+  for (const auto & section : kThreadSections) {
+    const std::string fragment =
+      std::string("Policy 'SCHED_OTHER' requires 'nice' for ") + section.desc;
+    expect_error(section.header + std::string("    policy: SCHED_OTHER\n"), fragment);
+    expect_error(section.header + std::string("    policy: SCHED_OTHER\n    nice:\n"), fragment);
+    // 'priority' does not satisfy the requirement.
+    expect_error(
+      section.header + std::string("    policy: SCHED_OTHER\n    priority: 5\n"), fragment);
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsMissingOrNullPriorityOnRtPolicy)
+{
+  for (const auto & section : kThreadSections) {
+    const std::string fragment =
+      std::string("Policy 'SCHED_FIFO' requires 'priority' for ") + section.desc;
+    expect_error(section.header + std::string("    policy: SCHED_FIFO\n"), fragment);
+    expect_error(
+      section.header + std::string("    policy: SCHED_FIFO\n    priority: ~\n"), fragment);
+    expect_error(
+      section.header + std::string("    policy: SCHED_RR\n    nice: 5\n"),
+      "Policy 'SCHED_RR' requires 'priority'");
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsNonIntegerNiceAndPriority)
+{
+  for (const auto & section : kThreadSections) {
+    expect_error(
+      section.header + std::string("    policy: SCHED_OTHER\n    nice: low\n"),
+      std::string("'nice' must be an integer for ") + section.desc);
+    expect_error(
+      section.header + std::string("    policy: SCHED_FIFO\n    priority: high\n"),
+      std::string("'priority' must be an integer for ") + section.desc);
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsNiceOutOfRange)
+{
+  for (const auto & section : kThreadSections) {
+    for (const char * bad_nice : {"-21", "20", "50"}) {
+      expect_error(
+        section.header + std::string("    policy: SCHED_OTHER\n    nice: ") + bad_nice + "\n",
+        "'nice' must be in [-20, 19]");
+    }
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsRtPriorityOutOfRange)
+{
+  for (const auto & section : kThreadSections) {
+    for (const char * bad_priority : {"0", "100", "-1"}) {
+      expect_error(
+        section.header + std::string("    policy: SCHED_FIFO\n    priority: ") + bad_priority +
+          "\n",
+        "'priority' must be in [1, 99]");
+    }
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsUnknownPolicy)
+{
+  for (const auto & section : kThreadSections) {
+    expect_error(
+      section.header + std::string("    policy: SCHED_BOGUS\n    priority: 5\n"),
+      std::string("Unknown scheduling policy 'SCHED_BOGUS' for ") + section.desc);
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsNonStringPolicy)
+{
+  for (const auto & section : kThreadSections) {
+    expect_error(
+      section.header + std::string("    policy: [a, b]\n"),
+      std::string("'policy' must be a string for ") + section.desc);
+  }
+}
+
+TEST(ParseSchedAttrs, ParsesSchedDeadline)
+{
+  for (const auto & section : kThreadSections) {
+    const auto attrs = attrs_of(
+      section,
+      "    policy: SCHED_DEADLINE\n    runtime: 1000000\n    period: 5000000\n    deadline: "
+      "5000000\n    affinity: [0]\n");
+    EXPECT_EQ(attrs.policy, acie::SchedPolicy::Deadline) << section.desc;
+    EXPECT_EQ(attrs.deadline.runtime, 1000000u) << section.desc;
+    EXPECT_EQ(attrs.deadline.period, 5000000u) << section.desc;
+    EXPECT_EQ(attrs.deadline.deadline, 5000000u) << section.desc;
+    EXPECT_EQ(attrs.nice, 0) << section.desc;
+    EXPECT_EQ(attrs.rt_priority, 0) << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, AcceptsDeadlineParamsBeyond32Bits)
+{
+  // sched_attr carries nanoseconds in 64-bit fields; a 5 s period exceeds
+  // 2^32 ns.
+  for (const auto & section : kThreadSections) {
+    const auto attrs = attrs_of(
+      section,
+      "    policy: SCHED_DEADLINE\n    runtime: 1000000000\n    period: 5000000000\n    "
+      "deadline: 5000000000\n");
+    EXPECT_EQ(attrs.deadline.period, 5000000000u) << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsSchedDeadlineMissingFields)
+{
+  for (const auto & section : kThreadSections) {
+    const std::string fragment =
+      std::string("SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for ") + section.desc;
+    expect_error(section.header + std::string("    policy: SCHED_DEADLINE\n"), fragment);
+    expect_error(
+      section.header + std::string("    policy: SCHED_DEADLINE\n    runtime: 1000000\n"), fragment);
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsMalformedSchedDeadlineFields)
+{
+  for (const auto & section : kThreadSections) {
+    expect_error(
+      section.header +
+        std::string(
+          "    policy: SCHED_DEADLINE\n    runtime: -5\n    period: 5000000\n    deadline: "
+          "5000000\n"),
+      std::string("'runtime' must be a non-negative decimal integer for ") + section.desc);
+    expect_error(
+      section.header +
+        std::string(
+          "    policy: SCHED_DEADLINE\n    runtime: 1000000\n    period: not_a_number\n    "
+          "deadline: 5000000\n"),
+      std::string("'period' must be a non-negative decimal integer for ") + section.desc);
+    // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
+    expect_error(
+      section.header +
+        std::string(
+          "    policy: SCHED_DEADLINE\n    runtime: 1000000\n    period: 5000000\n    deadline: "
+          "0x10\n"),
+      std::string("'deadline' must be a non-negative decimal integer for ") + section.desc);
+  }
+}
+
+TEST(ParseSchedAttrs, ParsesZeroPaddedDeadlineFieldAsBase10)
+{
+  // yaml-cpp's base auto-detection would read "0500000" as octal; a
+  // zero-padded column must mean decimal.
+  for (const auto & section : kThreadSections) {
+    const auto attrs = attrs_of(
+      section,
+      "    policy: SCHED_DEADLINE\n    runtime: 0500000\n    period: 5000000\n    deadline: "
+      "5000000\n");
+    EXPECT_EQ(attrs.deadline.runtime, 500000u) << section.desc;
+  }
+}
+
+// ---------- affinity (shared by all four sections) ----------
+
+TEST(ParseSchedAttrs, NormalizesAffinityToSortedUnique)
+{
+  // parse_affinity bounds values by the machine CPU count, so only CPUs 0
+  // and 1 are used to keep this test valid on small CI machines.
+  for (const auto & section : kThreadSections) {
+    const auto attrs =
+      attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n    affinity: [1, 0, 1]\n");
+    EXPECT_EQ(attrs.affinity, (std::vector<int>{0, 1})) << section.desc;
+  }
+  const auto config = parse("irqs:\n  - irq: 5\n    affinity: [1, 0, 1]\n");
+  EXPECT_EQ(config.irqs.at(0).affinity, (std::vector<int>{0, 1}));
+}
+
+TEST(ParseSchedAttrs, TreatsAbsentOrNullAffinityAsUnmanaged)
+{
+  for (const auto & section : kThreadSections) {
+    EXPECT_TRUE(attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n").affinity.empty())
+      << section.desc;
+    EXPECT_TRUE(attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n    affinity: ~\n")
+                  .affinity.empty())
+      << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsAffinityCpuOutOfRange)
+{
+  // CPU_SET(3) / sched_setaffinity(2) would silently ignore all of these,
+  // shrinking the mask without any error report. The valid CPU 0 in front
+  // checks that it does not mask the error.
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+  for (const auto & section : kThreadSections) {
+    for (const std::string & bad_affinity :
+         {std::string("[-1]"), "[0, " + std::to_string(num_cpus) + "]",
+          "[0, " + std::to_string(CPU_SETSIZE) + "]"}) {
+      expect_error(
+        section.header + std::string("    policy: SCHED_FIFO\n    priority: 50\n    affinity: ") +
+          bad_affinity + "\n",
+        "must be in [0, ");
+    }
+  }
+  expect_error("irqs:\n  - irq: 5\n    affinity: [-1]\n", "'affinity' CPU -1 must be in");
+}
+
+TEST(ParseSchedAttrs, AcceptsHighestValidAffinityCpu)
+{
+  // Pins the accept side of the [0, min(CPU_SETSIZE, num_cpus)) boundary.
+  const int max_cpu =
+    static_cast<int>(std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF))) - 1;
+  for (const auto & section : kThreadSections) {
+    const auto attrs = attrs_of(
+      section, "    policy: SCHED_FIFO\n    priority: 50\n    affinity: [" +
+                 std::to_string(max_cpu) + "]\n");
+    EXPECT_EQ(attrs.affinity, (std::vector<int>{max_cpu})) << section.desc;
+  }
+}
+
+TEST(ParseSchedAttrs, RejectsScalarAffinity)
+{
+  // A scalar (e.g. a cpu-list string copied from a scan) iterates zero times
+  // and would otherwise silently mean "no affinity".
+  for (const auto & section : kThreadSections) {
+    for (const char * bad_affinity : {"2", "\"0-3\""}) {
+      expect_error(
+        section.header + std::string("    policy: SCHED_FIFO\n    priority: 50\n    affinity: ") +
+          bad_affinity + "\n",
+        std::string("'affinity' must be a list of CPU numbers (e.g. [2, 3]) for ") + section.desc);
+    }
+  }
+  expect_error("irqs:\n  - irq: 5\n    affinity: 0-3\n", "'affinity' must be a list");
+}
+
+TEST(ParseSchedAttrs, RejectsNonIntegerAffinityElement)
+{
+  for (const auto & section : kThreadSections) {
+    expect_error(
+      section.header +
+        std::string("    policy: SCHED_FIFO\n    priority: 50\n    affinity: [0, all]\n"),
+      std::string("'affinity' must contain only integers for ") + section.desc + ", got 'all'");
+  }
+}
+
+// ---------- callback_groups ----------
+
+TEST(ParseCallbackGroups, ParsesEntry)
+{
+  const auto config = parse(R"YAML(
 callback_groups:
   - id: my_cbg
     domain_id: 3
     policy: SCHED_FIFO
     priority: 50
     affinity: [0, 1]
-non_ros_threads: []
 )YAML");
-  const auto config = parse(y);
   ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].id, "my_cbg");
-  EXPECT_EQ(config.callback_groups[0].domain_id, 3u);
-  EXPECT_EQ(config.callback_groups[0].attrs.policy, acie::SchedPolicy::Fifo);
-  EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 50);
-  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{0, 1}));
-  EXPECT_FALSE(config.callback_groups[0].is_wildcard());
+  const auto & entry = config.callback_groups[0];
+  EXPECT_EQ(entry.id, "my_cbg");
+  EXPECT_EQ(entry.domain_id, 3u);
+  EXPECT_EQ(entry.attrs.policy, acie::SchedPolicy::Fifo);
+  EXPECT_EQ(entry.attrs.rt_priority, 50);
+  EXPECT_EQ(entry.attrs.affinity, (std::vector<int>{0, 1}));
+  EXPECT_FALSE(entry.is_wildcard());
 }
 
-TEST(ParseConfig, ParsesNiceForCfsPolicies)
-{
-  for (const char * policy : {"SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"}) {
-    auto y = yaml_from_str(("callback_groups:\n"
-                            "  - id: my_cbg\n"
-                            "    domain_id: 0\n"
-                            "    policy: " +
-                            std::string(policy) +
-                            "\n"
-                            "    nice: -10\n"
-                            "    affinity: []\n"
-                            "non_ros_threads: []\n")
-                             .c_str());
-    const auto config = parse(y);
-    ASSERT_EQ(config.callback_groups.size(), 1u);
-    EXPECT_EQ(config.callback_groups[0].attrs.nice, -10) << policy;
-    EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 0) << policy;
-  }
-}
-
-TEST(ParseConfig, IgnoresStrayKeyOfTheOtherPolicyClass)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: cfs_cbg
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: -5
-    priority: 50
-    affinity: []
-  - id: rt_cbg
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: 50
-    nice: 10
-    affinity: []
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 2u);
-  EXPECT_EQ(config.callback_groups[0].attrs.nice, -5);
-  EXPECT_EQ(config.callback_groups[0].attrs.rt_priority, 0);
-  EXPECT_EQ(config.callback_groups[1].attrs.rt_priority, 50);
-  EXPECT_EQ(config.callback_groups[1].attrs.nice, 0);
-}
-
-TEST(ParseConfig, RejectsMissingNiceOnSchedOther)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_OTHER
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
-}
-
-TEST(ParseConfig, RejectsNiceOutOfRange)
-{
-  for (const char * bad_nice : {"-21", "20", "50"}) {
-    auto y = yaml_from_str(("callback_groups:\n"
-                            "  - id: my_cbg\n"
-                            "    domain_id: 0\n"
-                            "    policy: SCHED_OTHER\n"
-                            "    nice: " +
-                            std::string(bad_nice) +
-                            "\n"
-                            "    affinity: []\n"
-                            "non_ros_threads: []\n")
-                             .c_str());
-    EXPECT_THROW(parse(y), std::runtime_error) << "nice=" << bad_nice;
-  }
-}
-
-TEST(ParseConfig, TreatsNullNiceAsMissing)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice:
-    affinity: []
-non_ros_threads: []
-)YAML");
-  try {
-    parse(y);
-    FAIL() << "expected std::runtime_error";
-  } catch (const std::runtime_error & e) {
-    EXPECT_NE(std::string(e.what()).find("requires 'nice'"), std::string::npos) << e.what();
-  }
-}
-
-TEST(ParseConfig, ReportsEntryOnNonIntegerNice)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: low
-    affinity: []
-non_ros_threads: []
-)YAML");
-  try {
-    parse(y);
-    FAIL() << "expected std::runtime_error";
-  } catch (const std::runtime_error & e) {
-    const std::string what = e.what();
-    EXPECT_NE(what.find("'nice' must be an integer"), std::string::npos) << what;
-    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
-  }
-}
-
-TEST(ParseConfig, ReportsEntryOnNonIntegerRtPriority)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: high
-    affinity: []
-non_ros_threads: []
-)YAML");
-  try {
-    parse(y);
-    FAIL() << "expected std::runtime_error";
-  } catch (const std::runtime_error & e) {
-    const std::string what = e.what();
-    EXPECT_NE(what.find("'priority' must be an integer"), std::string::npos) << what;
-    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
-  }
-}
-
-TEST(ParseConfig, RejectsMissingPriorityOnRtPolicy)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_FIFO
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
-}
-
-TEST(ParseConfig, RejectsRtPriorityOutOfRange)
-{
-  for (const char * bad_priority : {"0", "100", "-1"}) {
-    auto y = yaml_from_str(("callback_groups:\n"
-                            "  - id: my_cbg\n"
-                            "    domain_id: 0\n"
-                            "    policy: SCHED_FIFO\n"
-                            "    priority: " +
-                            std::string(bad_priority) +
-                            "\n"
-                            "    affinity: []\n"
-                            "non_ros_threads: []\n")
-                             .c_str());
-    EXPECT_THROW(parse(y), std::runtime_error) << "priority=" << bad_priority;
-  }
-}
-
-TEST(ParseConfig, FallsBackToDefaultDomainId)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].domain_id, kTestDefaultDomain);
-}
-
-TEST(ParseConfig, ParsesSchedDeadline)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: dl_cbg
-    domain_id: 0
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    period: 5000000
-    deadline: 5000000
-    affinity: [0]
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].attrs.policy, acie::SchedPolicy::Deadline);
-  EXPECT_EQ(config.callback_groups[0].attrs.deadline.runtime, 1000000u);
-  EXPECT_EQ(config.callback_groups[0].attrs.deadline.period, 5000000u);
-  EXPECT_EQ(config.callback_groups[0].attrs.deadline.deadline, 5000000u);
-}
-
-TEST(ParseConfig, AcceptsDeadlineParamsBeyond32Bits)
-{
-  // sched_attr carries nanoseconds in 64-bit fields; a 5 s period exceeds
-  // 2^32 ns.
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: dl_cbg
-    domain_id: 0
-    policy: SCHED_DEADLINE
-    runtime: 1000000000
-    period: 5000000000
-    deadline: 5000000000
-    affinity: []
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].attrs.deadline.period, 5000000000u);
-}
-
-TEST(ParseConfig, RejectsUnknownPolicyOnCallbackGroup)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: bad
-    domain_id: 0
-    policy: SCHED_BOGUS
-    priority: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
-}
-
-TEST(ParseConfig, RejectsUnknownPolicyOnNonRosThread)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups: []
-non_ros_threads:
-  - name: bad_worker
-    policy: NOT_A_POLICY
-    priority: 0
-    affinity: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
-}
-
-TEST(ParseConfig, RejectsSchedDeadlineMissingFields)
-{
-  expect_error(
-    R"YAML(
-callback_groups:
-  - id: dl_cbg
-    domain_id: 0
-    policy: SCHED_DEADLINE
-    affinity: []
-)YAML",
-    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for id=dl_cbg");
-  expect_error(
-    R"YAML(
-non_ros_threads:
-  - name: dl_worker
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-)YAML",
-    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for name=dl_worker");
-}
-
-TEST(ParseConfig, RejectsMalformedSchedDeadlineFields)
-{
-  // Same rules as kernel_threads: non-negative decimal digits only.
-  expect_error(
-    R"YAML(
-callback_groups:
-  - id: dl_cbg
-    policy: SCHED_DEADLINE
-    runtime: -5
-    period: 5000000
-    deadline: 5000000
-)YAML",
-    "'runtime' must be a non-negative decimal integer for id=dl_cbg");
-  // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
-  expect_error(
-    R"YAML(
-non_ros_threads:
-  - name: dl_worker
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    period: 5000000
-    deadline: 0x10
-)YAML",
-    "'deadline' must be a non-negative decimal integer for name=dl_worker");
-}
-
-TEST(ParseConfig, ParsesZeroPaddedDeadlineFieldAsBase10)
-{
-  // yaml-cpp's base auto-detection would read "0500000" as octal; a
-  // zero-padded column must mean decimal.
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: dl_cbg
-    policy: SCHED_DEADLINE
-    runtime: 0500000
-    period: 5000000
-    deadline: 5000000
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].attrs.deadline.runtime, 500000u);
-}
-
-TEST(ParseConfig, RequiresPolicy)
+TEST(ParseCallbackGroups, RequiresPolicy)
 {
   // Unlike kernel_threads, an announced thread's entry has no "leave the
   // policy alone" meaning, so a missing or null policy is an error.
@@ -398,357 +440,185 @@ TEST(ParseConfig, RequiresPolicy)
     "non_ros_threads:\n  - name: worker\n    nice: 0\n", "'policy' is required for name=worker");
 }
 
-TEST(ParseConfig, RejectsNonStringPolicy)
+TEST(ParseCallbackGroups, FallsBackToDefaultDomainId)
+{
+  const auto config =
+    parse("callback_groups:\n  - id: my_cbg\n    policy: SCHED_OTHER\n    nice: 0\n");
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].domain_id, kTestDefaultDomain);
+}
+
+TEST(ParseCallbackGroups, RejectsDuplicateKey)
 {
   expect_error(
-    "callback_groups:\n  - id: my_cbg\n    policy: [a, b]\n",
-    "'policy' must be a string for id=my_cbg");
-}
-
-TEST(ParseConfig, ParsesNonRosThread)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups: []
-non_ros_threads:
-  - name: worker
-    policy: SCHED_RR
-    priority: 30
-    affinity: [0]
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.non_ros_threads.size(), 1u);
-  EXPECT_EQ(config.non_ros_threads[0].name, "worker");
-  EXPECT_EQ(config.non_ros_threads[0].attrs.policy, acie::SchedPolicy::Rr);
-  EXPECT_EQ(config.non_ros_threads[0].attrs.rt_priority, 30);
-}
-
-TEST(ParseConfig, RejectsDuplicateCallbackGroupKey)
-{
-  auto y = yaml_from_str(R"YAML(
+    R"YAML(
 callback_groups:
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+)YAML",
+    "Duplicate callback_group entry: domain_id=0, id=cg");
 }
 
-TEST(ParseConfig, AllowsSameIdInDifferentDomains)
+TEST(ParseCallbackGroups, AllowsSameIdInDifferentDomains)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 callback_groups:
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
   - id: cg
     domain_id: 1
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
-non_ros_threads: []
 )YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 2u);
+  EXPECT_EQ(config.callback_groups.size(), 2u);
 }
 
-TEST(ParseConfig, RejectsDuplicateNonRosThreadName)
+TEST(ParseCallbackGroups, UnmanageableSentinelIsNotRecognized)
 {
-  auto y = yaml_from_str(R"YAML(
-callback_groups: []
-non_ros_threads:
-  - name: t
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-  - name: t
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+  // The sentinel is scoped to kernel_threads/irqs (the tool writes it there);
+  // in the hand-written sections it must fail like any other invalid value,
+  // not silently mean "leave the attribute alone".
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    policy: SCHED_FIFO\n    priority: 50\n    affinity: "
+    "UNMANAGEABLE\n",
+    "'affinity' must be a list");
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    policy: SCHED_OTHER\n    nice: UNMANAGEABLE\n",
+    "'nice' must be an integer for id=my_cbg");
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    policy: UNMANAGEABLE\n",
+    "Unknown scheduling policy 'UNMANAGEABLE'");
+  expect_error(
+    "non_ros_threads:\n  - name: my_thread\n    policy: SCHED_OTHER\n    nice: UNMANAGEABLE\n",
+    "'nice' must be an integer for name=my_thread");
 }
 
 // ---------- wildcard ("<node name>/*") callback-group ids ----------
 
-TEST(ParseConfig, ParsesWildcardCallbackGroupId)
+TEST(ParseCallbackGroups, ParsesWildcardId)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 callback_groups:
   - id: /perception/lidar_node/*
     domain_id: 0
     policy: SCHED_FIFO
     priority: 50
     affinity: [0]
-non_ros_threads: []
 )YAML");
-  const auto config = parse(y);
   ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_TRUE(config.callback_groups[0].is_wildcard());
-  EXPECT_EQ(config.callback_groups[0].wildcard_prefix(), "/perception/lidar_node");
-  EXPECT_EQ(config.callback_groups[0].id, "/perception/lidar_node/*");  // kept as written
+  const auto & entry = config.callback_groups[0];
+  EXPECT_TRUE(entry.is_wildcard());
+  EXPECT_EQ(entry.wildcard_prefix(), "/perception/lidar_node");
+  EXPECT_EQ(entry.id, "/perception/lidar_node/*");  // kept as written
 }
 
-TEST(ParseConfig, RejectsWildcardWithEmptyNodePart)
+TEST(ParseCallbackGroups, RejectsWildcardWithEmptyNodePart)
 {
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: /*
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+  expect_error(
+    "callback_groups:\n  - id: /*\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "the part before \"/*\" must be a non-empty node name");
 }
 
-TEST(ParseConfig, RejectsStrayAsteriskInId)
+TEST(ParseCallbackGroups, RejectsStrayAsteriskInId)
 {
   for (const char * bad_id :
        {"/node*", "/node/**", "/node/*x", "/a/*/b", "*", "/node/*@Waitable"}) {
-    auto y = yaml_from_str(("callback_groups:\n"
-                            "  - id: \"" +
-                            std::string(bad_id) +
-                            "\"\n"
-                            "    domain_id: 0\n"
-                            "    policy: SCHED_OTHER\n"
-                            "    nice: 0\n"
-                            "    affinity: []\n"
-                            "non_ros_threads: []\n")
-                             .c_str());
-    EXPECT_THROW(parse(y), std::runtime_error) << "id=" << bad_id;
+    expect_error(
+      std::string("callback_groups:\n  - id: \"") + bad_id +
+        "\"\n    policy: SCHED_OTHER\n    nice: 0\n",
+      "'*' is only allowed as a trailing \"/*\" wildcard");
   }
 }
 
-TEST(ParseConfig, RejectsAtSignInWildcardPrefix)
+TEST(ParseCallbackGroups, RejectsAtSignInWildcardPrefix)
 {
   // A full callback-group id copied from the template with "/*" appended.
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: /node@Timer(100)/*
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+  expect_error(
+    "callback_groups:\n  - id: /node@Timer(100)/*\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "must be a plain node name, not a full callback-group id");
 }
 
-TEST(ParseConfig, RejectsDuplicateWildcardKey)
+TEST(ParseCallbackGroups, RejectsDuplicateWildcardKey)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_error(
+    R"YAML(
 callback_groups:
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+)YAML",
+    "Duplicate callback_group entry: domain_id=0, id=/node/*");
 }
 
-TEST(ParseConfig, AllowsSameWildcardInDifferentDomains)
+TEST(ParseCallbackGroups, AllowsSameWildcardInDifferentDomainsAndExactForSameNode)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 callback_groups:
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
   - id: /node/*
     domain_id: 1
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 2u);
-}
-
-TEST(ParseConfig, AllowsExactAndWildcardForSameNode)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: /node/*
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
   - id: /node@Timer(100)
     domain_id: 0
     policy: SCHED_FIFO
     priority: 80
-    affinity: []
-non_ros_threads: []
 )YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 2u);
+  ASSERT_EQ(config.callback_groups.size(), 3u);
   EXPECT_TRUE(config.callback_groups[0].is_wildcard());
-  EXPECT_FALSE(config.callback_groups[1].is_wildcard());
+  EXPECT_TRUE(config.callback_groups[1].is_wildcard());
+  EXPECT_FALSE(config.callback_groups[2].is_wildcard());
 }
 
-TEST(ParseConfig, NonRosThreadNameEndingInSlashStarStaysExact)
+// ---------- non_ros_threads ----------
+
+TEST(ParseNonRosThreads, NamesAreOpaque)
 {
-  // Wildcards are a callback_groups-only feature; non_ros_threads names are
-  // opaque strings matched exactly, even when they happen to end in "/*".
-  auto y = yaml_from_str(R"YAML(
-callback_groups: []
+  // Wildcards are a callback_groups-only feature; a name is matched exactly
+  // and no '*' rule applies to it.
+  const auto config = parse(R"YAML(
 non_ros_threads:
   - name: worker/*
     policy: SCHED_OTHER
     nice: 0
-    affinity: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.non_ros_threads.size(), 1u);
-  EXPECT_EQ(config.non_ros_threads[0].name, "worker/*");
-}
-
-// ---------- affinity validation ----------
-
-TEST(ParseConfig, NormalizesAffinityToSortedUnique)
-{
-  // parse_affinity bounds values by the machine CPU count, so only CPUs 0
-  // and 1 are used to keep this test valid on small CI machines.
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: 50
-    affinity: [1, 0, 1]
-non_ros_threads:
-  - name: my_thread
+  - name: w*rk
     policy: SCHED_OTHER
     nice: 0
-    affinity: [1, 1, 0]
 )YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{0, 1}));
-  ASSERT_EQ(config.non_ros_threads.size(), 1u);
-  EXPECT_EQ(config.non_ros_threads[0].attrs.affinity, (std::vector<int>{0, 1}));
+  ASSERT_EQ(config.non_ros_threads.size(), 2u);
+  EXPECT_EQ(config.non_ros_threads[0].name, "worker/*");
+  EXPECT_EQ(config.non_ros_threads[1].name, "w*rk");
 }
 
-TEST(ParseConfig, TreatsAbsentOrNullAffinityAsUnmanaged)
+TEST(ParseNonRosThreads, RejectsDuplicateName)
 {
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: no_key
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: 50
-  - id: null_value
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: 50
-    affinity: ~
-non_ros_threads: []
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 2u);
-  EXPECT_TRUE(config.callback_groups[0].attrs.affinity.empty());
-  EXPECT_TRUE(config.callback_groups[1].attrs.affinity.empty());
-}
-
-TEST(ParseConfig, RejectsAffinityCpuOutOfRange)
-{
-  // CPU_SET(3) / sched_setaffinity(2) would silently ignore all of these,
-  // shrinking the mask without any error report. The valid CPU 0 in front
-  // checks that it does not mask the error.
-  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
-  for (const std::string & bad_affinity :
-       {std::string("[-1]"), "[0, " + std::to_string(num_cpus) + "]",
-        "[0, " + std::to_string(CPU_SETSIZE) + "]"}) {
-    auto y = yaml_from_str(("callback_groups:\n"
-                            "  - id: my_cbg\n"
-                            "    domain_id: 0\n"
-                            "    policy: SCHED_FIFO\n"
-                            "    priority: 50\n"
-                            "    affinity: " +
-                            bad_affinity +
-                            "\n"
-                            "non_ros_threads: []\n")
-                             .c_str());
-    EXPECT_THROW(parse(y), std::runtime_error) << "affinity=" << bad_affinity;
-  }
-}
-
-TEST(ParseConfig, AcceptsHighestValidAffinityCpu)
-{
-  // Pins the accept side of the [0, min(CPU_SETSIZE, num_cpus)) boundary.
-  const int max_cpu =
-    static_cast<int>(std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF))) - 1;
-  auto y = yaml_from_str(("callback_groups:\n"
-                          "  - id: my_cbg\n"
-                          "    domain_id: 0\n"
-                          "    policy: SCHED_FIFO\n"
-                          "    priority: 50\n"
-                          "    affinity: [" +
-                          std::to_string(max_cpu) +
-                          "]\n"
-                          "non_ros_threads: []\n")
-                           .c_str());
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].attrs.affinity, (std::vector<int>{max_cpu}));
-}
-
-TEST(ParseConfig, RejectsScalarAffinity)
-{
-  // A scalar iterates zero times and would otherwise silently mean
-  // "no affinity".
-  for (const char * bad_affinity : {"2", "\"0-3\""}) {
-    auto y = yaml_from_str(("callback_groups: []\n"
-                            "non_ros_threads:\n"
-                            "  - name: my_thread\n"
-                            "    policy: SCHED_OTHER\n"
-                            "    nice: 0\n"
-                            "    affinity: " +
-                            std::string(bad_affinity) + "\n")
-                             .c_str());
-    EXPECT_THROW(parse(y), std::runtime_error) << "affinity=" << bad_affinity;
-  }
-}
-
-TEST(ParseConfig, ReportsEntryOnNonIntegerAffinityElement)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_FIFO
-    priority: 50
-    affinity: [0, all]
-non_ros_threads: []
-)YAML");
-  try {
-    parse(y);
-    FAIL() << "expected std::runtime_error";
-  } catch (const std::runtime_error & e) {
-    const std::string what = e.what();
-    EXPECT_NE(what.find("'affinity' must contain only integers"), std::string::npos) << what;
-    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
-  }
+  expect_error(
+    R"YAML(
+non_ros_threads:
+  - name: t
+    policy: SCHED_OTHER
+    nice: 0
+  - name: t
+    policy: SCHED_OTHER
+    nice: 0
+)YAML",
+    "Duplicate non_ros_thread entry: name=t");
 }
 
 // ---------- extract_node_part ----------
@@ -764,51 +634,27 @@ TEST(ExtractNodePart, SplitsAtFirstAtSign)
 
 // ---------- kernel_threads ----------
 
-TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
-{
-  EXPECT_TRUE(parse(yaml_from_str("callback_groups: []\n")).kernel_threads.empty());
-  EXPECT_TRUE(parse(yaml_from_str("kernel_threads: ~\n")).kernel_threads.empty());
-  EXPECT_TRUE(parse(yaml_from_str("kernel_threads: []\n")).kernel_threads.empty());
-}
-
 TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
 {
-  // CPUs 0/1 only, to keep this test valid on small CI machines.
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 kernel_threads:
   - comm: agnocast_exit_w
     policy: SCHED_FIFO
     priority: 10
     affinity: [0, 1]
 )YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].comm, "agnocast_exit_w");
-  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Fifo);
-  EXPECT_EQ(result[0].attrs.rt_priority, 10);
-  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{0, 1}));
-  EXPECT_TRUE(result[0].is_managed());
-}
-
-TEST(ParseKernelThreads, ParsesCfsPolicyWithNice)
-{
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: SCHED_OTHER
-    nice: -10
-    affinity: ~
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Other);
-  EXPECT_EQ(result[0].attrs.nice, -10);
-  EXPECT_TRUE(result[0].is_managed());
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  const auto & entry = config.kernel_threads[0];
+  EXPECT_EQ(entry.comm, "agnocast_exit_w");
+  EXPECT_EQ(entry.attrs.policy, acie::SchedPolicy::Fifo);
+  EXPECT_EQ(entry.attrs.rt_priority, 10);
+  EXPECT_EQ(entry.attrs.affinity, (std::vector<int>{0, 1}));
+  EXPECT_TRUE(entry.is_managed());
 }
 
 TEST(ParseKernelThreads, AllNullEntryIsUnmanaged)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: ~
@@ -816,16 +662,15 @@ kernel_threads:
     priority: ~
     affinity: ~
 )YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].attrs.policy.has_value());
-  EXPECT_TRUE(result[0].attrs.affinity.empty());
-  EXPECT_FALSE(result[0].is_managed());
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_FALSE(config.kernel_threads[0].attrs.policy.has_value());
+  EXPECT_TRUE(config.kernel_threads[0].attrs.affinity.empty());
+  EXPECT_FALSE(config.kernel_threads[0].is_managed());
 }
 
 TEST(ParseKernelThreads, UnmanageableSentinelEqualsNull)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 kernel_threads:
   - comm: ksoftirqd/0
     policy: UNMANAGEABLE
@@ -833,116 +678,40 @@ kernel_threads:
     priority: UNMANAGEABLE
     affinity: UNMANAGEABLE
 )YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].attrs.policy.has_value());
-  EXPECT_TRUE(result[0].attrs.affinity.empty());
-  EXPECT_FALSE(result[0].is_managed());
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_FALSE(config.kernel_threads[0].attrs.policy.has_value());
+  EXPECT_TRUE(config.kernel_threads[0].attrs.affinity.empty());
+  EXPECT_FALSE(config.kernel_threads[0].is_managed());
 }
 
 TEST(ParseKernelThreads, AffinityOnlyEntryIsManaged)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 kernel_threads:
   - comm: agnocast_exit_w
     policy: ~
     priority: ~
     affinity: [1]
 )YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_FALSE(result[0].attrs.policy.has_value());
-  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{1}));
-  EXPECT_TRUE(result[0].is_managed());
-}
-
-TEST(ParseKernelThreads, NormalizesAffinityToSortedUnique)
-{
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: ~
-    priority: ~
-    affinity: [1, 0, 1]
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].attrs.affinity, (std::vector<int>{0, 1}));
-}
-
-TEST(ParseKernelThreads, RejectsScalarAndOutOfRangeAffinity)
-{
-  // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
-  // silently mean "leave alone".
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: ~
-    priority: ~
-    affinity: 0-3
-)YAML",
-    "'affinity' must be a list");
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: ~
-    priority: ~
-    affinity: [-1]
-)YAML",
-    "'affinity' CPU -1 must be in");
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_FALSE(config.kernel_threads[0].attrs.policy.has_value());
+  EXPECT_EQ(config.kernel_threads[0].attrs.affinity, (std::vector<int>{1}));
+  EXPECT_TRUE(config.kernel_threads[0].is_managed());
 }
 
 TEST(ParseKernelThreads, PolicyWithUnmanageableAffinityIsManaged)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 kernel_threads:
   - comm: ksoftirqd/0
     policy: SCHED_FIFO
     priority: 5
     affinity: UNMANAGEABLE
 )YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  ASSERT_TRUE(result[0].attrs.policy.has_value());
-  EXPECT_TRUE(result[0].attrs.affinity.empty());
-  EXPECT_TRUE(result[0].is_managed());
-}
-
-TEST(ParseKernelThreads, ParsesSchedDeadline)
-{
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    period: 5000000
-    deadline: 5000000
-    affinity: ~
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].attrs.policy, acie::SchedPolicy::Deadline);
-  EXPECT_EQ(result[0].attrs.deadline.runtime, 1000000u);
-  EXPECT_EQ(result[0].attrs.deadline.period, 5000000u);
-  EXPECT_EQ(result[0].attrs.deadline.deadline, 5000000u);
-}
-
-TEST(ParseKernelThreads, AcceptsDeadlineParamsBeyond32Bits)
-{
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 1000000000
-    period: 5000000000
-    deadline: 5000000000
-    affinity: ~
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].attrs.deadline.period, 5000000000u);
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_TRUE(config.kernel_threads[0].attrs.policy.has_value());
+  EXPECT_TRUE(config.kernel_threads[0].attrs.affinity.empty());
+  EXPECT_TRUE(config.kernel_threads[0].is_managed());
 }
 
 TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
@@ -952,59 +721,36 @@ TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
   // other attribute key is set, so a case-insensitive sentinel match would
   // parse cleanly and fail the test.
   expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: unmanageable
-    affinity: ~
-)YAML",
+    "kernel_threads:\n  - comm: rcu_preempt\n    policy: unmanageable\n    affinity: ~\n",
     "Unknown scheduling policy 'unmanageable'");
 }
 
-TEST(ParseKernelThreads, RejectsMissingOrEmptyComm)
+TEST(ParseKernelThreads, SentinelTunableIsReportedAsUnset)
 {
+  // The sentinel counts as unset exactly like null does, and the message
+  // says so because the key is visibly present.
   expect_error(
-    R"YAML(
-kernel_threads:
-  - policy: ~
-    priority: ~
-    affinity: ~
-)YAML",
-    "is missing a non-empty 'comm'");
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: ""
-    policy: ~
-    priority: ~
-    affinity: ~
-)YAML",
-    "is missing a non-empty 'comm'");
+    "kernel_threads:\n  - comm: rcu_preempt\n    policy: SCHED_FIFO\n    priority: UNMANAGEABLE\n",
+    "requires 'priority' for comm=rcu_preempt (UNMANAGEABLE counts as unset)");
 }
 
-TEST(ParseKernelThreads, RejectsNonStringComm)
+TEST(ParseKernelThreads, RejectsMissingEmptyOrNonStringComm)
 {
   expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: [a, b]
-    policy: ~
-    priority: ~
-    affinity: ~
-)YAML",
-    "'comm' must be a string");
+    "kernel_threads:\n  - policy: ~\n    affinity: ~\n",
+    "kernel_threads entry #0 is missing a non-empty 'comm'");
+  expect_error(
+    "kernel_threads:\n  - comm: \"\"\n    policy: ~\n    affinity: ~\n",
+    "kernel_threads entry #0 is missing a non-empty 'comm'");
+  expect_error(
+    "kernel_threads:\n  - comm: [a, b]\n    policy: ~\n    affinity: ~\n",
+    "kernel_threads entry #0: 'comm' must be a string");
 }
 
 TEST(ParseKernelThreads, RejectsKworkerComm)
 {
   expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: kworker/0:0H-events_highpri
-    policy: ~
-    priority: ~
-    affinity: ~
-)YAML",
+    "kernel_threads:\n  - comm: kworker/0:0H-events_highpri\n    policy: ~\n    affinity: ~\n",
     "kworker comms are ephemeral");
 }
 
@@ -1013,17 +759,11 @@ TEST(ParseKernelThreads, AcceptsCommLongerThan15Chars)
   // Since Linux 5.17 /proc reports a kthread's full name untruncated (e.g.
   // the kmod's "agnocast_exit_worker"), so the scanner returns comms longer
   // than TASK_COMM_LEN - 1 and they must round-trip through the parser.
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: agnocast_exit_worker
-    policy: ~
-    priority: ~
-    affinity: [0]
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
-  EXPECT_TRUE(result[0].is_managed());
+  const auto config =
+    parse("kernel_threads:\n  - comm: agnocast_exit_worker\n    policy: ~\n    affinity: [0]\n");
+  ASSERT_EQ(config.kernel_threads.size(), 1u);
+  EXPECT_EQ(config.kernel_threads[0].comm, "agnocast_exit_worker");
+  EXPECT_TRUE(config.kernel_threads[0].is_managed());
 }
 
 TEST(ParseKernelThreads, RejectsDuplicateComm)
@@ -1033,201 +773,12 @@ TEST(ParseKernelThreads, RejectsDuplicateComm)
 kernel_threads:
   - comm: nfsd
     policy: ~
-    priority: ~
     affinity: ~
   - comm: nfsd
     policy: ~
-    priority: ~
     affinity: ~
 )YAML",
     "Duplicate kernel_thread entry: comm=nfsd");
-}
-
-TEST(ParseKernelThreads, RejectsUnknownPolicy)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: SCHED_BOGUS
-    priority: 0
-    affinity: ~
-)YAML",
-    "Unknown scheduling policy 'SCHED_BOGUS'");
-}
-
-TEST(ParseKernelThreads, RejectsPriorityWithoutPolicy)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: ~
-    priority: 5
-    affinity: ~
-)YAML",
-    "'priority' requires 'policy'");
-}
-
-TEST(ParseKernelThreads, RejectsNiceWithoutPolicy)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: ~
-    nice: 5
-    affinity: ~
-)YAML",
-    "'nice' requires 'policy'");
-}
-
-TEST(ParseKernelThreads, RejectsCfsPolicyWithoutNice)
-{
-  // As in callback_groups, a CFS policy takes 'nice'; 'priority' does not
-  // satisfy the requirement.
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: SCHED_OTHER
-    priority: 5
-    affinity: ~
-)YAML",
-    "requires 'nice'");
-}
-
-TEST(ParseKernelThreads, RejectsOutOfRangeNiceAndRtPriority)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: SCHED_OTHER
-    nice: 50
-    affinity: ~
-)YAML",
-    "'nice' must be in [-20, 19]");
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: nfsd
-    policy: SCHED_FIFO
-    priority: 150
-    affinity: ~
-)YAML",
-    "'priority' must be in [1, 99]");
-}
-
-TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: SCHED_FIFO
-    priority: ~
-    affinity: ~
-)YAML",
-    "requires 'priority'");
-  // The sentinel counts as unset exactly like null does, and the message
-  // says so because the key is visibly present.
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: rcu_preempt
-    policy: SCHED_FIFO
-    priority: UNMANAGEABLE
-    affinity: ~
-)YAML",
-    "requires 'priority' for comm=rcu_preempt (UNMANAGEABLE counts as unset)");
-}
-
-TEST(ParseKernelThreads, RejectsDeadlineFieldsWithoutPolicy)
-{
-  // The full SCHED_DEADLINE triple with 'policy' forgotten would otherwise
-  // parse cleanly as unmanaged, the same silently dead configuration the
-  // nice/priority guard rejects.
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: ~
-    runtime: 1000000
-    period: 5000000
-    deadline: 5000000
-    affinity: ~
-)YAML",
-    "'runtime' requires 'policy'");
-}
-
-TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    affinity: ~
-)YAML",
-    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline'");
-}
-
-TEST(ParseKernelThreads, RejectsMalformedSchedDeadlineFields)
-{
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: -5
-    period: 5000000
-    deadline: 5000000
-    affinity: ~
-)YAML",
-    "'runtime' must be a non-negative decimal integer for comm=dl_thread");
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    period: not_a_number
-    deadline: 5000000
-    affinity: ~
-)YAML",
-    "'period' must be a non-negative decimal integer for comm=dl_thread");
-  // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
-  expect_error(
-    R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 1000000
-    period: 5000000
-    deadline: 0x10
-    affinity: ~
-)YAML",
-    "'deadline' must be a non-negative decimal integer for comm=dl_thread");
-}
-
-TEST(ParseKernelThreads, ParsesZeroPaddedDeadlineFieldAsBase10)
-{
-  // yaml-cpp's base auto-detection would read "0500000" as octal; a
-  // zero-padded column must mean decimal.
-  auto y = yaml_from_str(R"YAML(
-kernel_threads:
-  - comm: dl_thread
-    policy: SCHED_DEADLINE
-    runtime: 0500000
-    period: 5000000
-    deadline: 5000000
-    affinity: ~
-)YAML");
-  const auto result = parse(y).kernel_threads;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].attrs.deadline.runtime, 500000u);
 }
 
 TEST(ParseKernelThreads, RejectsNonListSection)
@@ -1241,37 +792,45 @@ TEST(ParseKernelThreads, RejectsScalarListEntry)
 {
   // A plausible shorthand (a list of bare comms) must fail with the entry
   // diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_error("kernel_threads: [nfsd]\n", "entry #0 must be a mapping");
+  expect_error("kernel_threads: [nfsd]\n", "kernel_threads entry #0 must be a mapping");
+}
+
+TEST(ParseKernelThreads, RejectsPolicyDependentFieldsWithoutPolicy)
+{
+  // Such an entry would otherwise parse cleanly as unmanaged, i.e. silently
+  // dead configuration.
+  expect_error(
+    "kernel_threads:\n  - comm: rcu_preempt\n    policy: ~\n    priority: 5\n",
+    "'priority' requires 'policy' for comm=rcu_preempt: set both or leave both unset");
+  expect_error(
+    "kernel_threads:\n  - comm: rcu_preempt\n    policy: ~\n    nice: 5\n",
+    "'nice' requires 'policy'");
+  expect_error(
+    "kernel_threads:\n  - comm: dl_thread\n    policy: ~\n    runtime: 1000000\n    period: "
+    "5000000\n    deadline: 5000000\n",
+    "'runtime' requires 'policy'");
 }
 
 // ---------- irqs ----------
 
-TEST(ParseIrqs, MissingOrNullSectionYieldsEmpty)
-{
-  EXPECT_TRUE(parse(yaml_from_str("callback_groups: []\n")).irqs.empty());
-  EXPECT_TRUE(parse(yaml_from_str("irqs: ~\n")).irqs.empty());
-  EXPECT_TRUE(parse(yaml_from_str("irqs: []\n")).irqs.empty());
-}
-
 TEST(ParseIrqs, ParsesFilledAffinityAndName)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 irqs:
   - irq: 103
     name: nvidia
     affinity: [1, 0]
 )YAML");
-  const auto result = parse(y).irqs;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].irq, 103);
-  EXPECT_EQ(result[0].name, "nvidia");
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
-  EXPECT_TRUE(result[0].is_managed());
+  ASSERT_EQ(config.irqs.size(), 1u);
+  EXPECT_EQ(config.irqs[0].irq, 103);
+  EXPECT_EQ(config.irqs[0].name, "nvidia");
+  EXPECT_EQ(config.irqs[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_TRUE(config.irqs[0].is_managed());
 }
 
 TEST(ParseIrqs, NullOrUnmanageableAffinityIsUnmanaged)
 {
-  auto y = yaml_from_str(R"YAML(
+  const auto config = parse(R"YAML(
 irqs:
   - irq: 0
     name: timer
@@ -1280,47 +839,38 @@ irqs:
     name: i8042
     affinity: ~
 )YAML");
-  const auto result = parse(y).irqs;
-  ASSERT_EQ(result.size(), 2u);
-  EXPECT_FALSE(result[0].is_managed());
-  EXPECT_FALSE(result[1].is_managed());
+  ASSERT_EQ(config.irqs.size(), 2u);
+  EXPECT_FALSE(config.irqs[0].is_managed());
+  EXPECT_FALSE(config.irqs[1].is_managed());
 }
 
-TEST(ParseIrqs, MissingNameMeansNoVerification)
+TEST(ParseIrqs, MissingOrNullNameMeansNoVerification)
 {
-  auto y = yaml_from_str(R"YAML(
-irqs:
-  - irq: 42
-    affinity: [1]
-)YAML");
-  const auto result = parse(y).irqs;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_TRUE(result[0].name.empty());
-  EXPECT_TRUE(result[0].is_managed());
+  for (const char * name_line : {"", "    name: ~\n"}) {
+    const auto config =
+      parse(std::string("irqs:\n  - irq: 42\n") + name_line + "    affinity: [1]\n");
+    ASSERT_EQ(config.irqs.size(), 1u);
+    EXPECT_TRUE(config.irqs[0].name.empty());
+    EXPECT_TRUE(config.irqs[0].is_managed());
+  }
+}
+
+TEST(ParseIrqs, RejectsNonStringName)
+{
+  expect_error(
+    "irqs:\n  - irq: 5\n    name: [a]\n    affinity: ~\n", "'name' must be a string for irq=5");
 }
 
 TEST(ParseIrqs, RejectsMissingOrNegativeOrNonIntIrq)
 {
   expect_error(
-    R"YAML(
-irqs:
-  - name: orphan
-    affinity: ~
-)YAML",
-    "is missing a non-negative integer 'irq'");
+    "irqs:\n  - name: orphan\n    affinity: ~\n",
+    "irqs entry #0 is missing a non-negative integer 'irq'");
   expect_error(
-    R"YAML(
-irqs:
-  - irq: -1
-    affinity: ~
-)YAML",
-    "'irq' must be a non-negative decimal integer, got '-1'");
+    "irqs:\n  - irq: -1\n    affinity: ~\n",
+    "irqs entry #0: 'irq' must be a non-negative decimal integer, got '-1'");
   expect_error(
-    R"YAML(
-irqs:
-  - irq: not_a_number
-    affinity: ~
-)YAML",
+    "irqs:\n  - irq: not_a_number\n    affinity: ~\n",
     "'irq' must be a non-negative decimal integer, got 'not_a_number'");
 }
 
@@ -1328,59 +878,24 @@ TEST(ParseIrqs, ParsesZeroPaddedIrqAsBase10)
 {
   // yaml-cpp's as<int>() would read "010" as octal 8 and silently target a
   // different interrupt; a zero-padded column must mean decimal 10.
-  auto y = yaml_from_str(R"YAML(
-irqs:
-  - irq: 010
-    affinity: ~
-)YAML");
-  const auto result = parse(y).irqs;
-  ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].irq, 10);
+  const auto config = parse("irqs:\n  - irq: 010\n    affinity: ~\n");
+  ASSERT_EQ(config.irqs.size(), 1u);
+  EXPECT_EQ(config.irqs[0].irq, 10);
 }
 
 TEST(ParseIrqs, RejectsHexIrq)
 {
   // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
   expect_error(
-    R"YAML(
-irqs:
-  - irq: 0x10
-    affinity: ~
-)YAML",
+    "irqs:\n  - irq: 0x10\n    affinity: ~\n",
     "'irq' must be a non-negative decimal integer, got '0x10'");
 }
 
 TEST(ParseIrqs, RejectsDuplicateIrq)
 {
   expect_error(
-    R"YAML(
-irqs:
-  - irq: 5
-    affinity: ~
-  - irq: 5
-    affinity: ~
-)YAML",
+    "irqs:\n  - irq: 5\n    affinity: ~\n  - irq: 5\n    affinity: ~\n",
     "Duplicate irq entry: irq=5");
-}
-
-TEST(ParseIrqs, RejectsScalarAndOutOfRangeAffinity)
-{
-  // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
-  // silently mean "leave alone".
-  expect_error(
-    R"YAML(
-irqs:
-  - irq: 10
-    affinity: 0-3
-)YAML",
-    "'affinity' must be a list");
-  expect_error(
-    R"YAML(
-irqs:
-  - irq: 10
-    affinity: [-1]
-)YAML",
-    "'affinity' CPU -1 must be in");
 }
 
 TEST(ParseIrqs, RejectsNonListSection)
@@ -1393,82 +908,5 @@ TEST(ParseIrqs, RejectsScalarListEntry)
 {
   // A plausible shorthand (a list of bare IRQ numbers) must fail with the
   // entry diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_error("irqs: [42]\n", "entry #0 must be a mapping");
-}
-
-// ---------- all sections ----------
-
-TEST(ParseConfig, ParsesAllFourSectionsIntoTheirVectors)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    domain_id: 0
-    policy: SCHED_OTHER
-    nice: 0
-    affinity: []
-non_ros_threads:
-  - name: worker
-    policy: SCHED_RR
-    priority: 30
-    affinity: [0]
-kernel_threads:
-  - comm: agnocast_exit_w
-    policy: SCHED_FIFO
-    priority: 10
-    affinity: [0]
-irqs:
-  - irq: 103
-    name: nvidia
-    affinity: [0, 1]
-)YAML");
-  const auto config = parse(y);
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].id, "my_cbg");
-  ASSERT_EQ(config.non_ros_threads.size(), 1u);
-  EXPECT_EQ(config.non_ros_threads[0].name, "worker");
-  EXPECT_EQ(config.non_ros_threads[0].attrs.policy, acie::SchedPolicy::Rr);
-  EXPECT_EQ(config.non_ros_threads[0].attrs.rt_priority, 30);
-  ASSERT_EQ(config.kernel_threads.size(), 1u);
-  EXPECT_EQ(config.kernel_threads[0].comm, "agnocast_exit_w");
-  ASSERT_EQ(config.irqs.size(), 1u);
-  EXPECT_EQ(config.irqs[0].irq, 103);
-}
-
-TEST(ParseConfig, MissingOrNullSectionsYieldEmpty)
-{
-  for (const char * yaml :
-       {"{}\n", "callback_groups: ~\nnon_ros_threads: ~\nkernel_threads: ~\nirqs: ~\n"}) {
-    const auto config = parse(yaml_from_str(yaml));
-    EXPECT_TRUE(config.callback_groups.empty()) << yaml;
-    EXPECT_TRUE(config.non_ros_threads.empty()) << yaml;
-    EXPECT_TRUE(config.kernel_threads.empty()) << yaml;
-    EXPECT_TRUE(config.irqs.empty()) << yaml;
-  }
-}
-
-TEST(ParseConfig, UnmanageableSentinelIsNotRecognized)
-{
-  // The sentinel is scoped to kernel_threads/irqs (the tool writes it there);
-  // in the hand-written sections it must fail like any other invalid value,
-  // not silently mean "leave the attribute alone".
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg
-    policy: SCHED_FIFO
-    priority: 50
-    affinity: UNMANAGEABLE
-non_ros_threads: []
-)YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
-
-  auto y2 = yaml_from_str(R"YAML(
-callback_groups: []
-non_ros_threads:
-  - name: my_thread
-    policy: SCHED_OTHER
-    nice: UNMANAGEABLE
-    affinity: ~
-)YAML");
-  EXPECT_THROW(parse(y2), std::runtime_error);
+  expect_error("irqs: [42]\n", "irqs entry #0 must be a mapping");
 }


### PR DESCRIPTION
## Description

With `callback_groups`, `non_ros_threads` and `kernel_threads` now validating their attributes identically (#1632), the three loops in `parse_config()` differ only in the entry description used in messages, whether `policy` may be absent, and whether `UNMANAGEABLE` counts as unset.

`parse_sched_attrs(entry, EntryContext{desc, scanned})` is now the single path for all three. `parse_nice` / `parse_rt_priority` merge into `parse_tunable`, `parse_required_policy` folds into the policy branch, and the `irqs` section shares `parse_affinity` through the same context.

No behavior change: every message and accepted input is as before, so this PR can be reviewed as a mechanical deduplication. `test_thread_config.cpp` now runs the shared cases under each of the three section headers (`kThreadSections`) so the sections cannot drift again; most of the line count is that test restructuring.

Fourth of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1632; the base branch is `refactor/cie-tc-align-announced-sections`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.