### PR TITLE
refactor(agnocast_cie_thread_configurator): validate entry keys the same way in every section

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -104,9 +104,8 @@ inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
 // entry key (id / name / comm / irq), that callback_groups and
 // non_ros_threads require 'policy' and reject UNMANAGEABLE, and that
 // callback_groups take an optional 'domain_id' (default_domain_id otherwise).
-// Attribute integers (nice, priority, affinity, the SCHED_DEADLINE parameters
-// and irq) are decimal only ("010" is ten, "0x10" is rejected).
-// Throws std::runtime_error on validation error.
+// Integer fields are decimal only ("010" is ten, "0x10" is rejected).
+// Throws std::runtime_error naming the entry and key on validation error.
 // hardware_info / rt_throttling are validated only at startup, not here.
 ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id);
 

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -112,6 +112,22 @@ YAML::Node section_entries(const YAML::Node & yaml, const char * name, const cha
   return section;
 }
 
+std::string required_string(
+  const YAML::Node & entry, const char * key, const std::string & entry_position)
+{
+  const YAML::Node node = entry[key];
+  if (!node || node.IsNull()) {
+    throw std::runtime_error(entry_position + " is missing a non-empty '" + key + "'");
+  }
+  if (!node.IsScalar()) {
+    throw std::runtime_error(entry_position + ": '" + key + "' must be a string");
+  }
+  if (node.Scalar().empty()) {
+    throw std::runtime_error(entry_position + " is missing a non-empty '" + key + "'");
+  }
+  return node.Scalar();
+}
+
 // The policy's tunable ('nice' for CFS, 'priority' for FIFO/RR) is mandatory
 // once 'policy' is set. setpriority(2) would silently clamp an out-of-range
 // nice to [-20, 19], so both ranges are enforced here and a misunderstanding
@@ -324,9 +340,18 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
   for (size_t i = 0; i < callback_groups.size(); ++i) {
     const YAML::Node cg = callback_groups[i];
     CallbackGroupEntry entry;
-    entry.id = cg["id"].as<std::string>();
+    entry.id = required_string(cg, "id", entry_pos("callback_groups", i));
     validate_callback_group_id(entry);
-    entry.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
+    entry.domain_id = default_domain_id;
+    if (!is_unset(cg["domain_id"], /*allow_unmanageable=*/false)) {
+      const auto domain_id = as_decimal<size_t>(cg["domain_id"]);
+      if (!domain_id) {
+        throw std::runtime_error(
+          "'domain_id' must be a non-negative decimal integer for id=" + entry.id + ", got '" +
+          scalar_or_placeholder(cg["domain_id"]) + "'");
+      }
+      entry.domain_id = *domain_id;
+    }
     entry.attrs = parse_sched_attrs(cg, EntryContext{"id=" + entry.id, /*scanned=*/false});
     config.callback_groups.push_back(std::move(entry));
   }
@@ -338,7 +363,7 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
   for (size_t i = 0; i < non_ros_threads.size(); ++i) {
     const YAML::Node nrt = non_ros_threads[i];
     NonRosThreadEntry entry;
-    entry.name = nrt["name"].as<std::string>();
+    entry.name = required_string(nrt, "name", entry_pos("non_ros_threads", i));
     entry.attrs = parse_sched_attrs(nrt, EntryContext{"name=" + entry.name, /*scanned=*/false});
     config.non_ros_threads.push_back(std::move(entry));
   }
@@ -350,18 +375,7 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
   for (size_t i = 0; i < kernel_threads.size(); ++i) {
     const YAML::Node kt = kernel_threads[i];
     KernelThreadEntry entry;
-    const std::string entry_position = entry_pos("kernel_threads", i);
-    if (!kt["comm"] || kt["comm"].IsNull()) {
-      throw std::runtime_error(entry_position + " is missing a non-empty 'comm'");
-    }
-    try {
-      entry.comm = kt["comm"].as<std::string>();
-    } catch (const YAML::Exception &) {
-      throw std::runtime_error(entry_position + ": 'comm' must be a string");
-    }
-    if (entry.comm.empty()) {
-      throw std::runtime_error(entry_position + " is missing a non-empty 'comm'");
-    }
+    entry.comm = required_string(kt, "comm", entry_pos("kernel_threads", i));
     if (is_kworker_comm(entry.comm)) {
       throw std::runtime_error(
         "kernel_threads entry '" + entry.comm +
@@ -391,12 +405,11 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     }
     entry.irq = *irq;
     const std::string desc = "irq=" + std::to_string(entry.irq);
-    if (iq["name"] && !iq["name"].IsNull()) {
-      try {
-        entry.name = iq["name"].as<std::string>();
-      } catch (const YAML::Exception &) {
+    if (!is_unset(iq["name"], /*allow_unmanageable=*/false)) {
+      if (!iq["name"].IsScalar()) {
         throw std::runtime_error("'name' must be a string for " + desc);
       }
+      entry.name = iq["name"].Scalar();
     }
     entry.affinity = parse_affinity(iq, EntryContext{desc, /*scanned=*/true});
     config.irqs.push_back(std::move(entry));

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -492,12 +492,39 @@ TEST(ParseCallbackGroups, RequiresPolicy)
     "non_ros_threads:\n  - name: worker\n    nice: 0\n", "'policy' is required for name=worker");
 }
 
+TEST(ParseCallbackGroups, RejectsMissingEmptyOrNonStringId)
+{
+  expect_error(
+    "callback_groups:\n  - policy: SCHED_OTHER\n    nice: 0\n",
+    "callback_groups entry #0 is missing a non-empty 'id'");
+  expect_error(
+    "callback_groups:\n  - id: \"\"\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "callback_groups entry #0 is missing a non-empty 'id'");
+  expect_error(
+    "callback_groups:\n  - id: [a]\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "callback_groups entry #0: 'id' must be a string");
+}
+
 TEST(ParseCallbackGroups, FallsBackToDefaultDomainId)
 {
-  const auto config =
-    parse("callback_groups:\n  - id: my_cbg\n    policy: SCHED_OTHER\n    nice: 0\n");
-  ASSERT_EQ(config.callback_groups.size(), 1u);
-  EXPECT_EQ(config.callback_groups[0].domain_id, kTestDefaultDomain);
+  for (const char * domain_line : {"", "    domain_id: ~\n"}) {
+    const auto config = parse(
+      std::string("callback_groups:\n  - id: my_cbg\n") + domain_line +
+      "    policy: SCHED_OTHER\n    nice: 0\n");
+    ASSERT_EQ(config.callback_groups.size(), 1u);
+    EXPECT_EQ(config.callback_groups[0].domain_id, kTestDefaultDomain);
+  }
+}
+
+TEST(ParseCallbackGroups, RejectsNonDecimalDomainId)
+{
+  for (const char * bad : {"-1", "0x1", "one"}) {
+    expect_error(
+      std::string("callback_groups:\n  - id: my_cbg\n    domain_id: ") + bad +
+        "\n    policy: SCHED_OTHER\n    nice: 0\n",
+      std::string("'domain_id' must be a non-negative decimal integer for id=my_cbg, got '") + bad +
+        "'");
+  }
 }
 
 TEST(ParseCallbackGroups, RejectsDuplicateKey)
@@ -639,6 +666,19 @@ callback_groups:
 }
 
 // ---------- non_ros_threads ----------
+
+TEST(ParseNonRosThreads, RejectsMissingEmptyOrNonStringName)
+{
+  expect_error(
+    "non_ros_threads:\n  - policy: SCHED_OTHER\n    nice: 0\n",
+    "non_ros_threads entry #0 is missing a non-empty 'name'");
+  expect_error(
+    "non_ros_threads:\n  - name: \"\"\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "non_ros_threads entry #0 is missing a non-empty 'name'");
+  expect_error(
+    "non_ros_threads:\n  - name: {a: b}\n    policy: SCHED_OTHER\n    nice: 0\n",
+    "non_ros_threads entry #0: 'name' must be a string");
+}
 
 TEST(ParseNonRosThreads, NamesAreOpaque)
 {


### PR DESCRIPTION
## Description

`kernel_threads` reported a missing, empty or non-string `comm` with an entry-level message, while a missing or non-string `id` / `name` in `callback_groups` / `non_ros_threads` surfaced a raw yaml-cpp "invalid node" or "bad conversion", and `domain_id` went through the base-detecting `as<size_t>()` with the same raw failure on a null or malformed value.

`required_string(entry, key, entry_pos)` now serves `id`, `name` and `comm`, and `domain_id` uses `as_decimal` with an explicit message. The irq `name` check drops its try/catch for the same `IsScalar` test.

Behavior changes, in `callback_groups` / `non_ros_threads` validation only:

- A missing, empty or non-string `id` / `name` fails with `<section> entry #N is missing a non-empty '<key>'` or `<section> entry #N: '<key>' must be a string`.
- A malformed `domain_id` fails with `'domain_id' must be a non-negative decimal integer for id=..., got '...'` (`010` is ten, `0x1` is rejected); a null one falls back to the default domain like an absent key.

Last of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`. With this PR the stack matches the single-commit version of the change: test_thread_config runs 64 tests, cppcheck with the CI flags reports nothing new, and clang-tidy findings are unchanged from `main`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1634; the base branch is `refactor/cie-tc-section-shape`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.