### PR TITLE
refactor(agnocast_cie_thread_configurator): validate callback_groups and non_ros_threads like kernel_threads

### DIFF
--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -120,15 +120,53 @@ std::optional<T> as_base10(const YAML::Node & node)
   return value;
 }
 
-uint64_t parse_deadline_field(
-  const YAML::Node & entry, const char * key, const std::string & entry_desc)
+SchedPolicy parse_policy_or_throw(const std::string & policy, const std::string & entry_desc)
 {
-  const auto value = as_base10<uint64_t>(entry[key]);
-  if (!value) {
+  const auto parsed = parse_sched_policy(policy);
+  if (!parsed) {
     throw std::runtime_error(
-      "'" + std::string(key) + "' must be a non-negative decimal integer for " + entry_desc);
+      "Unknown scheduling policy '" + policy + "' for " + entry_desc +
+      ". Valid policies: " + sched_policy_names());
   }
-  return *value;
+  return *parsed;
+}
+
+DeadlineParams parse_deadline_params(
+  const YAML::Node & entry, const std::string & entry_desc, bool allow_unmanageable)
+{
+  // Explicit check for a clear message: these fields are always hand-written
+  // (prerun never emits DEADLINE) and easy to forget.
+  for (const char * key : {"runtime", "period", "deadline"}) {
+    // cppcheck-suppress useStlAlgorithm
+    if (is_unset(entry[key], allow_unmanageable)) {
+      throw std::runtime_error(
+        "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for " + entry_desc);
+    }
+  }
+  const auto field = [&](const char * key) {
+    const auto value = as_base10<uint64_t>(entry[key]);
+    if (!value) {
+      throw std::runtime_error(
+        "'" + std::string(key) + "' must be a non-negative decimal integer for " + entry_desc);
+    }
+    return *value;
+  };
+  return DeadlineParams{field("runtime"), field("period"), field("deadline")};
+}
+
+// callback_groups / non_ros_threads describe threads that announce
+// themselves, so 'policy' has no "leave it alone" meaning there and is
+// mandatory. kernel_threads handles an unset policy itself.
+SchedPolicy parse_required_policy(const YAML::Node & entry, const std::string & entry_desc)
+{
+  const YAML::Node policy_node = entry["policy"];
+  if (is_unset(policy_node, /*allow_unmanageable=*/false)) {
+    throw std::runtime_error("'policy' is required for " + entry_desc);
+  }
+  if (!policy_node.IsScalar()) {
+    throw std::runtime_error("'policy' must be a string for " + entry_desc);
+  }
+  return parse_policy_or_throw(policy_node.Scalar(), entry_desc);
 }
 
 // CPU_SET(3) and sched_setaffinity(2) silently drop out-of-range or
@@ -171,17 +209,6 @@ std::vector<int> parse_affinity(
   std::sort(cpus.begin(), cpus.end());
   cpus.erase(std::unique(cpus.begin(), cpus.end()), cpus.end());
   return cpus;
-}
-
-SchedPolicy parse_policy_or_throw(const std::string & policy, const std::string & entry_desc)
-{
-  const auto parsed = parse_sched_policy(policy);
-  if (!parsed) {
-    throw std::runtime_error(
-      "Unknown scheduling policy '" + policy + "' for " + entry_desc +
-      ". Valid policies: " + sched_policy_names());
-  }
-  return *parsed;
 }
 
 // A typo'd pattern silently treated as an exact id would never match, so any
@@ -270,13 +297,12 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     validate_callback_group_id(entry);
     entry.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
     entry.attrs.affinity = parse_affinity(cg, "id=" + entry.id, /*allow_unmanageable=*/false);
-    const SchedPolicy policy =
-      parse_policy_or_throw(cg["policy"].as<std::string>(), "id=" + entry.id);
+    const SchedPolicy policy = parse_required_policy(cg, "id=" + entry.id);
     entry.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      entry.attrs.deadline = DeadlineParams{
-        cg["runtime"].as<uint64_t>(), cg["period"].as<uint64_t>(), cg["deadline"].as<uint64_t>()};
+      entry.attrs.deadline =
+        parse_deadline_params(cg, "id=" + entry.id, /*allow_unmanageable=*/false);
     } else if (is_cfs(policy)) {
       entry.attrs.nice = parse_nice(cg, policy, "id=" + entry.id, /*allow_unmanageable=*/false);
     } else {
@@ -297,14 +323,12 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     NonRosThreadEntry entry;
     entry.name = nrt["name"].as<std::string>();
     entry.attrs.affinity = parse_affinity(nrt, "name=" + entry.name, /*allow_unmanageable=*/false);
-    const SchedPolicy policy =
-      parse_policy_or_throw(nrt["policy"].as<std::string>(), "name=" + entry.name);
+    const SchedPolicy policy = parse_required_policy(nrt, "name=" + entry.name);
     entry.attrs.policy = policy;
 
     if (policy == SchedPolicy::Deadline) {
-      entry.attrs.deadline = DeadlineParams{
-        nrt["runtime"].as<uint64_t>(), nrt["period"].as<uint64_t>(),
-        nrt["deadline"].as<uint64_t>()};
+      entry.attrs.deadline =
+        parse_deadline_params(nrt, "name=" + entry.name, /*allow_unmanageable=*/false);
     } else if (is_cfs(policy)) {
       entry.attrs.nice =
         parse_nice(nrt, policy, "name=" + entry.name, /*allow_unmanageable=*/false);
@@ -374,19 +398,8 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
       entry.attrs.policy = policy;
 
       if (policy == SchedPolicy::Deadline) {
-        // Explicit check for a clear message: these fields are always
-        // hand-written (prerun never emits DEADLINE) and easy to forget.
-        if (
-          is_unset(kt["runtime"], /*allow_unmanageable=*/true) ||
-          is_unset(kt["period"], /*allow_unmanageable=*/true) ||
-          is_unset(kt["deadline"], /*allow_unmanageable=*/true)) {
-          throw std::runtime_error(
-            "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + entry.comm);
-        }
-        entry.attrs.deadline = DeadlineParams{
-          parse_deadline_field(kt, "runtime", "comm=" + entry.comm),
-          parse_deadline_field(kt, "period", "comm=" + entry.comm),
-          parse_deadline_field(kt, "deadline", "comm=" + entry.comm)};
+        entry.attrs.deadline =
+          parse_deadline_params(kt, "comm=" + entry.comm, /*allow_unmanageable=*/true);
       } else if (is_cfs(policy)) {
         entry.attrs.nice =
           parse_nice(kt, policy, "comm=" + entry.comm, /*allow_unmanageable=*/true);

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -321,22 +321,88 @@ non_ros_threads:
   EXPECT_THROW(parse(y), std::runtime_error);
 }
 
-TEST(ParseConfig, RejectsSchedDeadlineMissingRuntimeField)
+TEST(ParseConfig, RejectsSchedDeadlineMissingFields)
 {
-  // SCHED_DEADLINE requires runtime/period/deadline. parse_config calls
-  // .as<uint64_t>() on a missing node, which makes yaml-cpp throw
-  // YAML::TypedBadConversion (a subclass of YAML::Exception, which is
-  // a subclass of std::runtime_error). The test catches the most general
-  // shape so it does not couple to the precise yaml-cpp exception type.
-  auto y = yaml_from_str(R"YAML(
+  expect_error(
+    R"YAML(
 callback_groups:
   - id: dl_cbg
     domain_id: 0
     policy: SCHED_DEADLINE
     affinity: []
-non_ros_threads: []
+)YAML",
+    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for id=dl_cbg");
+  expect_error(
+    R"YAML(
+non_ros_threads:
+  - name: dl_worker
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+)YAML",
+    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for name=dl_worker");
+}
+
+TEST(ParseConfig, RejectsMalformedSchedDeadlineFields)
+{
+  // Same rules as kernel_threads: non-negative decimal digits only.
+  expect_error(
+    R"YAML(
+callback_groups:
+  - id: dl_cbg
+    policy: SCHED_DEADLINE
+    runtime: -5
+    period: 5000000
+    deadline: 5000000
+)YAML",
+    "'runtime' must be a non-negative decimal integer for id=dl_cbg");
+  // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
+  expect_error(
+    R"YAML(
+non_ros_threads:
+  - name: dl_worker
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: 5000000
+    deadline: 0x10
+)YAML",
+    "'deadline' must be a non-negative decimal integer for name=dl_worker");
+}
+
+TEST(ParseConfig, ParsesZeroPaddedDeadlineFieldAsBase10)
+{
+  // yaml-cpp's base auto-detection would read "0500000" as octal; a
+  // zero-padded column must mean decimal.
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: dl_cbg
+    policy: SCHED_DEADLINE
+    runtime: 0500000
+    period: 5000000
+    deadline: 5000000
 )YAML");
-  EXPECT_THROW(parse(y), std::runtime_error);
+  const auto config = parse(y);
+  ASSERT_EQ(config.callback_groups.size(), 1u);
+  EXPECT_EQ(config.callback_groups[0].attrs.deadline.runtime, 500000u);
+}
+
+TEST(ParseConfig, RequiresPolicy)
+{
+  // Unlike kernel_threads, an announced thread's entry has no "leave the
+  // policy alone" meaning, so a missing or null policy is an error.
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    nice: 0\n", "'policy' is required for id=my_cbg");
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    policy: ~\n    nice: 0\n",
+    "'policy' is required for id=my_cbg");
+  expect_error(
+    "non_ros_threads:\n  - name: worker\n    nice: 0\n", "'policy' is required for name=worker");
+}
+
+TEST(ParseConfig, RejectsNonStringPolicy)
+{
+  expect_error(
+    "callback_groups:\n  - id: my_cbg\n    policy: [a, b]\n",
+    "'policy' must be a string for id=my_cbg");
 }
 
 TEST(ParseConfig, ParsesNonRosThread)


### PR DESCRIPTION
## Description

The three attribute loops in `parse_config()` are copies that had drifted. `kernel_threads` accepted SCHED_DEADLINE parameters as decimal only and reported a missing one explicitly, and rejected a non-string `policy` with its own message, while `callback_groups` / `non_ros_threads` read the parameters with yaml-cpp's base-detecting `as<T>()` and let a missing field or policy surface as a raw "invalid node" exception.

`parse_deadline_params()` (the explicit missing-field check plus the decimal-only fields) is now shared by all three sections, and `parse_required_policy()` gives the two announced sections the same policy checks `kernel_threads` already had. This PR only aligns behavior; the loops stay separate so the semantic change can be reviewed on its own. The next PR collapses them into one attribute parser with no behavior change.

Behavior changes, all in `callback_groups` / `non_ros_threads` validation:

- SCHED_DEADLINE `runtime` / `period` / `deadline` are decimal only (`0500000` is 500000, `0x10` is rejected), and a missing one fails with `SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for ...`.
- A missing or null `policy` fails with `'policy' is required for ...`, and a non-scalar one with `'policy' must be a string for ...`.

The `Unknown scheduling policy` wording asserted by the E2E reapply test is unchanged. New tests cover the aligned cases for both sections.

Third of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1628; the base branch is `refactor/cie-tc-parsed-config`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.