### PR TITLE
refactor(agnocast_cie_thread_configurator): accept attribute integers as decimal only in every section

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -104,6 +104,8 @@ inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
 // entry key (id / name / comm / irq), that callback_groups and
 // non_ros_threads require 'policy' and reject UNMANAGEABLE, and that
 // callback_groups take an optional 'domain_id' (default_domain_id otherwise).
+// Attribute integers (nice, priority, affinity, the SCHED_DEADLINE parameters
+// and irq) are decimal only ("010" is ten, "0x10" is rejected).
 // Throws std::runtime_error on validation error.
 // hardware_info / rt_throttling are validated only at startup, not here.
 ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id);

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 
@@ -47,26 +48,33 @@ bool is_unmanageable_sentinel(const YAML::Node & node)
   return node && node.IsScalar() && node.Scalar() == k_unmanageable;
 }
 
+std::string scalar_or_placeholder(const YAML::Node & node)
+{
+  return node.IsScalar() ? node.Scalar() : std::string("<non-scalar>");
+}
+
 constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
 constexpr int k_rt_priority_max = 99;
 
-// yaml-cpp's as<T>() auto-detects the numeric base (YAML 1.1), so a
-// zero-padded "010" would parse as octal 8 and "0x10" as hex 16. IRQ numbers
-// and SCHED_DEADLINE parameters are hand-aligned columns where zero-padding
-// is plausible, so accept digits only and parse base-10, matching the
+// Decimal digits only, with a leading '-' for signed T. yaml-cpp's as<T>()
+// auto-detects the base (YAML 1.1), so a zero-padded "010" would parse as
+// octal 8 and "0x10" as hex 16; IRQ numbers and SCHED_DEADLINE parameters are
+// hand-aligned columns where zero-padding is plausible. This matches the
 // is_all_digits() + from_chars() path the system scanners use.
 template <typename T>
-std::optional<T> as_base10(const YAML::Node & node)
+std::optional<T> as_decimal(const YAML::Node & node)
 {
   if (!node || !node.IsScalar()) {
     return std::nullopt;
   }
   const std::string & s = node.Scalar();
-  if (s.empty() || !std::all_of(s.begin(), s.end(), [](unsigned char c) {
-        return std::isdigit(c) != 0;
-      })) {
+  const size_t digits_begin = (std::is_signed_v<T> && !s.empty() && s[0] == '-') ? 1 : 0;
+  if (
+    s.size() == digits_begin || !std::all_of(
+                                  s.begin() + static_cast<std::ptrdiff_t>(digits_begin), s.end(),
+                                  [](unsigned char c) { return std::isdigit(c) != 0; })) {
     return std::nullopt;
   }
   T value{};
@@ -91,18 +99,18 @@ int parse_tunable(
       "Policy '" + std::string(to_string(policy)) + "' requires '" + key + "' for " + ctx.desc +
       (is_unmanageable_sentinel(node) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
-  int value = 0;
-  try {
-    value = node.as<int>();
-  } catch (const YAML::Exception &) {
-    throw std::runtime_error("'" + std::string(key) + "' must be an integer for " + ctx.desc);
+  const auto value = as_decimal<int>(node);
+  if (!value) {
+    throw std::runtime_error(
+      "'" + std::string(key) + "' must be a decimal integer for " + ctx.desc + ", got '" +
+      scalar_or_placeholder(node) + "'");
   }
-  if (value < min || value > max) {
+  if (*value < min || *value > max) {
     throw std::runtime_error(
       "'" + std::string(key) + "' must be in [" + std::to_string(min) + ", " + std::to_string(max) +
-      "] for " + ctx.desc + ", got " + std::to_string(value));
+      "] for " + ctx.desc + ", got " + std::to_string(*value));
   }
-  return value;
+  return *value;
 }
 
 DeadlineParams parse_deadline_params(const YAML::Node & entry, const EntryContext & ctx)
@@ -117,7 +125,7 @@ DeadlineParams parse_deadline_params(const YAML::Node & entry, const EntryContex
     }
   }
   const auto field = [&](const char * key) {
-    const auto value = as_base10<uint64_t>(entry[key]);
+    const auto value = as_decimal<uint64_t>(entry[key]);
     if (!value) {
       throw std::runtime_error(
         "'" + std::string(key) + "' must be a non-negative decimal integer for " + ctx.desc);
@@ -145,21 +153,19 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const EntryContext & c
   }
   const int max_cpu = manageable_cpu_bound();
   for (const auto & cpu_node : affinity) {
-    int cpu = 0;
-    try {
-      cpu = cpu_node.as<int>();
-    } catch (const YAML::Exception &) {
+    const auto cpu = as_decimal<int>(cpu_node);
+    if (!cpu) {
       throw std::runtime_error(
-        "'affinity' must contain only integers for " + ctx.desc + ", got '" +
-        (cpu_node.IsScalar() ? cpu_node.Scalar() : std::string("<non-scalar>")) + "'");
+        "'affinity' must contain only decimal integers for " + ctx.desc + ", got '" +
+        scalar_or_placeholder(cpu_node) + "'");
     }
-    if (cpu < 0 || cpu > max_cpu) {
+    if (*cpu < 0 || *cpu > max_cpu) {
       throw std::runtime_error(
-        "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " + std::to_string(max_cpu) +
+        "'affinity' CPU " + std::to_string(*cpu) + " must be in [0, " + std::to_string(max_cpu) +
         "] (this machine has " + std::to_string(sysconf(_SC_NPROCESSORS_CONF)) + " CPUs) for " +
         ctx.desc);
     }
-    cpus.push_back(cpu);
+    cpus.push_back(*cpu);
   }
   std::sort(cpus.begin(), cpus.end());
   cpus.erase(std::unique(cpus.begin(), cpus.end()), cpus.end());
@@ -369,14 +375,15 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
       if (!iq.IsMap()) {
         throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- irq: ...')");
       }
-      if (!iq["irq"] || iq["irq"].IsNull()) {
+      const YAML::Node irq_node = iq["irq"];
+      if (!irq_node || irq_node.IsNull()) {
         throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
       }
-      const auto irq = as_base10<int>(iq["irq"]);
-      if (!irq) {
+      const auto irq = as_decimal<int>(irq_node);
+      if (!irq || *irq < 0) {
         throw std::runtime_error(
           entry_pos + ": 'irq' must be a non-negative decimal integer, got '" +
-          (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
+          scalar_or_placeholder(irq_node) + "'");
       }
       entry.irq = *irq;
       const std::string desc = "irq=" + std::to_string(entry.irq);

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -191,15 +191,20 @@ TEST(ParseSchedAttrs, RejectsMissingOrNullPriorityOnRtPolicy)
   }
 }
 
-TEST(ParseSchedAttrs, RejectsNonIntegerNiceAndPriority)
+TEST(ParseSchedAttrs, RejectsNonDecimalNiceAndPriority)
 {
+  // yaml-cpp's as<int>() would read "0x10" as 16; only decimal digits (with
+  // an optional sign) are valid.
   for (const auto & section : kThreadSections) {
     expect_error(
       section.header + std::string("    policy: SCHED_OTHER\n    nice: low\n"),
-      std::string("'nice' must be an integer for ") + section.desc);
+      std::string("'nice' must be a decimal integer for ") + section.desc + ", got 'low'");
+    expect_error(
+      section.header + std::string("    policy: SCHED_OTHER\n    nice: 0x5\n"),
+      std::string("'nice' must be a decimal integer for ") + section.desc + ", got '0x5'");
     expect_error(
       section.header + std::string("    policy: SCHED_FIFO\n    priority: high\n"),
-      std::string("'priority' must be an integer for ") + section.desc);
+      std::string("'priority' must be a decimal integer for ") + section.desc + ", got 'high'");
   }
 }
 
@@ -337,6 +342,15 @@ TEST(ParseSchedAttrs, NormalizesAffinityToSortedUnique)
   EXPECT_EQ(config.irqs.at(0).affinity, (std::vector<int>{0, 1}));
 }
 
+TEST(ParseSchedAttrs, ParsesZeroPaddedAffinityCpuAsBase10)
+{
+  for (const auto & section : kThreadSections) {
+    const auto attrs =
+      attrs_of(section, "    policy: SCHED_FIFO\n    priority: 50\n    affinity: [01]\n");
+    EXPECT_EQ(attrs.affinity, (std::vector<int>{1})) << section.desc;
+  }
+}
+
 TEST(ParseSchedAttrs, TreatsAbsentOrNullAffinityAsUnmanaged)
 {
   for (const auto & section : kThreadSections) {
@@ -395,13 +409,18 @@ TEST(ParseSchedAttrs, RejectsScalarAffinity)
   expect_error("irqs:\n  - irq: 5\n    affinity: 0-3\n", "'affinity' must be a list");
 }
 
-TEST(ParseSchedAttrs, RejectsNonIntegerAffinityElement)
+TEST(ParseSchedAttrs, RejectsNonDecimalAffinityElement)
 {
   for (const auto & section : kThreadSections) {
     expect_error(
       section.header +
         std::string("    policy: SCHED_FIFO\n    priority: 50\n    affinity: [0, all]\n"),
-      std::string("'affinity' must contain only integers for ") + section.desc + ", got 'all'");
+      std::string("'affinity' must contain only decimal integers for ") + section.desc +
+        ", got 'all'");
+    expect_error(
+      section.header +
+        std::string("    policy: SCHED_FIFO\n    priority: 50\n    affinity: [0x1]\n"),
+      "got '0x1'");
   }
 }
 
@@ -492,13 +511,13 @@ TEST(ParseCallbackGroups, UnmanageableSentinelIsNotRecognized)
     "'affinity' must be a list");
   expect_error(
     "callback_groups:\n  - id: my_cbg\n    policy: SCHED_OTHER\n    nice: UNMANAGEABLE\n",
-    "'nice' must be an integer for id=my_cbg");
+    "'nice' must be a decimal integer for id=my_cbg, got 'UNMANAGEABLE'");
   expect_error(
     "callback_groups:\n  - id: my_cbg\n    policy: UNMANAGEABLE\n",
     "Unknown scheduling policy 'UNMANAGEABLE'");
   expect_error(
     "non_ros_threads:\n  - name: my_thread\n    policy: SCHED_OTHER\n    nice: UNMANAGEABLE\n",
-    "'nice' must be an integer for name=my_thread");
+    "'nice' must be a decimal integer for name=my_thread, got 'UNMANAGEABLE'");
 }
 
 // ---------- wildcard ("<node name>/*") callback-group ids ----------


### PR DESCRIPTION
## Description

`nice`, `priority` and `affinity` elements still went through yaml-cpp's base-detecting `as<int>()` (YAML 1.1), so `010` meant 8 and `0x10` meant 16, while the SCHED_DEADLINE parameters and `irq` were already read as decimal digits by `as_base10()`.

`as_decimal<T>()` replaces `as_base10` and additionally accepts a leading `-` for signed `T`, and every attribute integer goes through it. The `irq` path rejects a negative value explicitly instead of relying on the digits-only check. `scalar_or_placeholder()` renders the offending scalar (or `<non-scalar>`) in messages.

Behavior changes, all in validation:

- `nice`, `priority` and `affinity` CPUs are decimal only (`01` is one, `0x5` is rejected) in every section. Dropping octal / hex acceptance tightens the schema for hand-written configs and should be mentioned in the release notes.
- Non-integer `nice` / `priority` / `affinity` values report the offending text (`'nice' must be a decimal integer for id=..., got 'low'`).

Fifth of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`. `domain_id` is handled in the last PR together with the other entry keys.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1629; the base branch is `refactor/cie-tc-shared-attr-parser`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.