### PR TITLE
refactor(agnocast_cie_thread_configurator): reject a malformed section shape in every section

### DIFF
--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -53,6 +53,11 @@ std::string scalar_or_placeholder(const YAML::Node & node)
   return node.IsScalar() ? node.Scalar() : std::string("<non-scalar>");
 }
 
+std::string entry_pos(const char * section, size_t index)
+{
+  return std::string(section) + " entry #" + std::to_string(index);
+}
+
 constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
@@ -83,6 +88,28 @@ std::optional<T> as_decimal(const YAML::Node & node)
     return std::nullopt;
   }
   return value;
+}
+
+// Missing or null = no entries (pre-existing YAMLs keep working). Anything
+// but a list of mappings is rejected, since a scalar would iterate zero times
+// and silently drop the section, and a list of bare keys would fail with a
+// raw yaml-cpp BadSubscript instead of the entry diagnostic.
+YAML::Node section_entries(const YAML::Node & yaml, const char * name, const char * example_key)
+{
+  const YAML::Node section = yaml[name];
+  if (!section || section.IsNull()) {
+    return YAML::Node(YAML::NodeType::Sequence);
+  }
+  if (!section.IsSequence()) {
+    throw std::runtime_error("'" + std::string(name) + "' must be a list");
+  }
+  for (size_t i = 0; i < section.size(); ++i) {
+    if (!section[i].IsMap()) {
+      throw std::runtime_error(
+        entry_pos(name, i) + " must be a mapping (e.g. '- " + example_key + ": ...')");
+    }
+  }
+  return section;
 }
 
 // The policy's tunable ('nice' for CFS, 'priority' for FIFO/RR) is mandatory
@@ -293,11 +320,8 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
 {
   ParsedConfig config;
 
-  // A missing or null section has no entries, like kernel_threads / irqs.
-  const YAML::Node callback_groups = yaml["callback_groups"];
-  const size_t callback_group_count =
-    (callback_groups && !callback_groups.IsNull()) ? callback_groups.size() : 0;
-  for (size_t i = 0; i < callback_group_count; ++i) {
+  const YAML::Node callback_groups = section_entries(yaml, "callback_groups", "id");
+  for (size_t i = 0; i < callback_groups.size(); ++i) {
     const YAML::Node cg = callback_groups[i];
     CallbackGroupEntry entry;
     entry.id = cg["id"].as<std::string>();
@@ -310,10 +334,8 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     return "domain_id=" + std::to_string(e.domain_id) + ", id=" + e.id;
   });
 
-  const YAML::Node non_ros_threads = yaml["non_ros_threads"];
-  const size_t non_ros_thread_count =
-    (non_ros_threads && !non_ros_threads.IsNull()) ? non_ros_threads.size() : 0;
-  for (size_t i = 0; i < non_ros_thread_count; ++i) {
+  const YAML::Node non_ros_threads = section_entries(yaml, "non_ros_threads", "name");
+  for (size_t i = 0; i < non_ros_threads.size(); ++i) {
     const YAML::Node nrt = non_ros_threads[i];
     NonRosThreadEntry entry;
     entry.name = nrt["name"].as<std::string>();
@@ -324,80 +346,60 @@ ParsedConfig parse_config(const YAML::Node & yaml, size_t default_domain_id)
     return "name=" + e.name;
   });
 
-  const YAML::Node kernel_threads = yaml["kernel_threads"];
-  if (kernel_threads && !kernel_threads.IsNull()) {
-    if (!kernel_threads.IsSequence()) {
-      throw std::runtime_error("'kernel_threads' must be a list");
+  const YAML::Node kernel_threads = section_entries(yaml, "kernel_threads", "comm");
+  for (size_t i = 0; i < kernel_threads.size(); ++i) {
+    const YAML::Node kt = kernel_threads[i];
+    KernelThreadEntry entry;
+    const std::string entry_position = entry_pos("kernel_threads", i);
+    if (!kt["comm"] || kt["comm"].IsNull()) {
+      throw std::runtime_error(entry_position + " is missing a non-empty 'comm'");
     }
-    for (size_t i = 0; i < kernel_threads.size(); ++i) {
-      const YAML::Node kt = kernel_threads[i];
-      KernelThreadEntry entry;
-      const std::string entry_pos = "kernel_threads entry #" + std::to_string(i);
-
-      if (!kt.IsMap()) {
-        throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- comm: ...')");
-      }
-      if (!kt["comm"] || kt["comm"].IsNull()) {
-        throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
-      }
-      try {
-        entry.comm = kt["comm"].as<std::string>();
-      } catch (const YAML::Exception &) {
-        throw std::runtime_error(entry_pos + ": 'comm' must be a string");
-      }
-      if (entry.comm.empty()) {
-        throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
-      }
-      if (is_kworker_comm(entry.comm)) {
-        throw std::runtime_error(
-          "kernel_threads entry '" + entry.comm +
-          "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
-          "be matched reliably");
-      }
-      entry.attrs = parse_sched_attrs(kt, EntryContext{"comm=" + entry.comm, /*scanned=*/true});
-      config.kernel_threads.push_back(std::move(entry));
+    try {
+      entry.comm = kt["comm"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error(entry_position + ": 'comm' must be a string");
     }
+    if (entry.comm.empty()) {
+      throw std::runtime_error(entry_position + " is missing a non-empty 'comm'");
+    }
+    if (is_kworker_comm(entry.comm)) {
+      throw std::runtime_error(
+        "kernel_threads entry '" + entry.comm +
+        "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
+        "be matched reliably");
+    }
+    entry.attrs = parse_sched_attrs(kt, EntryContext{"comm=" + entry.comm, /*scanned=*/true});
+    config.kernel_threads.push_back(std::move(entry));
   }
   reject_duplicates(config.kernel_threads, "kernel_thread", [](const KernelThreadEntry & e) {
     return "comm=" + e.comm;
   });
 
-  const YAML::Node irqs = yaml["irqs"];
-  if (irqs && !irqs.IsNull()) {
-    if (!irqs.IsSequence()) {
-      throw std::runtime_error("'irqs' must be a list");
+  const YAML::Node irqs = section_entries(yaml, "irqs", "irq");
+  for (size_t i = 0; i < irqs.size(); ++i) {
+    const YAML::Node iq = irqs[i];
+    IrqEntry entry;
+    const YAML::Node irq_node = iq["irq"];
+    if (!irq_node || irq_node.IsNull()) {
+      throw std::runtime_error(entry_pos("irqs", i) + " is missing a non-negative integer 'irq'");
     }
-    for (size_t i = 0; i < irqs.size(); ++i) {
-      const YAML::Node iq = irqs[i];
-      IrqEntry entry;
-      const std::string entry_pos = "irqs entry #" + std::to_string(i);
-
-      if (!iq.IsMap()) {
-        throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- irq: ...')");
-      }
-      const YAML::Node irq_node = iq["irq"];
-      if (!irq_node || irq_node.IsNull()) {
-        throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
-      }
-      const auto irq = as_decimal<int>(irq_node);
-      if (!irq || *irq < 0) {
-        throw std::runtime_error(
-          entry_pos + ": 'irq' must be a non-negative decimal integer, got '" +
-          scalar_or_placeholder(irq_node) + "'");
-      }
-      entry.irq = *irq;
-      const std::string desc = "irq=" + std::to_string(entry.irq);
-
-      if (iq["name"] && !iq["name"].IsNull()) {
-        try {
-          entry.name = iq["name"].as<std::string>();
-        } catch (const YAML::Exception &) {
-          throw std::runtime_error("'name' must be a string for " + desc);
-        }
-      }
-      entry.affinity = parse_affinity(iq, EntryContext{desc, /*scanned=*/true});
-      config.irqs.push_back(std::move(entry));
+    const auto irq = as_decimal<int>(irq_node);
+    if (!irq || *irq < 0) {
+      throw std::runtime_error(
+        entry_pos("irqs", i) + ": 'irq' must be a non-negative decimal integer, got '" +
+        scalar_or_placeholder(irq_node) + "'");
     }
+    entry.irq = *irq;
+    const std::string desc = "irq=" + std::to_string(entry.irq);
+    if (iq["name"] && !iq["name"].IsNull()) {
+      try {
+        entry.name = iq["name"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        throw std::runtime_error("'name' must be a string for " + desc);
+      }
+    }
+    entry.affinity = parse_affinity(iq, EntryContext{desc, /*scanned=*/true});
+    config.irqs.push_back(std::move(entry));
   }
   reject_duplicates(
     config.irqs, "irq", [](const IrqEntry & e) { return "irq=" + std::to_string(e.irq); });

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -66,6 +66,18 @@ acie::SchedAttrs attrs_of(const ThreadSection & section, const std::string & bod
   return section.attrs(parse(section.header + body));
 }
 
+struct Section
+{
+  const char * name;
+  const char * key;
+};
+
+constexpr Section kSections[] = {
+  {"callback_groups", "id"},
+  {"non_ros_threads", "name"},
+  {"kernel_threads", "comm"},
+  {"irqs", "irq"},
+};
 }  // namespace
 
 // ---------- sections ----------
@@ -80,6 +92,27 @@ TEST(ParseConfig, MissingOrNullOrEmptySectionsYieldEmpty)
     EXPECT_TRUE(config.non_ros_threads.empty()) << yaml;
     EXPECT_TRUE(config.kernel_threads.empty()) << yaml;
     EXPECT_TRUE(config.irqs.empty()) << yaml;
+  }
+}
+
+TEST(ParseConfig, RejectsNonListSection)
+{
+  // A scalar or map section would otherwise silently parse as empty.
+  for (const auto & section : kSections) {
+    const std::string name = section.name;
+    expect_error(name + ": oops\n", "'" + name + "' must be a list");
+    expect_error(name + ":\n  " + section.key + ": x\n", "'" + name + "' must be a list");
+  }
+}
+
+TEST(ParseConfig, RejectsScalarListEntry)
+{
+  // A plausible shorthand (a list of bare ids/comms/IRQ numbers) must fail
+  // with the entry diagnostic, not a raw yaml-cpp BadSubscript.
+  for (const auto & section : kSections) {
+    const std::string name = section.name;
+    expect_error(
+      name + ": [x]\n", name + " entry #0 must be a mapping (e.g. '- " + section.key + ": ...')");
   }
 }
 
@@ -800,20 +833,6 @@ kernel_threads:
     "Duplicate kernel_thread entry: comm=nfsd");
 }
 
-TEST(ParseKernelThreads, RejectsNonListSection)
-{
-  // A scalar or map section would otherwise silently parse as empty.
-  expect_error("kernel_threads: oops\n", "'kernel_threads' must be a list");
-  expect_error("kernel_threads:\n  comm: nfsd\n", "'kernel_threads' must be a list");
-}
-
-TEST(ParseKernelThreads, RejectsScalarListEntry)
-{
-  // A plausible shorthand (a list of bare comms) must fail with the entry
-  // diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_error("kernel_threads: [nfsd]\n", "kernel_threads entry #0 must be a mapping");
-}
-
 TEST(ParseKernelThreads, RejectsPolicyDependentFieldsWithoutPolicy)
 {
   // Such an entry would otherwise parse cleanly as unmanaged, i.e. silently
@@ -915,17 +934,4 @@ TEST(ParseIrqs, RejectsDuplicateIrq)
   expect_error(
     "irqs:\n  - irq: 5\n    affinity: ~\n  - irq: 5\n    affinity: ~\n",
     "Duplicate irq entry: irq=5");
-}
-
-TEST(ParseIrqs, RejectsNonListSection)
-{
-  expect_error("irqs: oops\n", "'irqs' must be a list");
-  expect_error("irqs:\n  irq: 5\n", "'irqs' must be a list");
-}
-
-TEST(ParseIrqs, RejectsScalarListEntry)
-{
-  // A plausible shorthand (a list of bare IRQ numbers) must fail with the
-  // entry diagnostic, not a raw yaml-cpp BadSubscript.
-  expect_error("irqs: [42]\n", "irqs entry #0 must be a mapping");
 }


### PR DESCRIPTION
## Description

`kernel_threads` and `irqs` rejected a section that is not a list and a list entry that is not a mapping with entry-level messages, while a scalar `callback_groups` / `non_ros_threads` section iterated zero times and silently parsed nothing, and a bare list entry failed with a raw yaml-cpp `BadSubscript`.

`section_entries(yaml, name, example_key)` now returns the entries of any of the four sections, treating a missing or null section as empty and rejecting anything else with `'<section>' must be a list` or `<section> entry #N must be a mapping (e.g. '- <key>: ...')`. `entry_pos()` builds the `<section> entry #N` prefix for both.

Behavior change, in `callback_groups` / `non_ros_threads` validation only: a non-list section or a non-mapping entry now fails instead of being ignored or surfacing a raw exception. The section-shape tests now run over all four sections (`kSections`).

Sixth of seven stacked PRs implementing P2 of `docs/cie_thread_configurator_refactoring_proposal.md`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Stacked on #1633; the base branch is `refactor/cie-tc-decimal-integers`, so the diff shows only this step.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.